### PR TITLE
Harden participant persistence during account recovery

### DIFF
--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -516,6 +516,8 @@
   "recovery_failed": "Wiederherstellung fehlgeschlagen. Bitte überprüfe deine Wiederherstellungsphrase und versuche es erneut.",
   "recovery_user_not_found": "Kein Konto mit dieser Wiederherstellungsphrase gefunden.",
   "recovery_network_error": "Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut.",
+  "recovery_cleanup_failed": "Die Wiederherstellung war erfolgreich, aber dieses Gerät konnte die lokale Bereinigung nicht abschließen. Bitte versuche es erneut.",
+  "recovery_local_persistence_failed": "Die Wiederherstellung war erfolgreich, aber dieses Gerät konnte deine Kontodaten nicht lokal speichern. Bitte versuche es erneut.",
 
   "restore_account_description": "Stelle dein Konto auf diesem Gerät mit der Wiederherstellungsphrase wieder her, die du beim Beitritt zur Studie gespeichert hast.",
   "restore_account_help_title": "Mit Wiederherstellungsphrase wiederherstellen",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -535,6 +535,8 @@
   "recovery_failed": "Recovery failed. Please check your recovery phrase and try again.",
   "recovery_user_not_found": "No account found with this recovery phrase.",
   "recovery_network_error": "Network error. Please check your connection and try again.",
+  "recovery_cleanup_failed": "Recovery completed, but this device could not finish local cleanup. Please try again.",
+  "recovery_local_persistence_failed": "Recovery completed, but this device could not save your account data locally. Please try again.",
 
   "restore_account_description": "Restore your account on this device with the recovery phrase you saved before joining a study.",
   "restore_account_help_title": "Restore with your recovery phrase",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -2762,6 +2762,18 @@ abstract class AppLocalizations {
   /// **'Network error. Please check your connection and try again.'**
   String get recovery_network_error;
 
+  /// No description provided for @recovery_cleanup_failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Recovery completed, but this device could not finish local cleanup. Please try again.'**
+  String get recovery_cleanup_failed;
+
+  /// No description provided for @recovery_local_persistence_failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Recovery completed, but this device could not save your account data locally. Please try again.'**
+  String get recovery_local_persistence_failed;
+
   /// No description provided for @restore_account_description.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -1472,6 +1472,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut.';
 
   @override
+  String get recovery_cleanup_failed =>
+      'Die Wiederherstellung war erfolgreich, aber dieses Gerät konnte die lokale Bereinigung nicht abschließen. Bitte versuche es erneut.';
+
+  @override
+  String get recovery_local_persistence_failed =>
+      'Die Wiederherstellung war erfolgreich, aber dieses Gerät konnte deine Kontodaten nicht lokal speichern. Bitte versuche es erneut.';
+
+  @override
   String get restore_account_description =>
       'Stelle dein Konto auf diesem Gerät mit der Wiederherstellungsphrase wieder her, die du beim Beitritt zur Studie gespeichert hast.';
 

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1456,6 +1456,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'Network error. Please check your connection and try again.';
 
   @override
+  String get recovery_cleanup_failed =>
+      'Recovery completed, but this device could not finish local cleanup. Please try again.';
+
+  @override
+  String get recovery_local_persistence_failed =>
+      'Recovery completed, but this device could not save your account data locally. Please try again.';
+
+  @override
   String get restore_account_description =>
       'Restore your account on this device with the recovery phrase you saved before joining a study.';
 

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -79,6 +79,8 @@ class _LoadingScreenState extends State<LoadingScreen> {
     if (!hasStoredCredentials) return false;
     try {
       await signInParticipant();
+      if (!mounted) return false;
+      await context.read<AppLanguage>().syncWithAuthenticatedUser();
       return false;
     } on AuthApiException catch (error, stackTrace) {
       StudyULogger.warning(
@@ -429,6 +431,8 @@ class _LoadingScreenState extends State<LoadingScreen> {
     }
     if (!mounted) return;
     if (subject != null) {
+      await context.read<AppLanguage>().syncWithAuthenticatedUser();
+      if (!mounted) return;
       subject = await Cache.synchronize(subject);
       if (!mounted) return;
       if (!isStudyAvailableForTesting(subject.study)) {
@@ -451,6 +455,8 @@ class _LoadingScreenState extends State<LoadingScreen> {
 
     if (await _restoreParticipantSession()) return;
     if (isUserLoggedIn() && !state.isPreview) {
+      if (!mounted) return;
+      await context.read<AppLanguage>().syncWithAuthenticatedUser();
       if (!mounted) return;
       context.goNamed(RouteNames.welcome);
       return;

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -12,6 +12,7 @@ import 'package:studyu_app/screens/app_onboarding/iframe_helper.dart';
 import 'package:studyu_app/screens/app_onboarding/preview.dart'
     as study_preview;
 import 'package:studyu_app/screens/study/onboarding/eligibility_screen.dart';
+import 'package:studyu_app/services/authenticated_language_sync_service.dart';
 import 'package:studyu_app/services/deep_link_error_helper.dart';
 import 'package:studyu_app/services/deep_link_service.dart';
 import 'package:studyu_app/services/deferred_link_service.dart';
@@ -80,7 +81,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
     try {
       await signInParticipant();
       if (!mounted) return false;
-      await context.read<AppLanguage>().syncWithAuthenticatedUser();
+      await syncLanguageForAuthenticatedUser(context);
       return false;
     } on AuthApiException catch (error, stackTrace) {
       StudyULogger.warning(
@@ -431,7 +432,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
     }
     if (!mounted) return;
     if (subject != null) {
-      await context.read<AppLanguage>().syncWithAuthenticatedUser();
+      await syncLanguageForAuthenticatedUser(context);
       if (!mounted) return;
       subject = await Cache.synchronize(subject);
       if (!mounted) return;
@@ -456,7 +457,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
     if (await _restoreParticipantSession()) return;
     if (isUserLoggedIn() && !state.isPreview) {
       if (!mounted) return;
-      await context.read<AppLanguage>().syncWithAuthenticatedUser();
+      await syncLanguageForAuthenticatedUser(context);
       if (!mounted) return;
       context.goNamed(RouteNames.welcome);
       return;
@@ -851,45 +852,3 @@ class _LoadingScreenState extends State<LoadingScreen> {
     );
   }
 }
-
-/*if (!signInRes) {
-        final migrateRes = await migrateParticipantToNewDB(selectedStudyObjectId);
-        if (migrateRes) {
-          print("Successfully migrated to the new database");
-          if (mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Successfully migrated to the new database.')));
-        } else {
-          print("Error when trying to migrate to the new database");
-          if (mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Error when migrating to the new database.')));
-        }
-        initStudy();
-        return;
-      }*/
-
-/*Future<bool> migrateParticipantToNewDB(String selectedStudyObjectId) async {
-    if (await SecureStorage.containsKey(userEmailKey) && await SecureStorage.containsKey(userPasswordKey)) {
-      try {
-        // create new account
-        if (await anonymousSignUp()) {
-          // call supabase function to update user_id to new user id
-          // by matching a study_subject entry with the current subject ID
-          try {
-            await Supabase.instance.client.rpc(
-              'migrate_db',
-              params: {
-                'participant_user_id': Supabase.instance.client.auth.currentUser?.id,
-                'participant_subject_id': selectedStudyObjectId,
-              },
-            ).single();
-          } on PostgrestException catch (error) {
-            print('Supabase migrate_db Error: ${error.message}');
-          }
-          return true;
-        } else {
-          return false;
-        }
-      } catch (error, stacktrace) {
-        SupabaseQuery.catchSupabaseException(error, stacktrace);
-      }
-    }
-    return false;
-  }*/

--- a/app/lib/screens/app_onboarding/preview.dart
+++ b/app/lib/screens/app_onboarding/preview.dart
@@ -84,8 +84,17 @@ class Preview {
 
       for (final subject in subjects) {
         try {
+          await FitbitHandler.deleteRemoteFitbitCredentials(subject.studyId);
           await subject.delete();
-          await FitbitHandler.deleteFitbitCredentials(subject.studyId);
+          try {
+            await FitbitHandler.clearLocalFallbackCredentialsForStudy(
+              subject.studyId,
+            );
+          } on FitbitCredentialDeletionException catch (e) {
+            print(
+              '[PreviewApp]: Failed deleting local Fitbit credentials for subject ${subject.id}: $e',
+            );
+          }
         } catch (e) {
           print(
             '[PreviewApp]: Failed deleting subject ${subject.id} for user $userId: $e',

--- a/app/lib/screens/app_onboarding/preview.dart
+++ b/app/lib/screens/app_onboarding/preview.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/models/app_state.dart';
+import 'package:studyu_app/services/participant_fitbit_credentials_service.dart';
 import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';

--- a/app/lib/screens/app_onboarding/restore_account_screen.dart
+++ b/app/lib/screens/app_onboarding/restore_account_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/services/restore_account_service.dart';
 import 'package:studyu_app/widgets/onboarding_page.dart';
 import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 class RestoreAccountScreen extends StatefulWidget {
   const RestoreAccountScreen({super.key});
@@ -111,6 +113,8 @@ class _RestoreAccountScreenState extends State<RestoreAccountScreen> {
         return;
       }
 
+      if (!mounted) return;
+      await context.read<AppLanguage>().syncWithAuthenticatedUser();
       if (!mounted) return;
 
       if (result.subjectId != null) {

--- a/app/lib/screens/app_onboarding/restore_account_screen.dart
+++ b/app/lib/screens/app_onboarding/restore_account_screen.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:provider/provider.dart';
 import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
+import 'package:studyu_app/services/authenticated_language_sync_service.dart';
 import 'package:studyu_app/services/restore_account_service.dart';
 import 'package:studyu_app/widgets/onboarding_page.dart';
 import 'package:studyu_core/core.dart';
-import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 class RestoreAccountScreen extends StatefulWidget {
   const RestoreAccountScreen({super.key});
@@ -58,6 +57,10 @@ class _RestoreAccountScreenState extends State<RestoreAccountScreen> {
         return localizations.recovery_user_not_found;
       case 'recovery_network_error':
         return localizations.recovery_network_error;
+      case 'recovery_cleanup_failed':
+        return localizations.recovery_cleanup_failed;
+      case 'recovery_local_persistence_failed':
+        return localizations.recovery_local_persistence_failed;
       case 'recovery_failed':
         return localizations.recovery_failed;
       default:
@@ -114,7 +117,7 @@ class _RestoreAccountScreenState extends State<RestoreAccountScreen> {
       }
 
       if (!mounted) return;
-      await context.read<AppLanguage>().syncWithAuthenticatedUser();
+      await syncLanguageForAuthenticatedUser(context);
       if (!mounted) return;
 
       if (result.subjectId != null) {

--- a/app/lib/screens/app_onboarding/study_switch_dialogs.dart
+++ b/app/lib/screens/app_onboarding/study_switch_dialogs.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
-import 'package:studyu_app/services/restore_account_service.dart';
-import 'package:studyu_app/util/fitbit_handler.dart';
+import 'package:studyu_app/services/participant_study_exit_service.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';
 import 'package:studyu_core/core.dart';
-import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 class StudySwitchDialogs {
   // Returns true if the user decides to continue with deeplink handling.
@@ -174,11 +172,28 @@ class StudySwitchDialogs {
       return false;
     }
 
-    await currentSubject.softDelete();
-    await deleteActiveStudyReference();
-    await FitbitHandler.deleteFitbitCredentials(currentSubject.studyId);
-    if (context.mounted) {
-      await cancelNotifications(context);
+    final result = await ParticipantStudyExitService.exitStudy(
+      subject: currentSubject,
+      mode: StudyExitMode.softDelete,
+      notificationCleanup: () async {
+        if (!context.mounted) return;
+        await cancelNotifications(context);
+      },
+    );
+
+    if (!result.success) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              result.isOfflineFailure
+                  ? loc.no_internet_connection
+                  : loc.error_occurred_with_message(result.errorMessage ?? ''),
+            ),
+          ),
+        );
+      }
+      return false;
     }
     return true;
   }
@@ -214,12 +229,28 @@ class StudySwitchDialogs {
       return false;
     }
 
-    await currentSubject.delete();
-    RestoreAccountService.clearCache();
-    await deleteLocalData();
-    await FitbitHandler.deleteFitbitCredentials(currentSubject.studyId);
-    if (context.mounted) {
-      await cancelNotifications(context);
+    final result = await ParticipantStudyExitService.exitStudy(
+      subject: currentSubject,
+      mode: StudyExitMode.hardDelete,
+      notificationCleanup: () async {
+        if (!context.mounted) return;
+        await cancelNotifications(context);
+      },
+    );
+
+    if (!result.success) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              result.isOfflineFailure
+                  ? loc.no_internet_connection
+                  : loc.error_occurred_with_message(result.errorMessage ?? ''),
+            ),
+          ),
+        );
+      }
+      return false;
     }
     return true;
   }

--- a/app/lib/screens/study/dashboard/settings.dart
+++ b/app/lib/screens/study/dashboard/settings.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:go_router/go_router.dart';
@@ -7,15 +5,13 @@ import 'package:provider/provider.dart';
 import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
-import 'package:studyu_app/services/restore_account_service.dart';
+import 'package:studyu_app/services/participant_study_exit_service.dart';
 import 'package:studyu_app/util/dashboard_showcase.dart';
-import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_app/util/localization.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';
 import 'package:studyu_app/widgets/recovery_phrase_content.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
-import 'package:supabase/supabase.dart' show PostgrestException;
 
 class Settings extends StatefulWidget {
   const Settings({super.key});
@@ -371,30 +367,34 @@ class OptOutAlertDialog extends StatelessWidget {
             ),
             onPressed: acknowledged
                 ? () async {
-                    try {
-                      await subject!.softDelete();
-                    } on SocketException catch (_) {
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(
-                              AppLocalizations.of(
-                                context,
-                              )!.no_internet_connection,
-                            ),
+                    final result = await ParticipantStudyExitService.exitStudy(
+                      subject: subject!,
+                      mode: StudyExitMode.softDelete,
+                      notificationCleanup: () async {
+                        if (!context.mounted) return;
+                        await cancelNotifications(context);
+                      },
+                    );
+                    if (!context.mounted) return;
+                    if (!result.success) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(
+                            result.isOfflineFailure
+                                ? AppLocalizations.of(
+                                    context,
+                                  )!.no_internet_connection
+                                : AppLocalizations.of(
+                                    context,
+                                  )!.error_occurred_with_message(
+                                    result.errorMessage ?? '',
+                                  ),
                           ),
-                        );
-                      }
+                        ),
+                      );
                       return;
                     }
-                    await deleteActiveStudyReference();
-                    await FitbitHandler.deleteFitbitCredentials(
-                      subject!.studyId,
-                    );
-                    if (context.mounted) await cancelNotifications(context);
-                    if (context.mounted) {
-                      context.go('/${RouteNames.studySelection}');
-                    }
+                    context.go('/${RouteNames.studySelection}');
                   }
                 : null,
           ),
@@ -455,50 +455,34 @@ class DeleteAlertDialog extends StatelessWidget {
             style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
             onPressed: acknowledged
                 ? () async {
-                    try {
-                      await subject!.delete();
-                    } on SocketException catch (_) {
-                      // Device is offline — preserve local data so nothing is lost
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(
-                              AppLocalizations.of(
-                                context,
-                              )!.no_internet_connection,
-                            ),
-                          ),
-                        );
-                      }
-                      return;
-                    } on PostgrestException catch (e) {
-                      if (e.code != 'PGRST116') {
-                        // Unexpected DB error — don't clear local data
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: Text(
-                                AppLocalizations.of(
-                                  context,
-                                )!.error_occurred_with_message(e.message),
-                              ),
-                            ),
-                          );
-                        }
-                        return;
-                      }
-                      // PGRST116: subject already deleted from DB — proceed with local cleanup
-                    }
-                    // Reached when delete succeeded or subject was already gone from DB
-                    RestoreAccountService.clearCache();
-                    await deleteLocalData();
-                    await FitbitHandler.deleteFitbitCredentials(
-                      subject!.studyId,
+                    final result = await ParticipantStudyExitService.exitStudy(
+                      subject: subject!,
+                      mode: StudyExitMode.hardDelete,
+                      notificationCleanup: () async {
+                        if (!context.mounted) return;
+                        await cancelNotifications(context);
+                      },
                     );
-                    if (context.mounted) await cancelNotifications(context);
-                    if (context.mounted) {
-                      context.go('/${RouteNames.welcome}');
+                    if (!context.mounted) return;
+                    if (!result.success) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(
+                            result.isOfflineFailure
+                                ? AppLocalizations.of(
+                                    context,
+                                  )!.no_internet_connection
+                                : AppLocalizations.of(
+                                    context,
+                                  )!.error_occurred_with_message(
+                                    result.errorMessage ?? '',
+                                  ),
+                          ),
+                        ),
+                      );
+                      return;
                     }
+                    context.go('/${RouteNames.welcome}');
                   }
                 : null,
           ),

--- a/app/lib/services/authenticated_language_sync_service.dart
+++ b/app/lib/services/authenticated_language_sync_service.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+
+Future<void> syncLanguageForAuthenticatedUser(BuildContext context) async {
+  await context.read<AppLanguage>().syncWithAuthenticatedUser();
+}

--- a/app/lib/services/participant_fitbit_credentials_service.dart
+++ b/app/lib/services/participant_fitbit_credentials_service.dart
@@ -317,6 +317,21 @@ class ParticipantFitbitCredentialsService {
     }
   }
 
+  static Future<void> clearLocalFallbackCredentialsForRecovery(
+    String? recoveredUserId,
+  ) async {
+    final storedValues = await _readAllLocalValues();
+    final preservedPrefix = recoveredUserId == null
+        ? null
+        : '$_fitbitCredentialsPrefix${recoveredUserId}_';
+
+    for (final key in storedValues.keys) {
+      if (!key.startsWith(_fitbitCredentialsPrefix)) continue;
+      if (preservedPrefix != null && key.startsWith(preservedPrefix)) continue;
+      await _deleteLocalValue(key);
+    }
+  }
+
   static Future<fitbitter.FitbitCredentials?> _loadCredentialsFromServer({
     required String userId,
     required String studyKey,

--- a/app/lib/services/participant_fitbit_credentials_service.dart
+++ b/app/lib/services/participant_fitbit_credentials_service.dart
@@ -1,0 +1,472 @@
+// ignore_for_file: avoid_setters_without_getters
+
+import 'dart:convert';
+
+import 'package:fitbitter/fitbitter.dart' as fitbitter;
+import 'package:flutter/foundation.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class FitbitCredentialStorageException implements Exception {
+  final bool localOperationFailed;
+  final bool serverOperationFailed;
+
+  const FitbitCredentialStorageException({
+    required this.localOperationFailed,
+    required this.serverOperationFailed,
+  });
+
+  @override
+  String toString() =>
+      'FitbitCredentialStorageException(localOperationFailed: $localOperationFailed, serverOperationFailed: $serverOperationFailed)';
+}
+
+class FitbitCredentialDeletionException implements Exception {
+  final bool remoteDeletionFailed;
+  final bool localDeletionFailed;
+
+  const FitbitCredentialDeletionException({
+    required this.remoteDeletionFailed,
+    required this.localDeletionFailed,
+  });
+
+  @override
+  String toString() =>
+      'FitbitCredentialDeletionException(remoteDeletionFailed: $remoteDeletionFailed, localDeletionFailed: $localDeletionFailed)';
+}
+
+class ParticipantFitbitCredentialsService {
+  static const String _fitbitCredentialsPrefix = 'fitbit_credentials_';
+  static const String _participantFitbitTable =
+      'participant_fitbit_credentials';
+
+  static String? Function() _currentUserIdGetter = _defaultCurrentUserId;
+  static Future<String?> Function(String) _readLocalValue = SecureStorage.read;
+  static Future<void> Function(String, String) _writeLocalValue =
+      SecureStorage.write;
+  static Future<void> Function(String) _deleteLocalValue = SecureStorage.delete;
+  static Future<bool> Function(String) _containsLocalKey =
+      SecureStorage.containsKey;
+  static Future<Map<String, String>> Function() _readAllLocalValues =
+      SecureStorage.readAll;
+  static Future<fitbitter.FitbitCredentials?> Function({
+    required String userId,
+    required String studyKey,
+  })
+  _serverCredentialsLoader = _loadCredentialsFromServer;
+  static Future<void> Function({
+    required String userId,
+    required String studyKey,
+    required Map<String, dynamic> credentialsJson,
+  })
+  _serverCredentialsUpserter = _upsertCredentialsOnServer;
+  static Future<void> Function({
+    required String userId,
+    required String studyKey,
+  })
+  _serverCredentialsDeleter = _deleteCredentialsFromServer;
+
+  static String _legacyLocalKey(String studyKey) =>
+      '$_fitbitCredentialsPrefix$studyKey';
+
+  static String _scopedLocalKey(String userId, String studyKey) =>
+      '$_fitbitCredentialsPrefix${userId}_$studyKey';
+
+  static String? _defaultCurrentUserId() =>
+      Supabase.instance.client.auth.currentUser?.id;
+
+  static Map<String, dynamic> _credentialsToJson(
+    fitbitter.FitbitCredentials credentials,
+  ) {
+    return {
+      'userID': credentials.userID,
+      'fitbitAccessToken': credentials.fitbitAccessToken,
+      'fitbitRefreshToken': credentials.fitbitRefreshToken,
+    };
+  }
+
+  static fitbitter.FitbitCredentials _credentialsFromJson(
+    Map<String, dynamic> jsonData,
+  ) {
+    return fitbitter.FitbitCredentials(
+      userID: jsonData['userID'] as String,
+      fitbitAccessToken: jsonData['fitbitAccessToken'] as String,
+      fitbitRefreshToken: jsonData['fitbitRefreshToken'] as String,
+    );
+  }
+
+  static Future<fitbitter.FitbitCredentials?> loadCredentials(
+    String studyKey,
+  ) async {
+    final userId = _currentUserIdGetter();
+
+    if (userId != null) {
+      try {
+        final serverCredentials = await _serverCredentialsLoader(
+          userId: userId,
+          studyKey: studyKey,
+        );
+        if (serverCredentials != null) {
+          try {
+            await _writeLocalValue(
+              _scopedLocalKey(userId, studyKey),
+              jsonEncode(_credentialsToJson(serverCredentials)),
+            );
+          } catch (e) {
+            StudyULogger.warning(
+              'Failed to cache participant Fitbit credentials locally: $e',
+            );
+          }
+          try {
+            if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
+              await _deleteLocalValue(_legacyLocalKey(studyKey));
+            }
+          } catch (e) {
+            StudyULogger.warning(
+              'Failed to delete legacy Fitbit credentials locally: $e',
+            );
+          }
+          return serverCredentials;
+        }
+      } catch (e) {
+        StudyULogger.error(
+          'Failed to load participant Fitbit credentials from server: $e',
+        );
+      }
+
+      String? scopedString;
+      try {
+        scopedString = await _readLocalValue(_scopedLocalKey(userId, studyKey));
+      } catch (e) {
+        StudyULogger.error(
+          'Failed to load participant Fitbit credentials locally: $e',
+        );
+      }
+      try {
+        if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
+          await _deleteLocalValue(_legacyLocalKey(studyKey));
+          StudyULogger.warning(
+            'Discarded legacy Fitbit credentials for $studyKey after authenticated load because ownership cannot be verified.',
+          );
+        }
+      } catch (e) {
+        StudyULogger.warning(
+          'Failed to delete legacy Fitbit credentials locally: $e',
+        );
+      }
+      if (scopedString != null) {
+        final jsonData = jsonDecode(scopedString) as Map<String, dynamic>;
+        return _credentialsFromJson(jsonData);
+      }
+      return null;
+    }
+
+    try {
+      final legacyString = await _readLocalValue(_legacyLocalKey(studyKey));
+      if (legacyString != null) {
+        final jsonData = jsonDecode(legacyString) as Map<String, dynamic>;
+        return _credentialsFromJson(jsonData);
+      }
+    } catch (e) {
+      StudyULogger.error('Failed to load Fitbit credentials: $e');
+    }
+
+    return null;
+  }
+
+  static Future<void> storeCredentials(
+    fitbitter.FitbitCredentials? credentials,
+    String studyKey,
+  ) async {
+    final userId = _currentUserIdGetter();
+
+    if (credentials == null) {
+      if (userId != null) {
+        try {
+          await _serverCredentialsDeleter(userId: userId, studyKey: studyKey);
+        } catch (e) {
+          StudyULogger.error(
+            'Failed to delete participant Fitbit credentials from server: $e',
+          );
+        }
+      }
+      await _deleteLocalCredentials(studyKey, userId: userId);
+      return;
+    }
+
+    final credentialsJson = _credentialsToJson(credentials);
+    if (userId != null) {
+      var localOperationFailed = false;
+      var serverOperationFailed = false;
+
+      try {
+        await _writeLocalValue(
+          _scopedLocalKey(userId, studyKey),
+          jsonEncode(credentialsJson),
+        );
+      } catch (e) {
+        localOperationFailed = true;
+        StudyULogger.error(
+          'Failed to store participant Fitbit credentials locally: $e',
+        );
+      }
+
+      try {
+        if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
+          await _deleteLocalValue(_legacyLocalKey(studyKey));
+        }
+      } catch (e) {
+        StudyULogger.warning(
+          'Failed to delete legacy Fitbit credentials locally: $e',
+        );
+      }
+
+      try {
+        await _serverCredentialsUpserter(
+          userId: userId,
+          studyKey: studyKey,
+          credentialsJson: credentialsJson,
+        );
+      } catch (e) {
+        serverOperationFailed = true;
+        StudyULogger.error(
+          'Failed to store participant Fitbit credentials on server: $e',
+        );
+      }
+
+      if (localOperationFailed && serverOperationFailed) {
+        throw const FitbitCredentialStorageException(
+          localOperationFailed: true,
+          serverOperationFailed: true,
+        );
+      }
+      return;
+    }
+
+    await _writeLocalValue(
+      _legacyLocalKey(studyKey),
+      jsonEncode(credentialsJson),
+    );
+  }
+
+  static Future<void> deleteFitbitCredentials(String studyKey) async {
+    var remoteDeletionFailed = false;
+    var localDeletionFailed = false;
+    try {
+      await deleteRemoteFitbitCredentials(studyKey);
+    } on FitbitCredentialDeletionException catch (e) {
+      remoteDeletionFailed = e.remoteDeletionFailed;
+      localDeletionFailed = e.localDeletionFailed;
+    }
+
+    try {
+      await clearLocalFallbackCredentialsForStudy(studyKey);
+    } on FitbitCredentialDeletionException catch (e) {
+      remoteDeletionFailed = remoteDeletionFailed || e.remoteDeletionFailed;
+      localDeletionFailed = localDeletionFailed || e.localDeletionFailed;
+    }
+
+    if (remoteDeletionFailed || localDeletionFailed) {
+      throw FitbitCredentialDeletionException(
+        remoteDeletionFailed: remoteDeletionFailed,
+        localDeletionFailed: localDeletionFailed,
+      );
+    }
+  }
+
+  static Future<void> deleteRemoteFitbitCredentials(String studyKey) async {
+    final userId = _currentUserIdGetter();
+    if (userId != null) {
+      try {
+        await _serverCredentialsDeleter(userId: userId, studyKey: studyKey);
+      } catch (e) {
+        StudyULogger.error(
+          'Failed to delete participant Fitbit credentials from server: $e',
+        );
+        throw const FitbitCredentialDeletionException(
+          remoteDeletionFailed: true,
+          localDeletionFailed: false,
+        );
+      }
+    }
+  }
+
+  static Future<void> clearLocalFallbackCredentialsForStudy(
+    String studyKey,
+  ) async {
+    try {
+      await _deleteLocalCredentials(studyKey, userId: _currentUserIdGetter());
+    } catch (e) {
+      StudyULogger.error(
+        'Failed to delete participant Fitbit credentials locally: $e',
+      );
+      throw const FitbitCredentialDeletionException(
+        remoteDeletionFailed: false,
+        localDeletionFailed: true,
+      );
+    }
+  }
+
+  static Future<void> clearLocalFallbackCredentials() async {
+    final storedValues = await _readAllLocalValues();
+    for (final key in storedValues.keys) {
+      if (key.startsWith(_fitbitCredentialsPrefix)) {
+        await _deleteLocalValue(key);
+      }
+    }
+  }
+
+  static Future<fitbitter.FitbitCredentials?> _loadCredentialsFromServer({
+    required String userId,
+    required String studyKey,
+  }) async {
+    final response = await Supabase.instance.client
+        .from(_participantFitbitTable)
+        .select('fitbit_credentials')
+        .eq('user_id', userId)
+        .eq('study_id', studyKey)
+        .maybeSingle();
+
+    if (response == null) return null;
+
+    final jsonData = response['fitbit_credentials'] as Map<String, dynamic>?;
+    if (jsonData == null) return null;
+    return _credentialsFromJson(jsonData);
+  }
+
+  static Future<void> _upsertCredentialsOnServer({
+    required String userId,
+    required String studyKey,
+    required Map<String, dynamic> credentialsJson,
+  }) async {
+    await Supabase.instance.client.from(_participantFitbitTable).upsert({
+      'user_id': userId,
+      'study_id': studyKey,
+      'fitbit_credentials': credentialsJson,
+    });
+  }
+
+  static Future<void> _deleteCredentialsFromServer({
+    required String userId,
+    required String studyKey,
+  }) async {
+    await Supabase.instance.client
+        .from(_participantFitbitTable)
+        .delete()
+        .eq('user_id', userId)
+        .eq('study_id', studyKey);
+  }
+
+  static Future<void> _deleteLocalCredentials(
+    String studyKey, {
+    String? userId,
+  }) async {
+    final keysToDelete = <String>{_legacyLocalKey(studyKey)};
+    final effectiveUserId = userId ?? _currentUserIdGetter();
+    if (effectiveUserId != null) {
+      keysToDelete.add(_scopedLocalKey(effectiveUserId, studyKey));
+    }
+
+    for (final key in keysToDelete) {
+      if (await _containsLocalKey(key)) {
+        await _deleteLocalValue(key);
+      }
+    }
+  }
+
+  @visibleForTesting
+  static Future<fitbitter.FitbitCredentials?> debugLoadCredentialsForTesting(
+    String studyKey,
+  ) => loadCredentials(studyKey);
+
+  @visibleForTesting
+  static Future<void> debugStoreCredentialsForTesting(
+    fitbitter.FitbitCredentials? credentials,
+    String studyKey,
+  ) => storeCredentials(credentials, studyKey);
+
+  @visibleForTesting
+  static set debugCurrentUserIdGetterForTesting(String? Function() value) {
+    _currentUserIdGetter = value;
+  }
+
+  @visibleForTesting
+  static set debugReadLocalValueForTesting(
+    Future<String?> Function(String) value,
+  ) {
+    _readLocalValue = value;
+  }
+
+  @visibleForTesting
+  static set debugWriteLocalValueForTesting(
+    Future<void> Function(String, String) value,
+  ) {
+    _writeLocalValue = value;
+  }
+
+  @visibleForTesting
+  static set debugDeleteLocalValueForTesting(
+    Future<void> Function(String) value,
+  ) {
+    _deleteLocalValue = value;
+  }
+
+  @visibleForTesting
+  static set debugContainsLocalKeyForTesting(
+    Future<bool> Function(String) value,
+  ) {
+    _containsLocalKey = value;
+  }
+
+  @visibleForTesting
+  static set debugReadAllLocalValuesForTesting(
+    Future<Map<String, String>> Function() value,
+  ) {
+    _readAllLocalValues = value;
+  }
+
+  @visibleForTesting
+  static set debugServerCredentialsLoaderForTesting(
+    Future<fitbitter.FitbitCredentials?> Function({
+      required String userId,
+      required String studyKey,
+    })
+    value,
+  ) {
+    _serverCredentialsLoader = value;
+  }
+
+  @visibleForTesting
+  static set debugServerCredentialsUpserterForTesting(
+    Future<void> Function({
+      required String userId,
+      required String studyKey,
+      required Map<String, dynamic> credentialsJson,
+    })
+    value,
+  ) {
+    _serverCredentialsUpserter = value;
+  }
+
+  @visibleForTesting
+  static set debugServerCredentialsDeleterForTesting(
+    Future<void> Function({required String userId, required String studyKey})
+    value,
+  ) {
+    _serverCredentialsDeleter = value;
+  }
+
+  @visibleForTesting
+  static void debugResetTestingOverrides() {
+    _currentUserIdGetter = _defaultCurrentUserId;
+    _readLocalValue = SecureStorage.read;
+    _writeLocalValue = SecureStorage.write;
+    _deleteLocalValue = SecureStorage.delete;
+    _containsLocalKey = SecureStorage.containsKey;
+    _readAllLocalValues = SecureStorage.readAll;
+    _serverCredentialsLoader = _loadCredentialsFromServer;
+    _serverCredentialsUpserter = _upsertCredentialsOnServer;
+    _serverCredentialsDeleter = _deleteCredentialsFromServer;
+  }
+}

--- a/app/lib/services/participant_study_exit_service.dart
+++ b/app/lib/services/participant_study_exit_service.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:studyu_app/services/participant_fitbit_credentials_service.dart';
 import 'package:studyu_app/services/restore_account_service.dart';
-import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 import 'package:supabase/supabase.dart' show PostgrestException;
@@ -42,9 +42,9 @@ class StudyExitResult {
 
 class ParticipantStudyExitService {
   static Future<void> Function(String) _remoteFitbitDeletion =
-      FitbitHandler.deleteRemoteFitbitCredentials;
+      ParticipantFitbitCredentialsService.deleteRemoteFitbitCredentials;
   static Future<void> Function(String) _localFitbitCleanup =
-      FitbitHandler.clearLocalFallbackCredentialsForStudy;
+      ParticipantFitbitCredentialsService.clearLocalFallbackCredentialsForStudy;
   static Future<void> Function() _activeStudyReferenceDeletion =
       deleteActiveStudyReference;
   static Future<void> Function() _localDataDeletion = deleteLocalData;
@@ -163,8 +163,10 @@ class ParticipantStudyExitService {
 
   @visibleForTesting
   static void debugResetTestingOverrides() {
-    _remoteFitbitDeletion = FitbitHandler.deleteRemoteFitbitCredentials;
-    _localFitbitCleanup = FitbitHandler.clearLocalFallbackCredentialsForStudy;
+    _remoteFitbitDeletion =
+        ParticipantFitbitCredentialsService.deleteRemoteFitbitCredentials;
+    _localFitbitCleanup = ParticipantFitbitCredentialsService
+        .clearLocalFallbackCredentialsForStudy;
     _activeStudyReferenceDeletion = deleteActiveStudyReference;
     _localDataDeletion = deleteLocalData;
     _recoveryCacheClearer = RestoreAccountService.clearCache;

--- a/app/lib/services/participant_study_exit_service.dart
+++ b/app/lib/services/participant_study_exit_service.dart
@@ -1,0 +1,172 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:studyu_app/services/restore_account_service.dart';
+import 'package:studyu_app/util/fitbit_handler.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+import 'package:supabase/supabase.dart' show PostgrestException;
+
+enum StudyExitMode { softDelete, hardDelete }
+
+class StudyExitResult {
+  final bool success;
+  final bool localFitbitCleanupFailed;
+  final bool isOfflineFailure;
+  final String? errorMessage;
+
+  const StudyExitResult._({
+    required this.success,
+    required this.localFitbitCleanupFailed,
+    required this.isOfflineFailure,
+    this.errorMessage,
+  });
+
+  const StudyExitResult.success({bool localFitbitCleanupFailed = false})
+    : this._(
+        success: true,
+        localFitbitCleanupFailed: localFitbitCleanupFailed,
+        isOfflineFailure: false,
+      );
+
+  const StudyExitResult.failure({
+    required bool isOfflineFailure,
+    String? errorMessage,
+  }) : this._(
+         success: false,
+         localFitbitCleanupFailed: false,
+         isOfflineFailure: isOfflineFailure,
+         errorMessage: errorMessage,
+       );
+}
+
+class ParticipantStudyExitService {
+  static Future<void> Function(String) _remoteFitbitDeletion =
+      FitbitHandler.deleteRemoteFitbitCredentials;
+  static Future<void> Function(String) _localFitbitCleanup =
+      FitbitHandler.clearLocalFallbackCredentialsForStudy;
+  static Future<void> Function() _activeStudyReferenceDeletion =
+      deleteActiveStudyReference;
+  static Future<void> Function() _localDataDeletion = deleteLocalData;
+  static void Function() _recoveryCacheClearer =
+      RestoreAccountService.clearCache;
+
+  static Future<StudyExitResult> exitStudy({
+    required StudySubject subject,
+    required StudyExitMode mode,
+    required Future<void> Function() notificationCleanup,
+  }) async {
+    try {
+      await _remoteFitbitDeletion(subject.studyId);
+    } on FitbitCredentialDeletionException {
+      return const StudyExitResult.failure(
+        isOfflineFailure: false,
+        errorMessage: 'fitbit_remote_deletion_failed',
+      );
+    }
+
+    try {
+      switch (mode) {
+        case StudyExitMode.softDelete:
+          await subject.softDelete();
+        case StudyExitMode.hardDelete:
+          try {
+            await subject.delete();
+          } on PostgrestException catch (e) {
+            if (e.code != 'PGRST116') rethrow;
+          }
+      }
+    } on SocketException {
+      return const StudyExitResult.failure(isOfflineFailure: true);
+    } on PostgrestException catch (e) {
+      return StudyExitResult.failure(
+        isOfflineFailure: false,
+        errorMessage: e.message,
+      );
+    }
+
+    switch (mode) {
+      case StudyExitMode.softDelete:
+        await _activeStudyReferenceDeletion();
+      case StudyExitMode.hardDelete:
+        _recoveryCacheClearer();
+        await _localDataDeletion();
+    }
+
+    var localFitbitCleanupFailed = false;
+    try {
+      await _localFitbitCleanup(subject.studyId);
+    } on FitbitCredentialDeletionException catch (e) {
+      localFitbitCleanupFailed = e.localDeletionFailed;
+      StudyULogger.warning(
+        'Participant Fitbit credentials were deleted remotely but local cleanup failed.',
+      );
+    }
+
+    await notificationCleanup();
+    return StudyExitResult.success(
+      localFitbitCleanupFailed: localFitbitCleanupFailed,
+    );
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String)
+  get debugRemoteFitbitDeletionForTesting => _remoteFitbitDeletion;
+
+  @visibleForTesting
+  static set debugRemoteFitbitDeletionForTesting(
+    Future<void> Function(String) value,
+  ) {
+    _remoteFitbitDeletion = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String) get debugLocalFitbitCleanupForTesting =>
+      _localFitbitCleanup;
+
+  @visibleForTesting
+  static set debugLocalFitbitCleanupForTesting(
+    Future<void> Function(String) value,
+  ) {
+    _localFitbitCleanup = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function()
+  get debugActiveStudyReferenceDeletionForTesting =>
+      _activeStudyReferenceDeletion;
+
+  @visibleForTesting
+  static set debugActiveStudyReferenceDeletionForTesting(
+    Future<void> Function() value,
+  ) {
+    _activeStudyReferenceDeletion = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function() get debugLocalDataDeletionForTesting =>
+      _localDataDeletion;
+
+  @visibleForTesting
+  static set debugLocalDataDeletionForTesting(Future<void> Function() value) {
+    _localDataDeletion = value;
+  }
+
+  @visibleForTesting
+  static void Function() get debugRecoveryCacheClearerForTesting =>
+      _recoveryCacheClearer;
+
+  @visibleForTesting
+  static set debugRecoveryCacheClearerForTesting(void Function() value) {
+    _recoveryCacheClearer = value;
+  }
+
+  @visibleForTesting
+  static void debugResetTestingOverrides() {
+    _remoteFitbitDeletion = FitbitHandler.deleteRemoteFitbitCredentials;
+    _localFitbitCleanup = FitbitHandler.clearLocalFallbackCredentialsForStudy;
+    _activeStudyReferenceDeletion = deleteActiveStudyReference;
+    _localDataDeletion = deleteLocalData;
+    _recoveryCacheClearer = RestoreAccountService.clearCache;
+  }
+}

--- a/app/lib/services/recovery_local_transition_service.dart
+++ b/app/lib/services/recovery_local_transition_service.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/foundation.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class RecoveryLocalTransitionException implements Exception {
+  const RecoveryLocalTransitionException();
+}
+
+class RecoveryLocalTransitionService {
+  static Future<void> Function(String, String) _credentialStorer =
+      _storeRecoveredCredentials;
+  static Future<String?> Function() _storedEmailReader = getFakeUserEmail;
+  static Future<String?> Function() _storedPasswordReader = getFakeUserPassword;
+  static Future<void> Function(String) _storedEmailWriter = _writeStoredEmail;
+  static Future<void> Function(String) _storedPasswordWriter =
+      _writeStoredPassword;
+  static Future<void> Function() _storedEmailDeleter = _deleteStoredEmail;
+  static Future<void> Function() _storedPasswordDeleter = _deleteStoredPassword;
+  static Future<void> Function() _participantSignOutExecutor =
+      _signOutRecoveredParticipant;
+  static Future<void> Function() _activeSubjectClearer =
+      deleteActiveStudyReference;
+
+  static Future<void> prepareForRecoveredAccount({
+    required String email,
+    required String password,
+  }) async {
+    final previousEmail = await _storedEmailReader();
+    final previousPassword = await _storedPasswordReader();
+
+    try {
+      await _credentialStorer(email, password);
+      await _activeSubjectClearer();
+    } catch (e, stackTrace) {
+      StudyULogger.warning(
+        'Error updating local recovery transition state: $e\n$stackTrace',
+      );
+      try {
+        await _restoreStoredCredentials(
+          previousEmail: previousEmail,
+          previousPassword: previousPassword,
+        );
+      } catch (restoreError, restoreStackTrace) {
+        StudyULogger.warning(
+          'Error restoring previous local participant credentials: $restoreError\n$restoreStackTrace',
+        );
+      }
+      try {
+        await _participantSignOutExecutor();
+      } catch (signOutError, signOutStackTrace) {
+        StudyULogger.warning(
+          'Error rolling back recovered participant session: $signOutError\n$signOutStackTrace',
+        );
+      }
+      throw const RecoveryLocalTransitionException();
+    }
+  }
+
+  static Future<void> _signOutRecoveredParticipant() async {
+    await Supabase.instance.client.auth.signOut();
+  }
+
+  static Future<void> _writeStoredEmail(String email) async {
+    await SecureStorage.write(userEmailKey, email);
+  }
+
+  static Future<void> _writeStoredPassword(String password) async {
+    await SecureStorage.write(userPasswordKey, password);
+  }
+
+  static Future<void> _deleteStoredEmail() async {
+    await SecureStorage.delete(userEmailKey);
+  }
+
+  static Future<void> _deleteStoredPassword() async {
+    await SecureStorage.delete(userPasswordKey);
+  }
+
+  static Future<void> _storeRecoveredCredentials(
+    String email,
+    String password,
+  ) async {
+    await _storedEmailWriter(email);
+    await _storedPasswordWriter(password);
+  }
+
+  static Future<void> _restoreStoredCredentials({
+    required String? previousEmail,
+    required String? previousPassword,
+  }) async {
+    if (previousEmail == null) {
+      await _storedEmailDeleter();
+    } else {
+      await _storedEmailWriter(previousEmail);
+    }
+
+    if (previousPassword == null) {
+      await _storedPasswordDeleter();
+    } else {
+      await _storedPasswordWriter(previousPassword);
+    }
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String, String)
+  get debugCredentialStorerForTesting => _credentialStorer;
+
+  @visibleForTesting
+  static set debugCredentialStorerForTesting(
+    Future<void> Function(String, String) value,
+  ) {
+    _credentialStorer = value;
+  }
+
+  @visibleForTesting
+  static Future<String?> Function() get debugStoredEmailReaderForTesting =>
+      _storedEmailReader;
+
+  @visibleForTesting
+  static set debugStoredEmailReaderForTesting(
+    Future<String?> Function() value,
+  ) {
+    _storedEmailReader = value;
+  }
+
+  @visibleForTesting
+  static Future<String?> Function() get debugStoredPasswordReaderForTesting =>
+      _storedPasswordReader;
+
+  @visibleForTesting
+  static set debugStoredPasswordReaderForTesting(
+    Future<String?> Function() value,
+  ) {
+    _storedPasswordReader = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String) get debugStoredEmailWriterForTesting =>
+      _storedEmailWriter;
+
+  @visibleForTesting
+  static set debugStoredEmailWriterForTesting(
+    Future<void> Function(String) value,
+  ) {
+    _storedEmailWriter = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String)
+  get debugStoredPasswordWriterForTesting => _storedPasswordWriter;
+
+  @visibleForTesting
+  static set debugStoredPasswordWriterForTesting(
+    Future<void> Function(String) value,
+  ) {
+    _storedPasswordWriter = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function() get debugStoredEmailDeleterForTesting =>
+      _storedEmailDeleter;
+
+  @visibleForTesting
+  static set debugStoredEmailDeleterForTesting(Future<void> Function() value) {
+    _storedEmailDeleter = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function() get debugStoredPasswordDeleterForTesting =>
+      _storedPasswordDeleter;
+
+  @visibleForTesting
+  static set debugStoredPasswordDeleterForTesting(
+    Future<void> Function() value,
+  ) {
+    _storedPasswordDeleter = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function()
+  get debugParticipantSignOutExecutorForTesting => _participantSignOutExecutor;
+
+  @visibleForTesting
+  static set debugParticipantSignOutExecutorForTesting(
+    Future<void> Function() value,
+  ) {
+    _participantSignOutExecutor = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function() get debugActiveSubjectClearerForTesting =>
+      _activeSubjectClearer;
+
+  @visibleForTesting
+  static set debugActiveSubjectClearerForTesting(
+    Future<void> Function() value,
+  ) {
+    _activeSubjectClearer = value;
+  }
+
+  @visibleForTesting
+  static void debugResetTestingOverrides() {
+    _credentialStorer = _storeRecoveredCredentials;
+    _storedEmailReader = getFakeUserEmail;
+    _storedPasswordReader = getFakeUserPassword;
+    _storedEmailWriter = _writeStoredEmail;
+    _storedPasswordWriter = _writeStoredPassword;
+    _storedEmailDeleter = _deleteStoredEmail;
+    _storedPasswordDeleter = _deleteStoredPassword;
+    _participantSignOutExecutor = _signOutRecoveredParticipant;
+    _activeSubjectClearer = deleteActiveStudyReference;
+  }
+}

--- a/app/lib/services/recovery_local_transition_service.dart
+++ b/app/lib/services/recovery_local_transition_service.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_setters_without_getters
+
 import 'package:flutter/foundation.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
@@ -7,14 +9,29 @@ class RecoveryLocalTransitionException implements Exception {
   const RecoveryLocalTransitionException();
 }
 
+class RecoveryTransitionSnapshot {
+  final String? previousEmail;
+  final String? previousPassword;
+  final String? previousActiveSubjectId;
+
+  const RecoveryTransitionSnapshot({
+    required this.previousEmail,
+    required this.previousPassword,
+    required this.previousActiveSubjectId,
+  });
+}
+
 class RecoveryLocalTransitionService {
   static Future<void> Function(String, String) _credentialStorer =
       _storeRecoveredCredentials;
   static Future<String?> Function() _storedEmailReader = getFakeUserEmail;
   static Future<String?> Function() _storedPasswordReader = getFakeUserPassword;
+  static Future<String?> Function() _activeSubjectReader = getActiveSubjectId;
   static Future<void> Function(String) _storedEmailWriter = _writeStoredEmail;
   static Future<void> Function(String) _storedPasswordWriter =
       _writeStoredPassword;
+  static Future<void> Function(String) _activeSubjectWriter =
+      storeActiveSubjectId;
   static Future<void> Function() _storedEmailDeleter = _deleteStoredEmail;
   static Future<void> Function() _storedPasswordDeleter = _deleteStoredPassword;
   static Future<void> Function() _participantSignOutExecutor =
@@ -22,13 +39,26 @@ class RecoveryLocalTransitionService {
   static Future<void> Function() _activeSubjectClearer =
       deleteActiveStudyReference;
 
+  static Future<RecoveryTransitionSnapshot> captureSnapshot() async {
+    try {
+      return RecoveryTransitionSnapshot(
+        previousEmail: await _storedEmailReader(),
+        previousPassword: await _storedPasswordReader(),
+        previousActiveSubjectId: await _activeSubjectReader(),
+      );
+    } catch (e, stackTrace) {
+      StudyULogger.warning(
+        'Error capturing local recovery transition snapshot: $e\n$stackTrace',
+      );
+      throw const RecoveryLocalTransitionException();
+    }
+  }
+
   static Future<void> prepareForRecoveredAccount({
+    required RecoveryTransitionSnapshot snapshot,
     required String email,
     required String password,
   }) async {
-    final previousEmail = await _storedEmailReader();
-    final previousPassword = await _storedPasswordReader();
-
     try {
       await _credentialStorer(email, password);
       await _activeSubjectClearer();
@@ -37,15 +67,13 @@ class RecoveryLocalTransitionService {
         'Error updating local recovery transition state: $e\n$stackTrace',
       );
       try {
-        await _restoreStoredCredentials(
-          previousEmail: previousEmail,
-          previousPassword: previousPassword,
-        );
+        await _restoreStoredCredentials(snapshot);
       } catch (restoreError, restoreStackTrace) {
         StudyULogger.warning(
           'Error restoring previous local participant credentials: $restoreError\n$restoreStackTrace',
         );
       }
+      await _restoreActiveSubject(snapshot.previousActiveSubjectId);
       try {
         await _participantSignOutExecutor();
       } catch (signOutError, signOutStackTrace) {
@@ -85,20 +113,64 @@ class RecoveryLocalTransitionService {
     await _storedPasswordWriter(password);
   }
 
-  static Future<void> _restoreStoredCredentials({
-    required String? previousEmail,
-    required String? previousPassword,
-  }) async {
-    if (previousEmail == null) {
-      await _storedEmailDeleter();
-    } else {
-      await _storedEmailWriter(previousEmail);
-    }
+  static Future<void> _restoreStoredCredentials(
+    RecoveryTransitionSnapshot snapshot,
+  ) async {
+    final emailRestored = await _restoreCredentialValue(
+      value: snapshot.previousEmail,
+      writer: _storedEmailWriter,
+      deleter: _storedEmailDeleter,
+    );
+    final passwordRestored = await _restoreCredentialValue(
+      value: snapshot.previousPassword,
+      writer: _storedPasswordWriter,
+      deleter: _storedPasswordDeleter,
+    );
+    if (emailRestored && passwordRestored) return;
 
-    if (previousPassword == null) {
+    try {
+      await _storedEmailDeleter();
       await _storedPasswordDeleter();
-    } else {
-      await _storedPasswordWriter(previousPassword);
+    } catch (e, stackTrace) {
+      StudyULogger.warning(
+        'Error deleting incomplete local participant credentials during rollback: $e\n$stackTrace',
+      );
+    }
+  }
+
+  static Future<bool> _restoreCredentialValue({
+    required String? value,
+    required Future<void> Function(String) writer,
+    required Future<void> Function() deleter,
+  }) async {
+    try {
+      if (value == null) {
+        await deleter();
+      } else {
+        await writer(value);
+      }
+      return true;
+    } catch (e, stackTrace) {
+      StudyULogger.warning(
+        'Error restoring local participant credential value: $e\n$stackTrace',
+      );
+      return false;
+    }
+  }
+
+  static Future<void> _restoreActiveSubject(
+    String? previousActiveSubjectId,
+  ) async {
+    try {
+      if (previousActiveSubjectId == null) {
+        await _activeSubjectClearer();
+      } else {
+        await _activeSubjectWriter(previousActiveSubjectId);
+      }
+    } catch (e, stackTrace) {
+      StudyULogger.warning(
+        'Error restoring previous active subject reference: $e\n$stackTrace',
+      );
     }
   }
 
@@ -136,6 +208,13 @@ class RecoveryLocalTransitionService {
   }
 
   @visibleForTesting
+  static set debugActiveSubjectReaderForTesting(
+    Future<String?> Function() value,
+  ) {
+    _activeSubjectReader = value;
+  }
+
+  @visibleForTesting
   static Future<void> Function(String) get debugStoredEmailWriterForTesting =>
       _storedEmailWriter;
 
@@ -155,6 +234,13 @@ class RecoveryLocalTransitionService {
     Future<void> Function(String) value,
   ) {
     _storedPasswordWriter = value;
+  }
+
+  @visibleForTesting
+  static set debugActiveSubjectWriterForTesting(
+    Future<void> Function(String) value,
+  ) {
+    _activeSubjectWriter = value;
   }
 
   @visibleForTesting
@@ -204,8 +290,10 @@ class RecoveryLocalTransitionService {
     _credentialStorer = _storeRecoveredCredentials;
     _storedEmailReader = getFakeUserEmail;
     _storedPasswordReader = getFakeUserPassword;
+    _activeSubjectReader = getActiveSubjectId;
     _storedEmailWriter = _writeStoredEmail;
     _storedPasswordWriter = _writeStoredPassword;
+    _activeSubjectWriter = storeActiveSubjectId;
     _storedEmailDeleter = _deleteStoredEmail;
     _storedPasswordDeleter = _deleteStoredPassword;
     _participantSignOutExecutor = _signOutRecoveredParticipant;

--- a/app/lib/services/restore_account_service.dart
+++ b/app/lib/services/restore_account_service.dart
@@ -47,7 +47,7 @@ class RestoreAccountService {
   static Future<bool> Function(String) _subjectValidator = validateSubject;
   static Future<void> Function(String) _activeSubjectStorer =
       storeActiveSubjectId;
-  static Future<void> Function() _participantStateCleanup =
+  static Future<void> Function(String?, String?) _participantStateCleanup =
       _cleanupParticipantStateForRecovery;
 
   static void clearCache() {
@@ -167,12 +167,12 @@ class RestoreAccountService {
   }
 
   @visibleForTesting
-  static Future<void> Function() get debugParticipantStateCleanupForTesting =>
-      _participantStateCleanup;
+  static Future<void> Function(String?, String?)
+  get debugParticipantStateCleanupForTesting => _participantStateCleanup;
 
   @visibleForTesting
   static set debugParticipantStateCleanupForTesting(
-    Future<void> Function() cleanup,
+    Future<void> Function(String?, String?) cleanup,
   ) {
     _participantStateCleanup = cleanup;
   }
@@ -296,11 +296,19 @@ class RestoreAccountService {
     }
   }
 
-  static Future<void> _cleanupParticipantStateForRecovery() async {
+  static Future<void> _cleanupParticipantStateForRecovery(
+    String? recoveredUserId,
+    String? recoveredSubjectId,
+  ) async {
     clearCache();
-    await Cache.clearAllSubjectCaches();
+    await Cache.clearRecoverySubjectCaches(
+      recoveredUserId: recoveredUserId,
+      recoveredSubjectId: recoveredSubjectId,
+    );
     await PendingDeepLinkService.clearStorage();
-    await ParticipantFitbitCredentialsService.clearLocalFallbackCredentials();
+    await ParticipantFitbitCredentialsService.clearLocalFallbackCredentialsForRecovery(
+      recoveredUserId,
+    );
   }
 
   static BigInt decodeRecoveryPhrase(List<String> words) {
@@ -393,6 +401,17 @@ class RestoreAccountService {
         return RecoveryResult(success: false, error: 'recovery_failed');
       }
 
+      final RecoveryTransitionSnapshot transitionSnapshot;
+      try {
+        transitionSnapshot =
+            await RecoveryLocalTransitionService.captureSnapshot();
+      } on RecoveryLocalTransitionException {
+        return RecoveryResult(
+          success: false,
+          error: 'recovery_local_persistence_failed',
+        );
+      }
+
       final signInResult = await _participantSignInExecutor(
         recoveredEmail,
         recoveredPassword,
@@ -402,8 +421,12 @@ class RestoreAccountService {
         return RecoveryResult(success: false, error: 'recovery_failed');
       }
 
+      final recoveredUserId = _currentUserIdGetter();
+      final recoveredSubjectId = result.subjectId;
+
       try {
         await RecoveryLocalTransitionService.prepareForRecoveredAccount(
+          snapshot: transitionSnapshot,
           email: recoveredEmail,
           password: recoveredPassword,
         );
@@ -414,8 +437,17 @@ class RestoreAccountService {
         );
       }
 
+      final validRecoveredSubjectId =
+          recoveredSubjectId != null &&
+              await _subjectValidator(recoveredSubjectId)
+          ? recoveredSubjectId
+          : null;
+
       try {
-        await _participantStateCleanup();
+        await _participantStateCleanup(
+          recoveredUserId,
+          validRecoveredSubjectId,
+        );
       } catch (e, stackTrace) {
         StudyULogger.warning(
           'Error cleaning up participant state after recovery sign in: $e\n$stackTrace',
@@ -423,11 +455,7 @@ class RestoreAccountService {
         return RecoveryResult(success: false, error: 'recovery_cleanup_failed');
       }
 
-      final subjectId = result.subjectId;
-      if (subjectId == null) return result;
-
-      final isValid = await _subjectValidator(subjectId);
-      if (!isValid) {
+      if (validRecoveredSubjectId == null) {
         return RecoveryResult(
           success: true,
           email: result.email,
@@ -435,7 +463,7 @@ class RestoreAccountService {
         );
       }
 
-      await _activeSubjectStorer(subjectId);
+      await _activeSubjectStorer(validRecoveredSubjectId);
       return result;
     } catch (e, stackTrace) {
       StudyULogger.warning('Error in performRecovery: $e\n$stackTrace');

--- a/app/lib/services/restore_account_service.dart
+++ b/app/lib/services/restore_account_service.dart
@@ -348,7 +348,6 @@ class RestoreAccountService {
 
   static Future<void> _cleanupParticipantStateForRecovery() async {
     clearCache();
-    await _activeSubjectClearer();
     await Cache.clearAllSubjectCaches();
     await PendingDeepLinkService.clearStorage();
     await FitbitHandler.clearLocalFallbackCredentials();
@@ -464,14 +463,22 @@ class RestoreAccountService {
         return RecoveryResult(success: false, error: 'recovery_failed');
       }
 
-      await _participantStateCleanup();
       await _credentialStorer(recoveredEmail, recoveredPassword);
+      await _activeSubjectClearer();
+
+      try {
+        await _participantStateCleanup();
+      } catch (e, stackTrace) {
+        StudyULogger.warning(
+          'Error cleaning up participant state after recovery sign in: $e\n$stackTrace',
+        );
+        return RecoveryResult(success: false, error: 'recovery_cleanup_failed');
+      }
 
       if (result.subjectId != null) {
         final isValid = await _subjectValidator(result.subjectId!);
 
         if (!isValid) {
-          await _activeSubjectClearer();
           return RecoveryResult(
             success: true,
             email: result.email,
@@ -480,8 +487,6 @@ class RestoreAccountService {
         }
 
         await _activeSubjectStorer(result.subjectId!);
-      } else {
-        await _activeSubjectClearer();
       }
 
       return result;

--- a/app/lib/services/restore_account_service.dart
+++ b/app/lib/services/restore_account_service.dart
@@ -43,7 +43,8 @@ class RestoreAccountService {
       recoverAccount;
   static Future<void> Function(String, String) _credentialStorer =
       storeFakeUserEmailAndPassword;
-  static Future<bool> Function() _participantSignInExecutor = signInParticipant;
+  static Future<bool> Function(String, String) _participantSignInExecutor =
+      _signInRecoveredParticipant;
   static Future<bool> Function(String) _subjectValidator = validateSubject;
   static Future<void> Function(String) _activeSubjectStorer =
       storeActiveSubjectId;
@@ -137,19 +138,19 @@ class RestoreAccountService {
   }
 
   @visibleForTesting
-  static Future<bool> Function() get debugParticipantSignInExecutorForTesting =>
-      _participantSignInExecutor;
+  static Future<bool> Function(String, String)
+  get debugParticipantSignInExecutorForTesting => _participantSignInExecutor;
 
   @visibleForTesting
   static set debugParticipantSignInExecutorForTesting(
-    Future<bool> Function() executor,
+    Future<bool> Function(String, String) executor,
   ) {
     _participantSignInExecutor = executor;
   }
 
   @visibleForTesting
   static void debugResetParticipantSignInExecutorForTesting() {
-    _participantSignInExecutor = signInParticipant;
+    _participantSignInExecutor = _signInRecoveredParticipant;
   }
 
   @visibleForTesting
@@ -331,6 +332,20 @@ class RestoreAccountService {
   static String? _currentUserId() =>
       Supabase.instance.client.auth.currentUser?.id;
 
+  static Future<bool> _signInRecoveredParticipant(
+    String email,
+    String password,
+  ) async {
+    try {
+      final authResponse = await Supabase.instance.client.auth
+          .signInWithPassword(email: email, password: password);
+      return authResponse.session != null;
+    } catch (error, stacktrace) {
+      SupabaseQuery.catchSupabaseException(error, stacktrace);
+      return false;
+    }
+  }
+
   static Future<void> _cleanupParticipantStateForRecovery() async {
     clearCache();
     await _activeSubjectClearer();
@@ -433,15 +448,24 @@ class RestoreAccountService {
         return result;
       }
 
-      await _participantStateCleanup();
+      final recoveredEmail = result.email;
+      final recoveredPassword = result.password;
+      if (recoveredEmail == null || recoveredPassword == null) {
+        StudyULogger.warning('Recovery result missing credentials');
+        return RecoveryResult(success: false, error: 'recovery_failed');
+      }
 
-      await _credentialStorer(result.email!, result.password!);
-
-      final signInResult = await _participantSignInExecutor();
+      final signInResult = await _participantSignInExecutor(
+        recoveredEmail,
+        recoveredPassword,
+      );
       if (!signInResult) {
         StudyULogger.warning('Sign in failed after recovery');
         return RecoveryResult(success: false, error: 'recovery_failed');
       }
+
+      await _participantStateCleanup();
+      await _credentialStorer(recoveredEmail, recoveredPassword);
 
       if (result.subjectId != null) {
         final isValid = await _subjectValidator(result.subjectId!);

--- a/app/lib/services/restore_account_service.dart
+++ b/app/lib/services/restore_account_service.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/foundation.dart';
+import 'package:studyu_app/services/participant_fitbit_credentials_service.dart';
 import 'package:studyu_app/services/pending_deep_link_service.dart';
+import 'package:studyu_app/services/recovery_local_transition_service.dart';
 import 'package:studyu_app/util/cache.dart';
-import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -41,15 +42,11 @@ class RestoreAccountService {
   static String? Function() _currentUserIdGetter = _currentUserId;
   static Future<RecoveryResult> Function(BigInt) _recoverAccountExecutor =
       recoverAccount;
-  static Future<void> Function(String, String) _credentialStorer =
-      storeFakeUserEmailAndPassword;
   static Future<bool> Function(String, String) _participantSignInExecutor =
       _signInRecoveredParticipant;
   static Future<bool> Function(String) _subjectValidator = validateSubject;
   static Future<void> Function(String) _activeSubjectStorer =
       storeActiveSubjectId;
-  static Future<void> Function() _activeSubjectClearer =
-      deleteActiveStudyReference;
   static Future<void> Function() _participantStateCleanup =
       _cleanupParticipantStateForRecovery;
 
@@ -122,22 +119,6 @@ class RestoreAccountService {
   }
 
   @visibleForTesting
-  static Future<void> Function(String, String)
-  get debugCredentialStorerForTesting => _credentialStorer;
-
-  @visibleForTesting
-  static set debugCredentialStorerForTesting(
-    Future<void> Function(String, String) storer,
-  ) {
-    _credentialStorer = storer;
-  }
-
-  @visibleForTesting
-  static void debugResetCredentialStorerForTesting() {
-    _credentialStorer = storeFakeUserEmailAndPassword;
-  }
-
-  @visibleForTesting
   static Future<bool> Function(String, String)
   get debugParticipantSignInExecutorForTesting => _participantSignInExecutor;
 
@@ -186,22 +167,6 @@ class RestoreAccountService {
   }
 
   @visibleForTesting
-  static Future<void> Function() get debugActiveSubjectClearerForTesting =>
-      _activeSubjectClearer;
-
-  @visibleForTesting
-  static set debugActiveSubjectClearerForTesting(
-    Future<void> Function() clearer,
-  ) {
-    _activeSubjectClearer = clearer;
-  }
-
-  @visibleForTesting
-  static void debugResetActiveSubjectClearerForTesting() {
-    _activeSubjectClearer = deleteActiveStudyReference;
-  }
-
-  @visibleForTesting
   static Future<void> Function() get debugParticipantStateCleanupForTesting =>
       _participantStateCleanup;
 
@@ -244,23 +209,10 @@ class RestoreAccountService {
     }
   }
 
-  /// Sanitizes a UUID string by removing hyphens and validating format
-  /// Returns null if the UUID format is invalid
   static String? _sanitizeUuid(String uuid) {
-    // Remove all hyphens and convert to lowercase
     final sanitized = uuid.replaceAll('-', '').toLowerCase().trim();
-
-    // UUID without hyphens should be exactly 32 hex characters
-    if (sanitized.length != 32) {
-      return null;
-    }
-
-    // Validate hex characters only
-    final validHex = RegExp(r'^[0-9a-f]+$');
-    if (!validHex.hasMatch(sanitized)) {
-      return null;
-    }
-
+    if (sanitized.length != 32) return null;
+    if (!RegExp(r'^[0-9a-f]+$').hasMatch(sanitized)) return null;
     return sanitized;
   }
 
@@ -285,14 +237,12 @@ class RestoreAccountService {
       final response = await Supabase.instance.client.rpc(
         'get_or_create_recovery',
       );
-
       if (response is Map<String, dynamic> && response['success'] == true) {
         return _cachedRecoveryId = response['recovery_id'] as String?;
-      } else {
-        final error = response is Map ? response['error'] : 'Unknown error';
-        StudyULogger.warning('Failed to get recovery_id: $error');
-        return null;
       }
+      final error = response is Map ? response['error'] : 'Unknown error';
+      StudyULogger.warning('Failed to get recovery_id: $error');
+      return null;
     } catch (e) {
       StudyULogger.warning('Error getting recovery_id: $e');
       return null;
@@ -350,45 +300,38 @@ class RestoreAccountService {
     clearCache();
     await Cache.clearAllSubjectCaches();
     await PendingDeepLinkService.clearStorage();
-    await FitbitHandler.clearLocalFallbackCredentials();
+    await ParticipantFitbitCredentialsService.clearLocalFallbackCredentials();
   }
 
   static BigInt decodeRecoveryPhrase(List<String> words) {
-    // Validate word count first
     if (words.length != RecoveryConstants.totalWordCount) {
       throw ArgumentError(
         'Expected ${RecoveryConstants.totalWordCount} words, got ${words.length}',
       );
     }
 
-    // Try English wordlist first
     try {
       final enWords = words.map((w) => w.toLowerCase().trim()).toList();
       return decode(enWords, wordlist: wordlistEn);
     } catch (e) {
       if (e is! ArgumentError) rethrow;
-
-      // Check if error is due to word not found in English list
       final errorStr = e.toString();
-      if (errorStr.contains('Invalid word') ||
-          errorStr.contains('Checksum mismatch')) {
-        // Try German wordlist
-        try {
-          final deWords = words.map((w) => w.toLowerCase().trim()).toList();
-          return decode(deWords, wordlist: wordlistDe);
-        } catch (deError) {
-          if (deError is! ArgumentError) rethrow;
-
-          // German also failed, throw original English error
-          throw e;
-        }
+      if (!errorStr.contains('Invalid word') &&
+          !errorStr.contains('Checksum mismatch')) {
+        rethrow;
       }
-      rethrow;
+
+      try {
+        final deWords = words.map((w) => w.toLowerCase().trim()).toList();
+        return decode(deWords, wordlist: wordlistDe);
+      } catch (deError) {
+        if (deError is! ArgumentError) rethrow;
+        throw e;
+      }
     }
   }
 
   static String? convertBigIntToUuid(BigInt id) {
-    // Validate the ID fits within 128 bits
     if (id < BigInt.zero || id > _max128BitValue) {
       StudyULogger.warning('Recovery ID out of valid range');
       return null;
@@ -410,17 +353,16 @@ class RestoreAccountService {
       if (uuidString == null) {
         return RecoveryResult(success: false, error: 'invalid_recovery_id');
       }
+
       final response = await Supabase.instance.client.rpc(
         'recover_account',
         params: {'p_recovery_id': uuidString},
       );
-
       if (response is Map<String, dynamic>) {
         return RecoveryResult.fromJson(response);
-      } else {
-        StudyULogger.warning('Unexpected response format: $response');
-        return RecoveryResult(success: false, error: 'recovery_failed');
       }
+      StudyULogger.warning('Unexpected response format: $response');
+      return RecoveryResult(success: false, error: 'recovery_failed');
     } catch (e) {
       StudyULogger.warning('RPC call failed: $e');
       return RecoveryResult(success: false, error: 'recovery_network_error');
@@ -434,7 +376,7 @@ class RestoreAccountService {
         selectedColumns: ['*'],
       );
       return !subject.isDeleted;
-    } catch (e) {
+    } catch (_) {
       return false;
     }
   }
@@ -442,10 +384,7 @@ class RestoreAccountService {
   static Future<RecoveryResult> performRecovery(BigInt recoveryId) async {
     try {
       final result = await _recoverAccountExecutor(recoveryId);
-
-      if (!result.success) {
-        return result;
-      }
+      if (!result.success) return result;
 
       final recoveredEmail = result.email;
       final recoveredPassword = result.password;
@@ -463,8 +402,17 @@ class RestoreAccountService {
         return RecoveryResult(success: false, error: 'recovery_failed');
       }
 
-      await _credentialStorer(recoveredEmail, recoveredPassword);
-      await _activeSubjectClearer();
+      try {
+        await RecoveryLocalTransitionService.prepareForRecoveredAccount(
+          email: recoveredEmail,
+          password: recoveredPassword,
+        );
+      } on RecoveryLocalTransitionException {
+        return RecoveryResult(
+          success: false,
+          error: 'recovery_local_persistence_failed',
+        );
+      }
 
       try {
         await _participantStateCleanup();
@@ -475,20 +423,19 @@ class RestoreAccountService {
         return RecoveryResult(success: false, error: 'recovery_cleanup_failed');
       }
 
-      if (result.subjectId != null) {
-        final isValid = await _subjectValidator(result.subjectId!);
+      final subjectId = result.subjectId;
+      if (subjectId == null) return result;
 
-        if (!isValid) {
-          return RecoveryResult(
-            success: true,
-            email: result.email,
-            password: result.password,
-          );
-        }
-
-        await _activeSubjectStorer(result.subjectId!);
+      final isValid = await _subjectValidator(subjectId);
+      if (!isValid) {
+        return RecoveryResult(
+          success: true,
+          email: result.email,
+          password: result.password,
+        );
       }
 
+      await _activeSubjectStorer(subjectId);
       return result;
     } catch (e, stackTrace) {
       StudyULogger.warning('Error in performRecovery: $e\n$stackTrace');

--- a/app/lib/services/restore_account_service.dart
+++ b/app/lib/services/restore_account_service.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/foundation.dart';
+import 'package:studyu_app/services/pending_deep_link_service.dart';
+import 'package:studyu_app/util/cache.dart';
+import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -36,6 +39,18 @@ class RestoreAccountService {
   static Future<String?> Function() _recoveryIdGetter = _fetchRecoveryId;
   static Future<String?> Function() _recoveryIdRotator = _rotateRecoveryId;
   static String? Function() _currentUserIdGetter = _currentUserId;
+  static Future<RecoveryResult> Function(BigInt) _recoverAccountExecutor =
+      recoverAccount;
+  static Future<void> Function(String, String) _credentialStorer =
+      storeFakeUserEmailAndPassword;
+  static Future<bool> Function() _participantSignInExecutor = signInParticipant;
+  static Future<bool> Function(String) _subjectValidator = validateSubject;
+  static Future<void> Function(String) _activeSubjectStorer =
+      storeActiveSubjectId;
+  static Future<void> Function() _activeSubjectClearer =
+      deleteActiveStudyReference;
+  static Future<void> Function() _participantStateCleanup =
+      _cleanupParticipantStateForRecovery;
 
   static void clearCache() {
     _cachedPhrase = null;
@@ -87,6 +102,118 @@ class RestoreAccountService {
   @visibleForTesting
   static void debugResetCurrentUserIdGetterForTesting() {
     _currentUserIdGetter = _currentUserId;
+  }
+
+  @visibleForTesting
+  static Future<RecoveryResult> Function(BigInt)
+  get debugRecoverAccountExecutorForTesting => _recoverAccountExecutor;
+
+  @visibleForTesting
+  static set debugRecoverAccountExecutorForTesting(
+    Future<RecoveryResult> Function(BigInt) executor,
+  ) {
+    _recoverAccountExecutor = executor;
+  }
+
+  @visibleForTesting
+  static void debugResetRecoverAccountExecutorForTesting() {
+    _recoverAccountExecutor = recoverAccount;
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String, String)
+  get debugCredentialStorerForTesting => _credentialStorer;
+
+  @visibleForTesting
+  static set debugCredentialStorerForTesting(
+    Future<void> Function(String, String) storer,
+  ) {
+    _credentialStorer = storer;
+  }
+
+  @visibleForTesting
+  static void debugResetCredentialStorerForTesting() {
+    _credentialStorer = storeFakeUserEmailAndPassword;
+  }
+
+  @visibleForTesting
+  static Future<bool> Function() get debugParticipantSignInExecutorForTesting =>
+      _participantSignInExecutor;
+
+  @visibleForTesting
+  static set debugParticipantSignInExecutorForTesting(
+    Future<bool> Function() executor,
+  ) {
+    _participantSignInExecutor = executor;
+  }
+
+  @visibleForTesting
+  static void debugResetParticipantSignInExecutorForTesting() {
+    _participantSignInExecutor = signInParticipant;
+  }
+
+  @visibleForTesting
+  static Future<bool> Function(String) get debugSubjectValidatorForTesting =>
+      _subjectValidator;
+
+  @visibleForTesting
+  static set debugSubjectValidatorForTesting(
+    Future<bool> Function(String) validator,
+  ) {
+    _subjectValidator = validator;
+  }
+
+  @visibleForTesting
+  static void debugResetSubjectValidatorForTesting() {
+    _subjectValidator = validateSubject;
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String) get debugActiveSubjectStorerForTesting =>
+      _activeSubjectStorer;
+
+  @visibleForTesting
+  static set debugActiveSubjectStorerForTesting(
+    Future<void> Function(String) storer,
+  ) {
+    _activeSubjectStorer = storer;
+  }
+
+  @visibleForTesting
+  static void debugResetActiveSubjectStorerForTesting() {
+    _activeSubjectStorer = storeActiveSubjectId;
+  }
+
+  @visibleForTesting
+  static Future<void> Function() get debugActiveSubjectClearerForTesting =>
+      _activeSubjectClearer;
+
+  @visibleForTesting
+  static set debugActiveSubjectClearerForTesting(
+    Future<void> Function() clearer,
+  ) {
+    _activeSubjectClearer = clearer;
+  }
+
+  @visibleForTesting
+  static void debugResetActiveSubjectClearerForTesting() {
+    _activeSubjectClearer = deleteActiveStudyReference;
+  }
+
+  @visibleForTesting
+  static Future<void> Function() get debugParticipantStateCleanupForTesting =>
+      _participantStateCleanup;
+
+  @visibleForTesting
+  static set debugParticipantStateCleanupForTesting(
+    Future<void> Function() cleanup,
+  ) {
+    _participantStateCleanup = cleanup;
+  }
+
+  @visibleForTesting
+  static void debugResetParticipantStateCleanupForTesting() {
+    _participantStateCleanup = _cleanupParticipantStateForRecovery;
   }
 
   static Future<List<String>?> getRecoveryPhrase() async {
@@ -204,6 +331,14 @@ class RestoreAccountService {
   static String? _currentUserId() =>
       Supabase.instance.client.auth.currentUser?.id;
 
+  static Future<void> _cleanupParticipantStateForRecovery() async {
+    clearCache();
+    await _activeSubjectClearer();
+    await Cache.clearAllSubjectCaches();
+    await PendingDeepLinkService.clearStorage();
+    await FitbitHandler.clearLocalFallbackCredentials();
+  }
+
   static BigInt decodeRecoveryPhrase(List<String> words) {
     // Validate word count first
     if (words.length != RecoveryConstants.totalWordCount) {
@@ -291,29 +426,28 @@ class RestoreAccountService {
   }
 
   static Future<RecoveryResult> performRecovery(BigInt recoveryId) async {
-    // Invalidate any cached recovery secret from a prior session before
-    // establishing the recovered identity, so it cannot leak to the new
-    // account via the static cache on a shared device.
-    clearCache();
     try {
-      final result = await recoverAccount(recoveryId);
+      final result = await _recoverAccountExecutor(recoveryId);
 
       if (!result.success) {
         return result;
       }
 
-      await storeFakeUserEmailAndPassword(result.email!, result.password!);
+      await _participantStateCleanup();
 
-      final signInResult = await signInParticipant();
+      await _credentialStorer(result.email!, result.password!);
+
+      final signInResult = await _participantSignInExecutor();
       if (!signInResult) {
         StudyULogger.warning('Sign in failed after recovery');
         return RecoveryResult(success: false, error: 'recovery_failed');
       }
 
       if (result.subjectId != null) {
-        final isValid = await validateSubject(result.subjectId!);
+        final isValid = await _subjectValidator(result.subjectId!);
 
         if (!isValid) {
+          await _activeSubjectClearer();
           return RecoveryResult(
             success: true,
             email: result.email,
@@ -321,7 +455,9 @@ class RestoreAccountService {
           );
         }
 
-        await storeActiveSubjectId(result.subjectId!);
+        await _activeSubjectStorer(result.subjectId!);
+      } else {
+        await _activeSubjectClearer();
       }
 
       return result;

--- a/app/lib/util/cache.dart
+++ b/app/lib/util/cache.dart
@@ -6,51 +6,105 @@ import 'package:flutter/foundation.dart';
 import 'package:studyu_app/util/temporary_storage_handler.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class Cache {
   static bool isSynchronizing = false;
+  static const _scopedCachePrefix = '${cacheSubjectKey}_';
+
+  static String _scopedCacheKey(String userId, String subjectId) =>
+      '$_scopedCachePrefix${userId}_$subjectId';
+
+  static Future<String?> _preferredCacheKey({
+    StudySubject? subject,
+    StudySubject? backupSubject,
+  }) async {
+    final targetSubject = subject ?? backupSubject;
+    if (targetSubject != null) {
+      return _scopedCacheKey(targetSubject.userId, targetSubject.id);
+    }
+
+    final currentUserId = Supabase.instance.client.auth.currentUser?.id;
+    final activeSubjectId = await getActiveSubjectId();
+    if (currentUserId == null || activeSubjectId == null) return null;
+    return _scopedCacheKey(currentUserId, activeSubjectId);
+  }
+
+  static Future<String?> _readCachedSubjectString({
+    StudySubject? subject,
+    StudySubject? backupSubject,
+  }) async {
+    final scopedKey = await _preferredCacheKey(
+      subject: subject,
+      backupSubject: backupSubject,
+    );
+    if (scopedKey != null && await SecureStorage.containsKey(scopedKey)) {
+      return await SecureStorage.read(scopedKey);
+    }
+    if (await SecureStorage.containsKey(cacheSubjectKey)) {
+      return await SecureStorage.read(cacheSubjectKey);
+    }
+    return null;
+  }
+
+  static Future<StudySubject> _decodeCachedSubject(
+    String cachedSubjectStr, {
+    StudySubject? backupSubject,
+  }) async {
+    final cachedSubject = jsonDecode(cachedSubjectStr) as Map<String, dynamic>;
+    final cachedUserId = cachedSubject['user_id'] as String?;
+    final currentUserId = Supabase.instance.client.auth.currentUser?.id;
+
+    if (currentUserId != null &&
+        cachedUserId != null &&
+        cachedUserId != currentUserId) {
+      throw Exception('Cached subject belongs to a different user');
+    }
+
+    try {
+      return StudySubject.fromJson(cachedSubject);
+    } catch (e) {
+      StudyULogger.warning("Failed to parse cached subject: $cachedSubjectStr");
+      if (backupSubject != null) {
+        if (backupSubject.id != cachedSubject['id']) {
+          throw Exception("Cached subject ID does not match remote subject ID");
+        }
+        if (backupSubject.userId != cachedSubject['user_id']) {
+          throw Exception(
+            "Cached subject user does not match remote subject user",
+          );
+        }
+        final cachedProgress = (cachedSubject['progress'] as List?)
+            ?.map((e) => SubjectProgress.fromJson(e as Map<String, dynamic>))
+            .toList();
+        backupSubject.progress = cachedProgress ?? backupSubject.progress;
+        return backupSubject;
+      }
+      throw Exception("No backup subject provided");
+    }
+  }
 
   static Future<void> storeSubject(StudySubject? subject) async {
     // debugPrint("Store subject in cache");
     if (subject == null) return;
-    SecureStorage.write(cacheSubjectKey, jsonEncode(subject.toFullJson()));
+    final scopedKey = _scopedCacheKey(subject.userId, subject.id);
+    await SecureStorage.write(scopedKey, jsonEncode(subject.toFullJson()));
+    if (await SecureStorage.containsKey(cacheSubjectKey)) {
+      await SecureStorage.delete(cacheSubjectKey);
+    }
     assert(subject == (await loadSubject()));
   }
 
   static Future<StudySubject> loadSubject({StudySubject? backupSubject}) async {
     // debugPrint("Load subject from cache");
-    if (await SecureStorage.containsKey(cacheSubjectKey)) {
-      final cachedSubjectStr = await SecureStorage.read(cacheSubjectKey);
-      final cachedSubject =
-          jsonDecode(cachedSubjectStr!) as Map<String, dynamic>;
-      try {
-        return StudySubject.fromJson(cachedSubject);
-      } catch (e) {
-        StudyULogger.warning(
-          "Failed to parse cached subject: $cachedSubjectStr",
-        );
-        if (backupSubject != null) {
-          // Only take progress from cached subject and rest from backup,
-          // as the cached subject might be outdated or corrupted
-
-          // compare IDs to make sure we are not mixing up subjects
-          // If IDs do not match we should not use the cached subject
-          if (backupSubject.id != cachedSubject['id']) {
-            throw Exception(
-              "Cached subject ID does not match remote subject ID",
-            );
-          }
-          final cachedProgress = (cachedSubject['progress'] as List?)
-              ?.map((e) => SubjectProgress.fromJson(e as Map<String, dynamic>))
-              .toList();
-          backupSubject.progress = cachedProgress ?? backupSubject.progress;
-          return backupSubject;
-        }
-        throw Exception("No backup subject provided");
-      }
-    } else {
+    final cachedSubjectStr = await _readCachedSubjectString(
+      backupSubject: backupSubject,
+    );
+    if (cachedSubjectStr == null) {
       throw Exception("No cached subject found");
     }
+
+    return _decodeCachedSubject(cachedSubjectStr, backupSubject: backupSubject);
   }
 
   static Future<void> storeAnalytics(StudyUAnalytics analytics) async {
@@ -80,7 +134,16 @@ class Cache {
 
   static Future<void> delete() async {
     StudyULogger.warning("Delete cache");
-    SecureStorage.delete(cacheSubjectKey);
+    await clearAllSubjectCaches();
+  }
+
+  static Future<void> clearAllSubjectCaches() async {
+    final storedValues = await SecureStorage.readAll();
+    for (final key in storedValues.keys) {
+      if (key == cacheSubjectKey || key.startsWith(_scopedCachePrefix)) {
+        await SecureStorage.delete(key);
+      }
+    }
   }
 
   static Future<void> uploadBlobFiles() async {
@@ -98,10 +161,16 @@ class Cache {
   static Future<StudySubject> synchronize(StudySubject remoteSubject) async {
     if (isSynchronizing) return remoteSubject;
     // No local subject found
-    if (!(await SecureStorage.containsKey(cacheSubjectKey))) {
+    final cachedSubjectStr = await _readCachedSubjectString(
+      backupSubject: remoteSubject,
+    );
+    if (cachedSubjectStr == null) {
       return remoteSubject;
     }
-    final localSubject = await loadSubject(backupSubject: remoteSubject);
+    final localSubject = await _decodeCachedSubject(
+      cachedSubjectStr,
+      backupSubject: remoteSubject,
+    );
     // local and remote subject are equal, nothing to synchronize
     if (localSubject == remoteSubject) return remoteSubject;
     // remote subject belongs to a different study
@@ -201,7 +270,14 @@ class Cache {
       }
 
       // Check cached subject
-      if (await SecureStorage.containsKey('cache_subject')) {
+      final storedValues = await SecureStorage.readAll();
+      final cacheKeys = storedValues.keys
+          .where(
+            (key) =>
+                key == cacheSubjectKey || key.startsWith(_scopedCachePrefix),
+          )
+          .toList();
+      if (cacheKeys.isNotEmpty) {
         debugInfo.writeln('Cache Subject: EXISTS (data present)');
         try {
           final cachedSubject = await loadSubject();

--- a/app/lib/util/cache.dart
+++ b/app/lib/util/cache.dart
@@ -11,9 +11,21 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 class Cache {
   static bool isSynchronizing = false;
   static const _scopedCachePrefix = '${cacheSubjectKey}_';
+  static Future<bool> Function(String) _containsKey = SecureStorage.containsKey;
+  static Future<String?> Function(String) _readValue = SecureStorage.read;
+  static Future<void> Function(String, String) _writeValue =
+      SecureStorage.write;
+  static Future<void> Function(String) _deleteValue = SecureStorage.delete;
+  static Future<Map<String, String>> Function() _readAllValues =
+      SecureStorage.readAll;
+  static String? Function() _currentUserIdGetter = _defaultCurrentUserId;
+  static Future<String?> Function() _activeSubjectIdGetter = getActiveSubjectId;
 
   static String _scopedCacheKey(String userId, String subjectId) =>
       '$_scopedCachePrefix${userId}_$subjectId';
+
+  static String? _defaultCurrentUserId() =>
+      Supabase.instance.client.auth.currentUser?.id;
 
   static Future<String?> _preferredCacheKey({
     StudySubject? subject,
@@ -24,10 +36,55 @@ class Cache {
       return _scopedCacheKey(targetSubject.userId, targetSubject.id);
     }
 
-    final currentUserId = Supabase.instance.client.auth.currentUser?.id;
-    final activeSubjectId = await getActiveSubjectId();
+    final currentUserId = _currentUserIdGetter();
+    final activeSubjectId = await _activeSubjectIdGetter();
     if (currentUserId == null || activeSubjectId == null) return null;
     return _scopedCacheKey(currentUserId, activeSubjectId);
+  }
+
+  static ({String userId, String subjectId})? _expectedCacheIdentity({
+    StudySubject? subject,
+    StudySubject? backupSubject,
+    String? currentUserId,
+    String? activeSubjectId,
+  }) {
+    final targetSubject = subject ?? backupSubject;
+    if (targetSubject != null) {
+      return (userId: targetSubject.userId, subjectId: targetSubject.id);
+    }
+    if (currentUserId != null && activeSubjectId != null) {
+      return (userId: currentUserId, subjectId: activeSubjectId);
+    }
+    return null;
+  }
+
+  static ({String? userId, String? subjectId}) _extractCachedIdentity(
+    Map<String, dynamic> cachedSubject,
+  ) => (
+    userId: cachedSubject['user_id'] as String?,
+    subjectId: cachedSubject['id'] as String?,
+  );
+
+  static void _validateCachedSubjectIdentity(
+    Map<String, dynamic> cachedSubject, {
+    StudySubject? backupSubject,
+  }) {
+    final identity = _extractCachedIdentity(cachedSubject);
+    final currentUserId = _currentUserIdGetter();
+
+    if (backupSubject != null) {
+      if (identity.userId != backupSubject.userId ||
+          identity.subjectId != backupSubject.id) {
+        throw Exception('Cached subject does not match remote subject');
+      }
+      return;
+    }
+
+    if (currentUserId != null &&
+        identity.userId != null &&
+        identity.userId != currentUserId) {
+      throw Exception('Cached subject belongs to a different user');
+    }
   }
 
   static Future<String?> _readCachedSubjectString({
@@ -38,13 +95,50 @@ class Cache {
       subject: subject,
       backupSubject: backupSubject,
     );
-    if (scopedKey != null && await SecureStorage.containsKey(scopedKey)) {
-      return await SecureStorage.read(scopedKey);
+    if (scopedKey != null && await _containsKey(scopedKey)) {
+      return await _readValue(scopedKey);
     }
-    if (await SecureStorage.containsKey(cacheSubjectKey)) {
-      return await SecureStorage.read(cacheSubjectKey);
+
+    if (!await _containsKey(cacheSubjectKey)) {
+      return null;
     }
-    return null;
+
+    final legacyCache = await _readValue(cacheSubjectKey);
+    if (legacyCache == null) return null;
+
+    try {
+      final cachedSubject = jsonDecode(legacyCache) as Map<String, dynamic>;
+      final expectedIdentity = _expectedCacheIdentity(
+        subject: subject,
+        backupSubject: backupSubject,
+        currentUserId: _currentUserIdGetter(),
+        activeSubjectId: await _activeSubjectIdGetter(),
+      );
+
+      if (expectedIdentity != null) {
+        final actualIdentity = _extractCachedIdentity(cachedSubject);
+        final matchesExpected =
+            actualIdentity.userId == expectedIdentity.userId &&
+            actualIdentity.subjectId == expectedIdentity.subjectId;
+        if (!matchesExpected) {
+          await _deleteValue(cacheSubjectKey);
+          return null;
+        }
+
+        final migratedKey = _scopedCacheKey(
+          expectedIdentity.userId,
+          expectedIdentity.subjectId,
+        );
+        await _writeValue(migratedKey, legacyCache);
+        await _deleteValue(cacheSubjectKey);
+      }
+
+      return legacyCache;
+    } catch (e) {
+      StudyULogger.warning("Failed to parse legacy cached subject: $e");
+      await _deleteValue(cacheSubjectKey);
+      return null;
+    }
   }
 
   static Future<StudySubject> _decodeCachedSubject(
@@ -52,28 +146,13 @@ class Cache {
     StudySubject? backupSubject,
   }) async {
     final cachedSubject = jsonDecode(cachedSubjectStr) as Map<String, dynamic>;
-    final cachedUserId = cachedSubject['user_id'] as String?;
-    final currentUserId = Supabase.instance.client.auth.currentUser?.id;
-
-    if (currentUserId != null &&
-        cachedUserId != null &&
-        cachedUserId != currentUserId) {
-      throw Exception('Cached subject belongs to a different user');
-    }
+    _validateCachedSubjectIdentity(cachedSubject, backupSubject: backupSubject);
 
     try {
       return StudySubject.fromJson(cachedSubject);
     } catch (e) {
       StudyULogger.warning("Failed to parse cached subject: $cachedSubjectStr");
       if (backupSubject != null) {
-        if (backupSubject.id != cachedSubject['id']) {
-          throw Exception("Cached subject ID does not match remote subject ID");
-        }
-        if (backupSubject.userId != cachedSubject['user_id']) {
-          throw Exception(
-            "Cached subject user does not match remote subject user",
-          );
-        }
         final cachedProgress = (cachedSubject['progress'] as List?)
             ?.map((e) => SubjectProgress.fromJson(e as Map<String, dynamic>))
             .toList();
@@ -88,9 +167,9 @@ class Cache {
     // debugPrint("Store subject in cache");
     if (subject == null) return;
     final scopedKey = _scopedCacheKey(subject.userId, subject.id);
-    await SecureStorage.write(scopedKey, jsonEncode(subject.toFullJson()));
-    if (await SecureStorage.containsKey(cacheSubjectKey)) {
-      await SecureStorage.delete(cacheSubjectKey);
+    await _writeValue(scopedKey, jsonEncode(subject.toFullJson()));
+    if (await _containsKey(cacheSubjectKey)) {
+      await _deleteValue(cacheSubjectKey);
     }
     assert(subject == (await loadSubject()));
   }
@@ -116,8 +195,8 @@ class Cache {
 
   static Future<StudyUAnalytics?> loadAnalytics() async {
     try {
-      if (await SecureStorage.containsKey(StudyUAnalytics.keyStudyUAnalytics)) {
-        final analyticsData = await SecureStorage.read(
+      if (await _containsKey(StudyUAnalytics.keyStudyUAnalytics)) {
+        final analyticsData = await _readValue(
           StudyUAnalytics.keyStudyUAnalytics,
         );
         if (analyticsData != null) {
@@ -138,10 +217,10 @@ class Cache {
   }
 
   static Future<void> clearAllSubjectCaches() async {
-    final storedValues = await SecureStorage.readAll();
+    final storedValues = await _readAllValues();
     for (final key in storedValues.keys) {
       if (key == cacheSubjectKey || key.startsWith(_scopedCachePrefix)) {
-        await SecureStorage.delete(key);
+        await _deleteValue(key);
       }
     }
   }
@@ -252,10 +331,8 @@ class Cache {
 
     try {
       // Check selected subject ID
-      if (await SecureStorage.containsKey('selected_study_object_id')) {
-        final selectedSubjectId = await SecureStorage.read(
-          'selected_study_object_id',
-        );
+      if (await _containsKey('selected_study_object_id')) {
+        final selectedSubjectId = await _readValue('selected_study_object_id');
         debugInfo.writeln('Selected Subject ID: $selectedSubjectId');
       } else {
         debugInfo.writeln('Selected Subject ID: NOT FOUND');
@@ -305,5 +382,85 @@ class Cache {
     }
 
     return debugInfo.toString();
+  }
+
+  @visibleForTesting
+  static Future<bool> Function(String) get debugContainsKeyForTesting =>
+      _containsKey;
+
+  @visibleForTesting
+  static set debugContainsKeyForTesting(Future<bool> Function(String) value) {
+    _containsKey = value;
+  }
+
+  @visibleForTesting
+  static Future<String?> Function(String) get debugReadValueForTesting =>
+      _readValue;
+
+  @visibleForTesting
+  static set debugReadValueForTesting(Future<String?> Function(String) value) {
+    _readValue = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String, String) get debugWriteValueForTesting =>
+      _writeValue;
+
+  @visibleForTesting
+  static set debugWriteValueForTesting(
+    Future<void> Function(String, String) value,
+  ) {
+    _writeValue = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String) get debugDeleteValueForTesting =>
+      _deleteValue;
+
+  @visibleForTesting
+  static set debugDeleteValueForTesting(Future<void> Function(String) value) {
+    _deleteValue = value;
+  }
+
+  @visibleForTesting
+  static Future<Map<String, String>> Function()
+  get debugReadAllValuesForTesting => _readAllValues;
+
+  @visibleForTesting
+  static set debugReadAllValuesForTesting(
+    Future<Map<String, String>> Function() value,
+  ) {
+    _readAllValues = value;
+  }
+
+  @visibleForTesting
+  static String? Function() get debugCurrentUserIdGetterForTesting =>
+      _currentUserIdGetter;
+
+  @visibleForTesting
+  static set debugCurrentUserIdGetterForTesting(String? Function() value) {
+    _currentUserIdGetter = value;
+  }
+
+  @visibleForTesting
+  static Future<String?> Function() get debugActiveSubjectIdGetterForTesting =>
+      _activeSubjectIdGetter;
+
+  @visibleForTesting
+  static set debugActiveSubjectIdGetterForTesting(
+    Future<String?> Function() value,
+  ) {
+    _activeSubjectIdGetter = value;
+  }
+
+  @visibleForTesting
+  static void debugResetTestingOverrides() {
+    _containsKey = SecureStorage.containsKey;
+    _readValue = SecureStorage.read;
+    _writeValue = SecureStorage.write;
+    _deleteValue = SecureStorage.delete;
+    _readAllValues = SecureStorage.readAll;
+    _currentUserIdGetter = _defaultCurrentUserId;
+    _activeSubjectIdGetter = getActiveSubjectId;
   }
 }

--- a/app/lib/util/cache.dart
+++ b/app/lib/util/cache.dart
@@ -228,6 +228,24 @@ class Cache {
     }
   }
 
+  static Future<void> clearRecoverySubjectCaches({
+    required String? recoveredUserId,
+    required String? recoveredSubjectId,
+  }) async {
+    final storedValues = await _readAllValues();
+    final preservedKey = recoveredUserId != null && recoveredSubjectId != null
+        ? _scopedCacheKey(recoveredUserId, recoveredSubjectId)
+        : null;
+
+    for (final key in storedValues.keys) {
+      final isSubjectCacheKey =
+          key == cacheSubjectKey || key.startsWith(_scopedCachePrefix);
+      if (!isSubjectCacheKey) continue;
+      if (preservedKey != null && key == preservedKey) continue;
+      await _deleteValue(key);
+    }
+  }
+
   static Future<void> uploadBlobFiles() async {
     final blobStorageHandler = BlobStorageHandler();
     final futureBlobFiles = await TemporaryStorageHandler.getFutureBlobFiles();

--- a/app/lib/util/cache.dart
+++ b/app/lib/util/cache.dart
@@ -106,39 +106,42 @@ class Cache {
     final legacyCache = await _readValue(cacheSubjectKey);
     if (legacyCache == null) return null;
 
+    late final Map<String, dynamic> cachedSubject;
     try {
-      final cachedSubject = jsonDecode(legacyCache) as Map<String, dynamic>;
-      final expectedIdentity = _expectedCacheIdentity(
-        subject: subject,
-        backupSubject: backupSubject,
-        currentUserId: _currentUserIdGetter(),
-        activeSubjectId: await _activeSubjectIdGetter(),
-      );
-
-      if (expectedIdentity != null) {
-        final actualIdentity = _extractCachedIdentity(cachedSubject);
-        final matchesExpected =
-            actualIdentity.userId == expectedIdentity.userId &&
-            actualIdentity.subjectId == expectedIdentity.subjectId;
-        if (!matchesExpected) {
-          await _deleteValue(cacheSubjectKey);
-          return null;
-        }
-
-        final migratedKey = _scopedCacheKey(
-          expectedIdentity.userId,
-          expectedIdentity.subjectId,
-        );
-        await _writeValue(migratedKey, legacyCache);
-        await _deleteValue(cacheSubjectKey);
-      }
-
-      return legacyCache;
+      cachedSubject = jsonDecode(legacyCache) as Map<String, dynamic>;
     } catch (e) {
-      StudyULogger.warning("Failed to parse legacy cached subject: $e");
+      StudyULogger.warning('Failed to parse legacy cached subject JSON: $e');
       await _deleteValue(cacheSubjectKey);
       return null;
     }
+
+    final expectedIdentity = _expectedCacheIdentity(
+      subject: subject,
+      backupSubject: backupSubject,
+      currentUserId: _currentUserIdGetter(),
+      activeSubjectId: await _activeSubjectIdGetter(),
+    );
+
+    if (expectedIdentity == null) {
+      return legacyCache;
+    }
+
+    final actualIdentity = _extractCachedIdentity(cachedSubject);
+    final matchesExpected =
+        actualIdentity.userId == expectedIdentity.userId &&
+        actualIdentity.subjectId == expectedIdentity.subjectId;
+    if (!matchesExpected) {
+      await _deleteValue(cacheSubjectKey);
+      return null;
+    }
+
+    final migratedKey = _scopedCacheKey(
+      expectedIdentity.userId,
+      expectedIdentity.subjectId,
+    );
+    await _writeValue(migratedKey, legacyCache);
+    await _deleteValue(cacheSubjectKey);
+    return legacyCache;
   }
 
   static Future<StudySubject> _decodeCachedSubject(
@@ -171,7 +174,7 @@ class Cache {
     if (await _containsKey(cacheSubjectKey)) {
       await _deleteValue(cacheSubjectKey);
     }
-    assert(subject == (await loadSubject()));
+    assert(subject == (await loadSubject(backupSubject: subject)));
   }
 
   static Future<StudySubject> loadSubject({StudySubject? backupSubject}) async {

--- a/app/lib/util/fitbit_handler.dart
+++ b/app/lib/util/fitbit_handler.dart
@@ -1,381 +1,29 @@
-import 'dart:convert';
-
 import 'package:fitbitter/fitbitter.dart' as fitbitter;
-import 'package:flutter/foundation.dart';
 import 'package:studyu_app/constants.dart';
+import 'package:studyu_app/services/participant_fitbit_credentials_service.dart';
 import 'package:studyu_core/core.dart';
-import 'package:studyu_flutter_common/studyu_flutter_common.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
-
-class FitbitCredentialStorageException implements Exception {
-  final bool localOperationFailed;
-  final bool serverOperationFailed;
-
-  const FitbitCredentialStorageException({
-    required this.localOperationFailed,
-    required this.serverOperationFailed,
-  });
-
-  @override
-  String toString() =>
-      'FitbitCredentialStorageException(localOperationFailed: $localOperationFailed, serverOperationFailed: $serverOperationFailed)';
-}
-
-class FitbitCredentialDeletionException implements Exception {
-  final bool remoteDeletionFailed;
-  final bool localDeletionFailed;
-
-  const FitbitCredentialDeletionException({
-    required this.remoteDeletionFailed,
-    required this.localDeletionFailed,
-  });
-
-  @override
-  String toString() =>
-      'FitbitCredentialDeletionException(remoteDeletionFailed: $remoteDeletionFailed, localDeletionFailed: $localDeletionFailed)';
-}
 
 class FitbitHandler {
-  static const String _fitbitCredentialsPrefix = 'fitbit_credentials_';
-  static const String _participantFitbitTable =
-      'participant_fitbit_credentials';
-  static String? Function() _currentUserIdGetter = _defaultCurrentUserId;
-  static Future<String?> Function(String) _readLocalValue = SecureStorage.read;
-  static Future<void> Function(String, String) _writeLocalValue =
-      SecureStorage.write;
-  static Future<void> Function(String) _deleteLocalValue = SecureStorage.delete;
-  static Future<bool> Function(String) _containsLocalKey =
-      SecureStorage.containsKey;
-  static Future<Map<String, String>> Function() _readAllLocalValues =
-      SecureStorage.readAll;
-  static Future<fitbitter.FitbitCredentials?> Function({
-    required String userId,
-    required String studyKey,
-  })
-  _serverCredentialsLoader = _loadCredentialsFromServer;
-  static Future<void> Function({
-    required String userId,
-    required String studyKey,
-    required Map<String, dynamic> credentialsJson,
-  })
-  _serverCredentialsUpserter = _upsertCredentialsOnServer;
-  static Future<void> Function({
-    required String userId,
-    required String studyKey,
-  })
-  _serverCredentialsDeleter = _deleteCredentialsFromServer;
-
-  static String _legacyLocalKey(String studyKey) =>
-      '$_fitbitCredentialsPrefix$studyKey';
-
-  static String _scopedLocalKey(String userId, String studyKey) =>
-      '$_fitbitCredentialsPrefix${userId}_$studyKey';
-
-  static String? _defaultCurrentUserId() =>
-      Supabase.instance.client.auth.currentUser?.id;
-
-  @visibleForTesting
-  static bool shouldDiscardLegacyCredentialsForAuthenticatedUser(
-    String? userId,
-  ) => userId != null;
-
-  static Map<String, dynamic> _credentialsToJson(
-    fitbitter.FitbitCredentials credentials,
-  ) {
-    return {
-      'userID': credentials.userID,
-      'fitbitAccessToken': credentials.fitbitAccessToken,
-      'fitbitRefreshToken': credentials.fitbitRefreshToken,
-    };
-  }
-
-  static fitbitter.FitbitCredentials _credentialsFromJson(
-    Map<String, dynamic> jsonData,
-  ) {
-    return fitbitter.FitbitCredentials(
-      userID: jsonData['userID'] as String,
-      fitbitAccessToken: jsonData['fitbitAccessToken'] as String,
-      fitbitRefreshToken: jsonData['fitbitRefreshToken'] as String,
-    );
-  }
-
   static Future<void> deleteFitbitCredentials(String studyKey) async {
-    var remoteDeletionFailed = false;
-    var localDeletionFailed = false;
-    try {
-      await deleteRemoteFitbitCredentials(studyKey);
-    } on FitbitCredentialDeletionException catch (e) {
-      remoteDeletionFailed = e.remoteDeletionFailed;
-      localDeletionFailed = e.localDeletionFailed;
-    }
-
-    try {
-      await clearLocalFallbackCredentialsForStudy(studyKey);
-    } on FitbitCredentialDeletionException catch (e) {
-      remoteDeletionFailed = remoteDeletionFailed || e.remoteDeletionFailed;
-      localDeletionFailed = localDeletionFailed || e.localDeletionFailed;
-    }
-
-    if (remoteDeletionFailed || localDeletionFailed) {
-      throw FitbitCredentialDeletionException(
-        remoteDeletionFailed: remoteDeletionFailed,
-        localDeletionFailed: localDeletionFailed,
-      );
-    }
+    await ParticipantFitbitCredentialsService.deleteFitbitCredentials(studyKey);
   }
 
   static Future<void> deleteRemoteFitbitCredentials(String studyKey) async {
-    final userId = _currentUserIdGetter();
-    if (userId != null) {
-      try {
-        await _serverCredentialsDeleter(userId: userId, studyKey: studyKey);
-      } catch (e) {
-        StudyULogger.error(
-          'Failed to delete participant Fitbit credentials from server: $e',
-        );
-        throw const FitbitCredentialDeletionException(
-          remoteDeletionFailed: true,
-          localDeletionFailed: false,
-        );
-      }
-    }
+    await ParticipantFitbitCredentialsService.deleteRemoteFitbitCredentials(
+      studyKey,
+    );
   }
 
   static Future<void> clearLocalFallbackCredentialsForStudy(
     String studyKey,
   ) async {
-    try {
-      await _deleteLocalCredentials(studyKey, userId: _currentUserIdGetter());
-    } catch (e) {
-      StudyULogger.error(
-        'Failed to delete participant Fitbit credentials locally: $e',
-      );
-      throw const FitbitCredentialDeletionException(
-        remoteDeletionFailed: false,
-        localDeletionFailed: true,
-      );
-    }
-  }
-
-  static Future<void> _storeCredentials(
-    fitbitter.FitbitCredentials? credentials,
-    String studyKey,
-  ) async {
-    final userId = _currentUserIdGetter();
-
-    if (credentials == null) {
-      if (userId != null) {
-        try {
-          await _serverCredentialsDeleter(userId: userId, studyKey: studyKey);
-        } catch (e) {
-          StudyULogger.error(
-            'Failed to delete participant Fitbit credentials from server: $e',
-          );
-        }
-      }
-      await _deleteLocalCredentials(studyKey, userId: userId);
-      return;
-    }
-
-    final credentialsJson = _credentialsToJson(credentials);
-    if (userId != null) {
-      var localOperationFailed = false;
-      var serverOperationFailed = false;
-
-      try {
-        await _writeLocalValue(
-          _scopedLocalKey(userId, studyKey),
-          jsonEncode(credentialsJson),
-        );
-      } catch (e) {
-        localOperationFailed = true;
-        StudyULogger.error(
-          'Failed to store participant Fitbit credentials locally: $e',
-        );
-      }
-
-      try {
-        if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
-          await _deleteLocalValue(_legacyLocalKey(studyKey));
-        }
-      } catch (e) {
-        StudyULogger.warning(
-          'Failed to delete legacy Fitbit credentials locally: $e',
-        );
-      }
-
-      try {
-        await _serverCredentialsUpserter(
-          userId: userId,
-          studyKey: studyKey,
-          credentialsJson: credentialsJson,
-        );
-      } catch (e) {
-        serverOperationFailed = true;
-        StudyULogger.error(
-          'Failed to store participant Fitbit credentials on server: $e',
-        );
-      }
-
-      if (localOperationFailed && serverOperationFailed) {
-        throw const FitbitCredentialStorageException(
-          localOperationFailed: true,
-          serverOperationFailed: true,
-        );
-      }
-      return;
-    }
-
-    await _writeLocalValue(
-      _legacyLocalKey(studyKey),
-      jsonEncode(credentialsJson),
+    await ParticipantFitbitCredentialsService.clearLocalFallbackCredentialsForStudy(
+      studyKey,
     );
   }
 
-  static Future<fitbitter.FitbitCredentials?> _loadCredentials(
-    String studyKey,
-  ) async {
-    final userId = _currentUserIdGetter();
-
-    if (userId != null) {
-      try {
-        final serverCredentials = await _serverCredentialsLoader(
-          userId: userId,
-          studyKey: studyKey,
-        );
-        if (serverCredentials != null) {
-          try {
-            await _writeLocalValue(
-              _scopedLocalKey(userId, studyKey),
-              jsonEncode(_credentialsToJson(serverCredentials)),
-            );
-          } catch (e) {
-            StudyULogger.warning(
-              'Failed to cache participant Fitbit credentials locally: $e',
-            );
-          }
-          try {
-            if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
-              await _deleteLocalValue(_legacyLocalKey(studyKey));
-            }
-          } catch (e) {
-            StudyULogger.warning(
-              'Failed to delete legacy Fitbit credentials locally: $e',
-            );
-          }
-          return serverCredentials;
-        }
-      } catch (e) {
-        StudyULogger.error(
-          'Failed to load participant Fitbit credentials from server: $e',
-        );
-      }
-
-      String? scopedString;
-      try {
-        scopedString = await _readLocalValue(_scopedLocalKey(userId, studyKey));
-      } catch (e) {
-        StudyULogger.error(
-          'Failed to load participant Fitbit credentials locally: $e',
-        );
-      }
-      try {
-        if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
-          await _deleteLocalValue(_legacyLocalKey(studyKey));
-          StudyULogger.warning(
-            'Discarded legacy Fitbit credentials for $studyKey after authenticated load because ownership cannot be verified.',
-          );
-        }
-      } catch (e) {
-        StudyULogger.warning(
-          'Failed to delete legacy Fitbit credentials locally: $e',
-        );
-      }
-      if (scopedString != null) {
-        final jsonData = jsonDecode(scopedString) as Map<String, dynamic>;
-        return _credentialsFromJson(jsonData);
-      }
-      return null;
-    }
-
-    try {
-      final legacyString = await _readLocalValue(_legacyLocalKey(studyKey));
-      if (legacyString != null) {
-        final jsonData = jsonDecode(legacyString) as Map<String, dynamic>;
-        return _credentialsFromJson(jsonData);
-      }
-    } catch (e) {
-      StudyULogger.error('Failed to load Fitbit credentials: $e');
-    }
-
-    return null;
-  }
-
-  static Future<fitbitter.FitbitCredentials?> _loadCredentialsFromServer({
-    required String userId,
-    required String studyKey,
-  }) async {
-    final response = await Supabase.instance.client
-        .from(_participantFitbitTable)
-        .select('fitbit_credentials')
-        .eq('user_id', userId)
-        .eq('study_id', studyKey)
-        .maybeSingle();
-
-    if (response == null) return null;
-
-    final jsonData = response['fitbit_credentials'] as Map<String, dynamic>?;
-    if (jsonData == null) return null;
-    return _credentialsFromJson(jsonData);
-  }
-
-  static Future<void> _upsertCredentialsOnServer({
-    required String userId,
-    required String studyKey,
-    required Map<String, dynamic> credentialsJson,
-  }) async {
-    await Supabase.instance.client.from(_participantFitbitTable).upsert({
-      'user_id': userId,
-      'study_id': studyKey,
-      'fitbit_credentials': credentialsJson,
-    });
-  }
-
-  static Future<void> _deleteCredentialsFromServer({
-    required String userId,
-    required String studyKey,
-  }) async {
-    await Supabase.instance.client
-        .from(_participantFitbitTable)
-        .delete()
-        .eq('user_id', userId)
-        .eq('study_id', studyKey);
-  }
-
-  static Future<void> _deleteLocalCredentials(
-    String studyKey, {
-    String? userId,
-  }) async {
-    final keysToDelete = <String>{_legacyLocalKey(studyKey)};
-    final effectiveUserId = userId ?? _currentUserIdGetter();
-    if (effectiveUserId != null) {
-      keysToDelete.add(_scopedLocalKey(effectiveUserId, studyKey));
-    }
-
-    for (final key in keysToDelete) {
-      if (await _containsLocalKey(key)) {
-        await _deleteLocalValue(key);
-      }
-    }
-  }
-
   static Future<void> clearLocalFallbackCredentials() async {
-    final storedValues = await _readAllLocalValues();
-    for (final key in storedValues.keys) {
-      if (key.startsWith(_fitbitCredentialsPrefix)) {
-        await _deleteLocalValue(key);
-      }
-    }
+    await ParticipantFitbitCredentialsService.clearLocalFallbackCredentials();
   }
 
   static Future<fitbitter.FitbitCredentials?> _validateToken(
@@ -396,7 +44,10 @@ class FitbitHandler {
         clientSecret: studyCredentials.clientSecret,
       );
 
-      await _storeCredentials(newCredentials, study.id);
+      await ParticipantFitbitCredentialsService.storeCredentials(
+        newCredentials,
+        study.id,
+      );
 
       return newCredentials;
     } catch (e) {
@@ -416,7 +67,8 @@ class FitbitHandler {
       return null;
     }
 
-    final storedCredentials = await _loadCredentials(study.id);
+    final storedCredentials =
+        await ParticipantFitbitCredentialsService.loadCredentials(study.id);
 
     if (storedCredentials != null) {
       final validCredentials = await _validateToken(
@@ -450,7 +102,10 @@ class FitbitHandler {
       );
 
       if (newCredentials != null) {
-        await _storeCredentials(newCredentials, study.id);
+        await ParticipantFitbitCredentialsService.storeCredentials(
+          newCredentials,
+          study.id,
+        );
         return newCredentials;
       }
     } catch (e) {
@@ -753,146 +408,5 @@ class FitbitHandler {
       subject,
       question,
     );
-  }
-
-  @visibleForTesting
-  static Future<void> debugStoreCredentialsForTesting(
-    fitbitter.FitbitCredentials? credentials,
-    String studyKey,
-  ) => _storeCredentials(credentials, studyKey);
-
-  @visibleForTesting
-  static Future<fitbitter.FitbitCredentials?> debugLoadCredentialsForTesting(
-    String studyKey,
-  ) => _loadCredentials(studyKey);
-
-  @visibleForTesting
-  static String? Function() get debugCurrentUserIdGetterForTesting =>
-      _currentUserIdGetter;
-
-  @visibleForTesting
-  static set debugCurrentUserIdGetterForTesting(String? Function() value) {
-    _currentUserIdGetter = value;
-  }
-
-  @visibleForTesting
-  static Future<String?> Function(String) get debugReadLocalValueForTesting =>
-      _readLocalValue;
-
-  @visibleForTesting
-  static set debugReadLocalValueForTesting(
-    Future<String?> Function(String) value,
-  ) {
-    _readLocalValue = value;
-  }
-
-  @visibleForTesting
-  static Future<void> Function(String, String)
-  get debugWriteLocalValueForTesting => _writeLocalValue;
-
-  @visibleForTesting
-  static set debugWriteLocalValueForTesting(
-    Future<void> Function(String, String) value,
-  ) {
-    _writeLocalValue = value;
-  }
-
-  @visibleForTesting
-  static Future<void> Function(String) get debugDeleteLocalValueForTesting =>
-      _deleteLocalValue;
-
-  @visibleForTesting
-  static set debugDeleteLocalValueForTesting(
-    Future<void> Function(String) value,
-  ) {
-    _deleteLocalValue = value;
-  }
-
-  @visibleForTesting
-  static Future<bool> Function(String) get debugContainsLocalKeyForTesting =>
-      _containsLocalKey;
-
-  @visibleForTesting
-  static set debugContainsLocalKeyForTesting(
-    Future<bool> Function(String) value,
-  ) {
-    _containsLocalKey = value;
-  }
-
-  @visibleForTesting
-  static Future<Map<String, String>> Function()
-  get debugReadAllLocalValuesForTesting => _readAllLocalValues;
-
-  @visibleForTesting
-  static set debugReadAllLocalValuesForTesting(
-    Future<Map<String, String>> Function() value,
-  ) {
-    _readAllLocalValues = value;
-  }
-
-  @visibleForTesting
-  static Future<fitbitter.FitbitCredentials?> Function({
-    required String userId,
-    required String studyKey,
-  })
-  get debugServerCredentialsLoaderForTesting => _serverCredentialsLoader;
-
-  @visibleForTesting
-  static set debugServerCredentialsLoaderForTesting(
-    Future<fitbitter.FitbitCredentials?> Function({
-      required String userId,
-      required String studyKey,
-    })
-    value,
-  ) {
-    _serverCredentialsLoader = value;
-  }
-
-  @visibleForTesting
-  static Future<void> Function({
-    required String userId,
-    required String studyKey,
-    required Map<String, dynamic> credentialsJson,
-  })
-  get debugServerCredentialsUpserterForTesting => _serverCredentialsUpserter;
-
-  @visibleForTesting
-  static set debugServerCredentialsUpserterForTesting(
-    Future<void> Function({
-      required String userId,
-      required String studyKey,
-      required Map<String, dynamic> credentialsJson,
-    })
-    value,
-  ) {
-    _serverCredentialsUpserter = value;
-  }
-
-  @visibleForTesting
-  static Future<void> Function({
-    required String userId,
-    required String studyKey,
-  })
-  get debugServerCredentialsDeleterForTesting => _serverCredentialsDeleter;
-
-  @visibleForTesting
-  static set debugServerCredentialsDeleterForTesting(
-    Future<void> Function({required String userId, required String studyKey})
-    value,
-  ) {
-    _serverCredentialsDeleter = value;
-  }
-
-  @visibleForTesting
-  static void debugResetTestingOverrides() {
-    _currentUserIdGetter = _defaultCurrentUserId;
-    _readLocalValue = SecureStorage.read;
-    _writeLocalValue = SecureStorage.write;
-    _deleteLocalValue = SecureStorage.delete;
-    _containsLocalKey = SecureStorage.containsKey;
-    _readAllLocalValues = SecureStorage.readAll;
-    _serverCredentialsLoader = _loadCredentialsFromServer;
-    _serverCredentialsUpserter = _upsertCredentialsOnServer;
-    _serverCredentialsDeleter = _deleteCredentialsFromServer;
   }
 }

--- a/app/lib/util/fitbit_handler.dart
+++ b/app/lib/util/fitbit_handler.dart
@@ -1,12 +1,30 @@
 import 'dart:convert';
 
 import 'package:fitbitter/fitbitter.dart' as fitbitter;
+import 'package:flutter/foundation.dart';
 import 'package:studyu_app/constants.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class FitbitHandler {
   static const String _fitbitCredentialsPrefix = 'fitbit_credentials_';
+  static const String _participantFitbitTable =
+      'participant_fitbit_credentials';
+
+  static String _legacyLocalKey(String studyKey) =>
+      '$_fitbitCredentialsPrefix$studyKey';
+
+  static String _scopedLocalKey(String userId, String studyKey) =>
+      '$_fitbitCredentialsPrefix${userId}_$studyKey';
+
+  static String? _currentUserId() =>
+      Supabase.instance.client.auth.currentUser?.id;
+
+  @visibleForTesting
+  static bool shouldDiscardLegacyCredentialsForAuthenticatedUser(
+    String? userId,
+  ) => userId != null;
 
   static Map<String, dynamic> _credentialsToJson(
     fitbitter.FitbitCredentials credentials,
@@ -29,25 +47,58 @@ class FitbitHandler {
   }
 
   static Future<void> deleteFitbitCredentials(String studyKey) async {
-    if (await SecureStorage.containsKey('$_fitbitCredentialsPrefix$studyKey')) {
-      await SecureStorage.delete('$_fitbitCredentialsPrefix$studyKey');
+    final userId = _currentUserId();
+    try {
+      if (userId != null) {
+        await Supabase.instance.client
+            .from(_participantFitbitTable)
+            .delete()
+            .eq('user_id', userId)
+            .eq('study_id', studyKey);
+      }
+    } catch (e) {
+      StudyULogger.error('Failed to delete participant Fitbit credentials: $e');
     }
+    await _deleteLocalCredentials(studyKey, userId: userId);
   }
 
   static Future<void> _storeCredentials(
     fitbitter.FitbitCredentials? credentials,
     String studyKey,
   ) async {
-    final key = '$_fitbitCredentialsPrefix$studyKey';
+    final userId = _currentUserId();
 
     try {
       if (credentials == null) {
-        await SecureStorage.delete(key);
+        if (userId != null) {
+          await Supabase.instance.client
+              .from(_participantFitbitTable)
+              .delete()
+              .eq('user_id', userId)
+              .eq('study_id', studyKey);
+        }
+        await _deleteLocalCredentials(studyKey, userId: userId);
       } else {
-        await SecureStorage.write(
-          key,
-          jsonEncode(_credentialsToJson(credentials)),
-        );
+        final credentialsJson = _credentialsToJson(credentials);
+        if (userId != null) {
+          await Supabase.instance.client.from(_participantFitbitTable).upsert({
+            'user_id': userId,
+            'study_id': studyKey,
+            'fitbit_credentials': credentialsJson,
+          });
+          await SecureStorage.write(
+            _scopedLocalKey(userId, studyKey),
+            jsonEncode(credentialsJson),
+          );
+          if (await SecureStorage.containsKey(_legacyLocalKey(studyKey))) {
+            await SecureStorage.delete(_legacyLocalKey(studyKey));
+          }
+        } else {
+          await SecureStorage.write(
+            _legacyLocalKey(studyKey),
+            jsonEncode(credentialsJson),
+          );
+        }
       }
     } catch (e) {
       StudyULogger.error('Failed to store Fitbit credentials: $e');
@@ -57,21 +108,96 @@ class FitbitHandler {
   static Future<fitbitter.FitbitCredentials?> _loadCredentials(
     String studyKey,
   ) async {
-    final key = '$_fitbitCredentialsPrefix$studyKey';
+    final userId = _currentUserId();
 
     try {
-      if (await SecureStorage.containsKey(key)) {
-        final storedString = await SecureStorage.read(key);
-        if (storedString != null) {
-          final jsonData = jsonDecode(storedString) as Map<String, dynamic>;
+      if (userId != null) {
+        final serverCredentials = await _loadCredentialsFromServer(
+          userId: userId,
+          studyKey: studyKey,
+        );
+        if (serverCredentials != null) {
+          await SecureStorage.write(
+            _scopedLocalKey(userId, studyKey),
+            jsonEncode(_credentialsToJson(serverCredentials)),
+          );
+          if (await SecureStorage.containsKey(_legacyLocalKey(studyKey))) {
+            await SecureStorage.delete(_legacyLocalKey(studyKey));
+          }
+          return serverCredentials;
+        }
+
+        final scopedString = await SecureStorage.read(
+          _scopedLocalKey(userId, studyKey),
+        );
+        if (scopedString != null) {
+          final jsonData = jsonDecode(scopedString) as Map<String, dynamic>;
           return _credentialsFromJson(jsonData);
         }
+      }
+
+      final legacyString = await SecureStorage.read(_legacyLocalKey(studyKey));
+      if (legacyString != null) {
+        if (shouldDiscardLegacyCredentialsForAuthenticatedUser(userId)) {
+          await SecureStorage.delete(_legacyLocalKey(studyKey));
+          StudyULogger.warning(
+            'Discarded legacy Fitbit credentials for $studyKey after authenticated load because ownership cannot be verified.',
+          );
+          return null;
+        }
+
+        final jsonData = jsonDecode(legacyString) as Map<String, dynamic>;
+        return _credentialsFromJson(jsonData);
       }
     } catch (e) {
       StudyULogger.error('Failed to load Fitbit credentials: $e');
     }
 
     return null;
+  }
+
+  static Future<fitbitter.FitbitCredentials?> _loadCredentialsFromServer({
+    required String userId,
+    required String studyKey,
+  }) async {
+    final response = await Supabase.instance.client
+        .from(_participantFitbitTable)
+        .select('fitbit_credentials')
+        .eq('user_id', userId)
+        .eq('study_id', studyKey)
+        .maybeSingle();
+
+    if (response == null) return null;
+
+    final jsonData = response['fitbit_credentials'] as Map<String, dynamic>?;
+    if (jsonData == null) return null;
+    return _credentialsFromJson(jsonData);
+  }
+
+  static Future<void> _deleteLocalCredentials(
+    String studyKey, {
+    String? userId,
+  }) async {
+    final keysToDelete = <String>{_legacyLocalKey(studyKey)};
+    final effectiveUserId = userId ?? _currentUserId();
+    if (effectiveUserId != null) {
+      keysToDelete.add(_scopedLocalKey(effectiveUserId, studyKey));
+    }
+
+    for (final key in keysToDelete) {
+      if (await SecureStorage.containsKey(key)) {
+        await SecureStorage.delete(key);
+      }
+    }
+  }
+
+  static Future<void> clearLocalFallbackCredentials() async {
+    final storedValues = await SecureStorage.readAll();
+    for (final key in storedValues.keys) {
+      if (key.startsWith(_fitbitCredentialsPrefix)) {
+        await SecureStorage.delete(key);
+      }
+    }
   }
 
   static Future<fitbitter.FitbitCredentials?> _validateToken(

--- a/app/lib/util/fitbit_handler.dart
+++ b/app/lib/util/fitbit_handler.dart
@@ -11,6 +11,31 @@ class FitbitHandler {
   static const String _fitbitCredentialsPrefix = 'fitbit_credentials_';
   static const String _participantFitbitTable =
       'participant_fitbit_credentials';
+  static String? Function() _currentUserIdGetter = _defaultCurrentUserId;
+  static Future<String?> Function(String) _readLocalValue = SecureStorage.read;
+  static Future<void> Function(String, String) _writeLocalValue =
+      SecureStorage.write;
+  static Future<void> Function(String) _deleteLocalValue = SecureStorage.delete;
+  static Future<bool> Function(String) _containsLocalKey =
+      SecureStorage.containsKey;
+  static Future<Map<String, String>> Function() _readAllLocalValues =
+      SecureStorage.readAll;
+  static Future<fitbitter.FitbitCredentials?> Function({
+    required String userId,
+    required String studyKey,
+  })
+  _serverCredentialsLoader = _loadCredentialsFromServer;
+  static Future<void> Function({
+    required String userId,
+    required String studyKey,
+    required Map<String, dynamic> credentialsJson,
+  })
+  _serverCredentialsUpserter = _upsertCredentialsOnServer;
+  static Future<void> Function({
+    required String userId,
+    required String studyKey,
+  })
+  _serverCredentialsDeleter = _deleteCredentialsFromServer;
 
   static String _legacyLocalKey(String studyKey) =>
       '$_fitbitCredentialsPrefix$studyKey';
@@ -18,7 +43,7 @@ class FitbitHandler {
   static String _scopedLocalKey(String userId, String studyKey) =>
       '$_fitbitCredentialsPrefix${userId}_$studyKey';
 
-  static String? _currentUserId() =>
+  static String? _defaultCurrentUserId() =>
       Supabase.instance.client.auth.currentUser?.id;
 
   @visibleForTesting
@@ -47,105 +72,119 @@ class FitbitHandler {
   }
 
   static Future<void> deleteFitbitCredentials(String studyKey) async {
-    final userId = _currentUserId();
-    try {
-      if (userId != null) {
-        await Supabase.instance.client
-            .from(_participantFitbitTable)
-            .delete()
-            .eq('user_id', userId)
-            .eq('study_id', studyKey);
+    final userId = _currentUserIdGetter();
+    var serverDeleteFailed = false;
+    if (userId != null) {
+      try {
+        await _serverCredentialsDeleter(userId: userId, studyKey: studyKey);
+      } catch (e) {
+        serverDeleteFailed = true;
+        StudyULogger.error(
+          'Failed to delete participant Fitbit credentials from server: $e',
+        );
       }
-    } catch (e) {
-      StudyULogger.error('Failed to delete participant Fitbit credentials: $e');
     }
     await _deleteLocalCredentials(studyKey, userId: userId);
+    if (serverDeleteFailed) {
+      throw Exception('Failed to delete participant Fitbit credentials');
+    }
   }
 
   static Future<void> _storeCredentials(
     fitbitter.FitbitCredentials? credentials,
     String studyKey,
   ) async {
-    final userId = _currentUserId();
+    final userId = _currentUserIdGetter();
 
-    try {
-      if (credentials == null) {
-        if (userId != null) {
-          await Supabase.instance.client
-              .from(_participantFitbitTable)
-              .delete()
-              .eq('user_id', userId)
-              .eq('study_id', studyKey);
-        }
-        await _deleteLocalCredentials(studyKey, userId: userId);
-      } else {
-        final credentialsJson = _credentialsToJson(credentials);
-        if (userId != null) {
-          await Supabase.instance.client.from(_participantFitbitTable).upsert({
-            'user_id': userId,
-            'study_id': studyKey,
-            'fitbit_credentials': credentialsJson,
-          });
-          await SecureStorage.write(
-            _scopedLocalKey(userId, studyKey),
-            jsonEncode(credentialsJson),
-          );
-          if (await SecureStorage.containsKey(_legacyLocalKey(studyKey))) {
-            await SecureStorage.delete(_legacyLocalKey(studyKey));
-          }
-        } else {
-          await SecureStorage.write(
-            _legacyLocalKey(studyKey),
-            jsonEncode(credentialsJson),
+    if (credentials == null) {
+      if (userId != null) {
+        try {
+          await _serverCredentialsDeleter(userId: userId, studyKey: studyKey);
+        } catch (e) {
+          StudyULogger.error(
+            'Failed to delete participant Fitbit credentials from server: $e',
           );
         }
       }
-    } catch (e) {
-      StudyULogger.error('Failed to store Fitbit credentials: $e');
+      await _deleteLocalCredentials(studyKey, userId: userId);
+      return;
     }
+
+    final credentialsJson = _credentialsToJson(credentials);
+    if (userId != null) {
+      await _writeLocalValue(
+        _scopedLocalKey(userId, studyKey),
+        jsonEncode(credentialsJson),
+      );
+      if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
+        await _deleteLocalValue(_legacyLocalKey(studyKey));
+      }
+      try {
+        await _serverCredentialsUpserter(
+          userId: userId,
+          studyKey: studyKey,
+          credentialsJson: credentialsJson,
+        );
+      } catch (e) {
+        StudyULogger.error(
+          'Failed to store participant Fitbit credentials on server: $e',
+        );
+      }
+      return;
+    }
+
+    await _writeLocalValue(
+      _legacyLocalKey(studyKey),
+      jsonEncode(credentialsJson),
+    );
   }
 
   static Future<fitbitter.FitbitCredentials?> _loadCredentials(
     String studyKey,
   ) async {
-    final userId = _currentUserId();
+    final userId = _currentUserIdGetter();
 
-    try {
-      if (userId != null) {
-        final serverCredentials = await _loadCredentialsFromServer(
+    if (userId != null) {
+      try {
+        final serverCredentials = await _serverCredentialsLoader(
           userId: userId,
           studyKey: studyKey,
         );
         if (serverCredentials != null) {
-          await SecureStorage.write(
+          await _writeLocalValue(
             _scopedLocalKey(userId, studyKey),
             jsonEncode(_credentialsToJson(serverCredentials)),
           );
-          if (await SecureStorage.containsKey(_legacyLocalKey(studyKey))) {
-            await SecureStorage.delete(_legacyLocalKey(studyKey));
+          if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
+            await _deleteLocalValue(_legacyLocalKey(studyKey));
           }
           return serverCredentials;
         }
-
-        final scopedString = await SecureStorage.read(
-          _scopedLocalKey(userId, studyKey),
+      } catch (e) {
+        StudyULogger.error(
+          'Failed to load participant Fitbit credentials from server: $e',
         );
-        if (scopedString != null) {
-          final jsonData = jsonDecode(scopedString) as Map<String, dynamic>;
-          return _credentialsFromJson(jsonData);
-        }
       }
 
-      final legacyString = await SecureStorage.read(_legacyLocalKey(studyKey));
-      if (legacyString != null) {
-        if (shouldDiscardLegacyCredentialsForAuthenticatedUser(userId)) {
-          await SecureStorage.delete(_legacyLocalKey(studyKey));
-          StudyULogger.warning(
-            'Discarded legacy Fitbit credentials for $studyKey after authenticated load because ownership cannot be verified.',
-          );
-          return null;
-        }
+      final scopedString = await _readLocalValue(
+        _scopedLocalKey(userId, studyKey),
+      );
+      if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
+        await _deleteLocalValue(_legacyLocalKey(studyKey));
+        StudyULogger.warning(
+          'Discarded legacy Fitbit credentials for $studyKey after authenticated load because ownership cannot be verified.',
+        );
+      }
+      if (scopedString != null) {
+        final jsonData = jsonDecode(scopedString) as Map<String, dynamic>;
+        return _credentialsFromJson(jsonData);
+      }
+      return null;
+    }
 
+    try {
+      final legacyString = await _readLocalValue(_legacyLocalKey(studyKey));
+      if (legacyString != null) {
         final jsonData = jsonDecode(legacyString) as Map<String, dynamic>;
         return _credentialsFromJson(jsonData);
       }
@@ -174,28 +213,51 @@ class FitbitHandler {
     return _credentialsFromJson(jsonData);
   }
 
+  static Future<void> _upsertCredentialsOnServer({
+    required String userId,
+    required String studyKey,
+    required Map<String, dynamic> credentialsJson,
+  }) async {
+    await Supabase.instance.client.from(_participantFitbitTable).upsert({
+      'user_id': userId,
+      'study_id': studyKey,
+      'fitbit_credentials': credentialsJson,
+    });
+  }
+
+  static Future<void> _deleteCredentialsFromServer({
+    required String userId,
+    required String studyKey,
+  }) async {
+    await Supabase.instance.client
+        .from(_participantFitbitTable)
+        .delete()
+        .eq('user_id', userId)
+        .eq('study_id', studyKey);
+  }
+
   static Future<void> _deleteLocalCredentials(
     String studyKey, {
     String? userId,
   }) async {
     final keysToDelete = <String>{_legacyLocalKey(studyKey)};
-    final effectiveUserId = userId ?? _currentUserId();
+    final effectiveUserId = userId ?? _currentUserIdGetter();
     if (effectiveUserId != null) {
       keysToDelete.add(_scopedLocalKey(effectiveUserId, studyKey));
     }
 
     for (final key in keysToDelete) {
-      if (await SecureStorage.containsKey(key)) {
-        await SecureStorage.delete(key);
+      if (await _containsLocalKey(key)) {
+        await _deleteLocalValue(key);
       }
     }
   }
 
   static Future<void> clearLocalFallbackCredentials() async {
-    final storedValues = await SecureStorage.readAll();
+    final storedValues = await _readAllLocalValues();
     for (final key in storedValues.keys) {
       if (key.startsWith(_fitbitCredentialsPrefix)) {
-        await SecureStorage.delete(key);
+        await _deleteLocalValue(key);
       }
     }
   }
@@ -575,5 +637,146 @@ class FitbitHandler {
       subject,
       question,
     );
+  }
+
+  @visibleForTesting
+  static Future<void> debugStoreCredentialsForTesting(
+    fitbitter.FitbitCredentials? credentials,
+    String studyKey,
+  ) => _storeCredentials(credentials, studyKey);
+
+  @visibleForTesting
+  static Future<fitbitter.FitbitCredentials?> debugLoadCredentialsForTesting(
+    String studyKey,
+  ) => _loadCredentials(studyKey);
+
+  @visibleForTesting
+  static String? Function() get debugCurrentUserIdGetterForTesting =>
+      _currentUserIdGetter;
+
+  @visibleForTesting
+  static set debugCurrentUserIdGetterForTesting(String? Function() value) {
+    _currentUserIdGetter = value;
+  }
+
+  @visibleForTesting
+  static Future<String?> Function(String) get debugReadLocalValueForTesting =>
+      _readLocalValue;
+
+  @visibleForTesting
+  static set debugReadLocalValueForTesting(
+    Future<String?> Function(String) value,
+  ) {
+    _readLocalValue = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String, String)
+  get debugWriteLocalValueForTesting => _writeLocalValue;
+
+  @visibleForTesting
+  static set debugWriteLocalValueForTesting(
+    Future<void> Function(String, String) value,
+  ) {
+    _writeLocalValue = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String) get debugDeleteLocalValueForTesting =>
+      _deleteLocalValue;
+
+  @visibleForTesting
+  static set debugDeleteLocalValueForTesting(
+    Future<void> Function(String) value,
+  ) {
+    _deleteLocalValue = value;
+  }
+
+  @visibleForTesting
+  static Future<bool> Function(String) get debugContainsLocalKeyForTesting =>
+      _containsLocalKey;
+
+  @visibleForTesting
+  static set debugContainsLocalKeyForTesting(
+    Future<bool> Function(String) value,
+  ) {
+    _containsLocalKey = value;
+  }
+
+  @visibleForTesting
+  static Future<Map<String, String>> Function()
+  get debugReadAllLocalValuesForTesting => _readAllLocalValues;
+
+  @visibleForTesting
+  static set debugReadAllLocalValuesForTesting(
+    Future<Map<String, String>> Function() value,
+  ) {
+    _readAllLocalValues = value;
+  }
+
+  @visibleForTesting
+  static Future<fitbitter.FitbitCredentials?> Function({
+    required String userId,
+    required String studyKey,
+  })
+  get debugServerCredentialsLoaderForTesting => _serverCredentialsLoader;
+
+  @visibleForTesting
+  static set debugServerCredentialsLoaderForTesting(
+    Future<fitbitter.FitbitCredentials?> Function({
+      required String userId,
+      required String studyKey,
+    })
+    value,
+  ) {
+    _serverCredentialsLoader = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function({
+    required String userId,
+    required String studyKey,
+    required Map<String, dynamic> credentialsJson,
+  })
+  get debugServerCredentialsUpserterForTesting => _serverCredentialsUpserter;
+
+  @visibleForTesting
+  static set debugServerCredentialsUpserterForTesting(
+    Future<void> Function({
+      required String userId,
+      required String studyKey,
+      required Map<String, dynamic> credentialsJson,
+    })
+    value,
+  ) {
+    _serverCredentialsUpserter = value;
+  }
+
+  @visibleForTesting
+  static Future<void> Function({
+    required String userId,
+    required String studyKey,
+  })
+  get debugServerCredentialsDeleterForTesting => _serverCredentialsDeleter;
+
+  @visibleForTesting
+  static set debugServerCredentialsDeleterForTesting(
+    Future<void> Function({required String userId, required String studyKey})
+    value,
+  ) {
+    _serverCredentialsDeleter = value;
+  }
+
+  @visibleForTesting
+  static void debugResetTestingOverrides() {
+    _currentUserIdGetter = _defaultCurrentUserId;
+    _readLocalValue = SecureStorage.read;
+    _writeLocalValue = SecureStorage.write;
+    _deleteLocalValue = SecureStorage.delete;
+    _containsLocalKey = SecureStorage.containsKey;
+    _readAllLocalValues = SecureStorage.readAll;
+    _serverCredentialsLoader = _loadCredentialsFromServer;
+    _serverCredentialsUpserter = _upsertCredentialsOnServer;
+    _serverCredentialsDeleter = _deleteCredentialsFromServer;
   }
 }

--- a/app/lib/util/fitbit_handler.dart
+++ b/app/lib/util/fitbit_handler.dart
@@ -7,6 +7,34 @@ import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+class FitbitCredentialStorageException implements Exception {
+  final bool localOperationFailed;
+  final bool serverOperationFailed;
+
+  const FitbitCredentialStorageException({
+    required this.localOperationFailed,
+    required this.serverOperationFailed,
+  });
+
+  @override
+  String toString() =>
+      'FitbitCredentialStorageException(localOperationFailed: $localOperationFailed, serverOperationFailed: $serverOperationFailed)';
+}
+
+class FitbitCredentialDeletionException implements Exception {
+  final bool remoteDeletionFailed;
+  final bool localDeletionFailed;
+
+  const FitbitCredentialDeletionException({
+    required this.remoteDeletionFailed,
+    required this.localDeletionFailed,
+  });
+
+  @override
+  String toString() =>
+      'FitbitCredentialDeletionException(remoteDeletionFailed: $remoteDeletionFailed, localDeletionFailed: $localDeletionFailed)';
+}
+
 class FitbitHandler {
   static const String _fitbitCredentialsPrefix = 'fitbit_credentials_';
   static const String _participantFitbitTable =
@@ -72,21 +100,60 @@ class FitbitHandler {
   }
 
   static Future<void> deleteFitbitCredentials(String studyKey) async {
+    var remoteDeletionFailed = false;
+    var localDeletionFailed = false;
+    try {
+      await deleteRemoteFitbitCredentials(studyKey);
+    } on FitbitCredentialDeletionException catch (e) {
+      remoteDeletionFailed = e.remoteDeletionFailed;
+      localDeletionFailed = e.localDeletionFailed;
+    }
+
+    try {
+      await clearLocalFallbackCredentialsForStudy(studyKey);
+    } on FitbitCredentialDeletionException catch (e) {
+      remoteDeletionFailed = remoteDeletionFailed || e.remoteDeletionFailed;
+      localDeletionFailed = localDeletionFailed || e.localDeletionFailed;
+    }
+
+    if (remoteDeletionFailed || localDeletionFailed) {
+      throw FitbitCredentialDeletionException(
+        remoteDeletionFailed: remoteDeletionFailed,
+        localDeletionFailed: localDeletionFailed,
+      );
+    }
+  }
+
+  static Future<void> deleteRemoteFitbitCredentials(String studyKey) async {
     final userId = _currentUserIdGetter();
-    var serverDeleteFailed = false;
     if (userId != null) {
       try {
         await _serverCredentialsDeleter(userId: userId, studyKey: studyKey);
       } catch (e) {
-        serverDeleteFailed = true;
         StudyULogger.error(
           'Failed to delete participant Fitbit credentials from server: $e',
         );
+        throw const FitbitCredentialDeletionException(
+          remoteDeletionFailed: true,
+          localDeletionFailed: false,
+        );
       }
     }
-    await _deleteLocalCredentials(studyKey, userId: userId);
-    if (serverDeleteFailed) {
-      throw Exception('Failed to delete participant Fitbit credentials');
+  }
+
+  static Future<void> clearLocalFallbackCredentialsForStudy(
+    String studyKey,
+  ) async {
+    try {
+      await _deleteLocalCredentials(studyKey, userId: _currentUserIdGetter());
+    } catch (e) {
+      StudyULogger.error(
+        'Failed to delete participant Fitbit credentials locally: $e',
+      );
+      throw const FitbitCredentialDeletionException(
+        remoteDeletionFailed: false,
+        localDeletionFailed: true,
+      );
     }
   }
 
@@ -112,13 +179,31 @@ class FitbitHandler {
 
     final credentialsJson = _credentialsToJson(credentials);
     if (userId != null) {
-      await _writeLocalValue(
-        _scopedLocalKey(userId, studyKey),
-        jsonEncode(credentialsJson),
-      );
-      if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
-        await _deleteLocalValue(_legacyLocalKey(studyKey));
+      var localOperationFailed = false;
+      var serverOperationFailed = false;
+
+      try {
+        await _writeLocalValue(
+          _scopedLocalKey(userId, studyKey),
+          jsonEncode(credentialsJson),
+        );
+      } catch (e) {
+        localOperationFailed = true;
+        StudyULogger.error(
+          'Failed to store participant Fitbit credentials locally: $e',
+        );
       }
+
+      try {
+        if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
+          await _deleteLocalValue(_legacyLocalKey(studyKey));
+        }
+      } catch (e) {
+        StudyULogger.warning(
+          'Failed to delete legacy Fitbit credentials locally: $e',
+        );
+      }
+
       try {
         await _serverCredentialsUpserter(
           userId: userId,
@@ -126,8 +211,16 @@ class FitbitHandler {
           credentialsJson: credentialsJson,
         );
       } catch (e) {
+        serverOperationFailed = true;
         StudyULogger.error(
           'Failed to store participant Fitbit credentials on server: $e',
+        );
+      }
+
+      if (localOperationFailed && serverOperationFailed) {
+        throw const FitbitCredentialStorageException(
+          localOperationFailed: true,
+          serverOperationFailed: true,
         );
       }
       return;
@@ -151,12 +244,24 @@ class FitbitHandler {
           studyKey: studyKey,
         );
         if (serverCredentials != null) {
-          await _writeLocalValue(
-            _scopedLocalKey(userId, studyKey),
-            jsonEncode(_credentialsToJson(serverCredentials)),
-          );
-          if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
-            await _deleteLocalValue(_legacyLocalKey(studyKey));
+          try {
+            await _writeLocalValue(
+              _scopedLocalKey(userId, studyKey),
+              jsonEncode(_credentialsToJson(serverCredentials)),
+            );
+          } catch (e) {
+            StudyULogger.warning(
+              'Failed to cache participant Fitbit credentials locally: $e',
+            );
+          }
+          try {
+            if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
+              await _deleteLocalValue(_legacyLocalKey(studyKey));
+            }
+          } catch (e) {
+            StudyULogger.warning(
+              'Failed to delete legacy Fitbit credentials locally: $e',
+            );
           }
           return serverCredentials;
         }
@@ -166,13 +271,24 @@ class FitbitHandler {
         );
       }
 
-      final scopedString = await _readLocalValue(
-        _scopedLocalKey(userId, studyKey),
-      );
-      if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
-        await _deleteLocalValue(_legacyLocalKey(studyKey));
+      String? scopedString;
+      try {
+        scopedString = await _readLocalValue(_scopedLocalKey(userId, studyKey));
+      } catch (e) {
+        StudyULogger.error(
+          'Failed to load participant Fitbit credentials locally: $e',
+        );
+      }
+      try {
+        if (await _containsLocalKey(_legacyLocalKey(studyKey))) {
+          await _deleteLocalValue(_legacyLocalKey(studyKey));
+          StudyULogger.warning(
+            'Discarded legacy Fitbit credentials for $studyKey after authenticated load because ownership cannot be verified.',
+          );
+        }
+      } catch (e) {
         StudyULogger.warning(
-          'Discarded legacy Fitbit credentials for $studyKey after authenticated load because ownership cannot be verified.',
+          'Failed to delete legacy Fitbit credentials locally: $e',
         );
       }
       if (scopedString != null) {

--- a/app/test/screens/study/dashboard/study_information_test.dart
+++ b/app/test/screens/study/dashboard/study_information_test.dart
@@ -301,4 +301,7 @@ class _TestAppLanguage extends ChangeNotifier implements AppLanguage {
 
   @override
   Future<void> fetchLocale() async {}
+
+  @override
+  Future<void> syncWithAuthenticatedUser() async {}
 }

--- a/app/test/services/participant_fitbit_credentials_service_test.dart
+++ b/app/test/services/participant_fitbit_credentials_service_test.dart
@@ -1,0 +1,241 @@
+import 'dart:convert';
+
+import 'package:fitbitter/fitbitter.dart' as fitbitter;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/services/participant_fitbit_credentials_service.dart';
+
+void main() {
+  group('ParticipantFitbitCredentialsService', () {
+    late Map<String, String> storage;
+    late fitbitter.FitbitCredentials serverCredentials;
+    late fitbitter.FitbitCredentials scopedCredentials;
+
+    setUp(() {
+      storage = {};
+      serverCredentials = _credentials('server-user');
+      scopedCredentials = _credentials('local-user');
+
+      ParticipantFitbitCredentialsService.debugCurrentUserIdGetterForTesting =
+          () => 'user-1';
+      ParticipantFitbitCredentialsService.debugReadLocalValueForTesting =
+          (key) async => storage[key];
+      ParticipantFitbitCredentialsService.debugWriteLocalValueForTesting =
+          (key, value) async {
+            storage[key] = value;
+          };
+      ParticipantFitbitCredentialsService.debugDeleteLocalValueForTesting =
+          (key) async {
+            storage.remove(key);
+          };
+      ParticipantFitbitCredentialsService.debugContainsLocalKeyForTesting =
+          (key) async => storage.containsKey(key);
+      ParticipantFitbitCredentialsService.debugReadAllLocalValuesForTesting =
+          () async => Map<String, String>.from(storage);
+      ParticipantFitbitCredentialsService
+              .debugServerCredentialsLoaderForTesting =
+          ({required userId, required studyKey}) async => null;
+      ParticipantFitbitCredentialsService
+              .debugServerCredentialsUpserterForTesting =
+          ({
+            required userId,
+            required studyKey,
+            required credentialsJson,
+          }) async {};
+      ParticipantFitbitCredentialsService
+              .debugServerCredentialsDeleterForTesting =
+          ({required userId, required studyKey}) async {};
+    });
+
+    tearDown(ParticipantFitbitCredentialsService.debugResetTestingOverrides);
+
+    test('server credentials are preferred and cached locally', () async {
+      ParticipantFitbitCredentialsService
+              .debugServerCredentialsLoaderForTesting =
+          ({required userId, required studyKey}) async => serverCredentials;
+
+      final loaded =
+          await ParticipantFitbitCredentialsService.debugLoadCredentialsForTesting(
+            'study-1',
+          );
+
+      expect(loaded?.userID, 'server-user');
+      expect(
+        storage['fitbit_credentials_user-1_study-1'],
+        jsonEncode({
+          'userID': 'server-user',
+          'fitbitAccessToken': 'access-server-user',
+          'fitbitRefreshToken': 'refresh-server-user',
+        }),
+      );
+    });
+
+    test('server credentials are returned when local caching throws', () async {
+      ParticipantFitbitCredentialsService
+              .debugServerCredentialsLoaderForTesting =
+          ({required userId, required studyKey}) async => serverCredentials;
+      ParticipantFitbitCredentialsService.debugWriteLocalValueForTesting =
+          (key, value) => Future<void>.error(Exception('local cache failed'));
+
+      final loaded =
+          await ParticipantFitbitCredentialsService.debugLoadCredentialsForTesting(
+            'study-1',
+          );
+
+      expect(loaded?.userID, 'server-user');
+    });
+
+    test('server returns no row so scoped local credentials are used', () async {
+      storage['fitbit_credentials_user-1_study-1'] = jsonEncode({
+        'userID': scopedCredentials.userID,
+        'fitbitAccessToken': scopedCredentials.fitbitAccessToken,
+        'fitbitRefreshToken': scopedCredentials.fitbitRefreshToken,
+      });
+
+      final loaded =
+          await ParticipantFitbitCredentialsService.debugLoadCredentialsForTesting(
+            'study-1',
+          );
+
+      expect(loaded?.userID, 'local-user');
+    });
+
+    test('server read throws so scoped local credentials are used', () async {
+      storage['fitbit_credentials_user-1_study-1'] = jsonEncode({
+        'userID': scopedCredentials.userID,
+        'fitbitAccessToken': scopedCredentials.fitbitAccessToken,
+        'fitbitRefreshToken': scopedCredentials.fitbitRefreshToken,
+      });
+      ParticipantFitbitCredentialsService
+              .debugServerCredentialsLoaderForTesting =
+          ({required userId, required studyKey}) async =>
+              throw Exception('network');
+
+      final loaded =
+          await ParticipantFitbitCredentialsService.debugLoadCredentialsForTesting(
+            'study-1',
+          );
+
+      expect(loaded?.userID, 'local-user');
+    });
+
+    test(
+      'server upsert throws but scoped local credentials are still stored',
+      () async {
+        ParticipantFitbitCredentialsService
+                .debugServerCredentialsUpserterForTesting =
+            ({
+              required userId,
+              required studyKey,
+              required credentialsJson,
+            }) async => throw Exception('server down');
+
+        await ParticipantFitbitCredentialsService.debugStoreCredentialsForTesting(
+          scopedCredentials,
+          'study-1',
+        );
+
+        expect(
+          storage.containsKey('fitbit_credentials_user-1_study-1'),
+          isTrue,
+        );
+      },
+    );
+
+    test('server upsert still occurs when local writing throws', () async {
+      var upsertCalls = 0;
+      ParticipantFitbitCredentialsService.debugWriteLocalValueForTesting =
+          (key, value) => Future<void>.error(Exception('local failed'));
+      ParticipantFitbitCredentialsService
+              .debugServerCredentialsUpserterForTesting =
+          ({
+            required userId,
+            required studyKey,
+            required credentialsJson,
+          }) async {
+            upsertCalls++;
+          };
+
+      await ParticipantFitbitCredentialsService.debugStoreCredentialsForTesting(
+        scopedCredentials,
+        'study-1',
+      );
+
+      expect(upsertCalls, 1);
+    });
+
+    test('both storage failures are surfaced without exposing tokens', () async {
+      ParticipantFitbitCredentialsService.debugWriteLocalValueForTesting =
+          (key, value) => Future<void>.error(Exception('local failed'));
+      ParticipantFitbitCredentialsService
+              .debugServerCredentialsUpserterForTesting =
+          ({
+            required userId,
+            required studyKey,
+            required credentialsJson,
+          }) async => throw Exception('server failed');
+
+      try {
+        await ParticipantFitbitCredentialsService.debugStoreCredentialsForTesting(
+          scopedCredentials,
+          'study-1',
+        );
+        fail('Expected storage failure');
+      } catch (e) {
+        expect(e, isA<FitbitCredentialStorageException>());
+        expect(
+          e.toString(),
+          isNot(contains(scopedCredentials.fitbitAccessToken)),
+        );
+        expect(
+          e.toString(),
+          isNot(contains(scopedCredentials.fitbitRefreshToken)),
+        );
+      }
+    });
+
+    test(
+      'authenticated users never consume legacy unscoped credentials',
+      () async {
+        storage['fitbit_credentials_study-1'] = jsonEncode({
+          'userID': 'legacy-user',
+          'fitbitAccessToken': 'legacy-access',
+          'fitbitRefreshToken': 'legacy-refresh',
+        });
+
+        final loaded =
+            await ParticipantFitbitCredentialsService.debugLoadCredentialsForTesting(
+              'study-1',
+            );
+
+        expect(loaded, isNull);
+        expect(storage.containsKey('fitbit_credentials_study-1'), isFalse);
+      },
+    );
+
+    test(
+      'participant A scoped value is never returned for participant B',
+      () async {
+        storage['fitbit_credentials_user-a_study-1'] = jsonEncode({
+          'userID': 'participant-a',
+          'fitbitAccessToken': 'access-a',
+          'fitbitRefreshToken': 'refresh-a',
+        });
+
+        final loaded =
+            await ParticipantFitbitCredentialsService.debugLoadCredentialsForTesting(
+              'study-1',
+            );
+
+        expect(loaded, isNull);
+      },
+    );
+  });
+}
+
+fitbitter.FitbitCredentials _credentials(String userId) {
+  return fitbitter.FitbitCredentials(
+    userID: userId,
+    fitbitAccessToken: 'access-$userId',
+    fitbitRefreshToken: 'refresh-$userId',
+  );
+}

--- a/app/test/services/participant_fitbit_credentials_service_test.dart
+++ b/app/test/services/participant_fitbit_credentials_service_test.dart
@@ -229,6 +229,72 @@ void main() {
         expect(loaded, isNull);
       },
     );
+
+    test(
+      'recovery cleanup removes legacy and other-user Fitbit fallback while preserving recovered user',
+      () async {
+        storage['fitbit_credentials_study-1'] = jsonEncode({
+          'userID': 'legacy-user',
+          'fitbitAccessToken': 'legacy-access',
+          'fitbitRefreshToken': 'legacy-refresh',
+        });
+        storage['fitbit_credentials_user-a_study-1'] = jsonEncode({
+          'userID': 'participant-a',
+          'fitbitAccessToken': 'access-a',
+          'fitbitRefreshToken': 'refresh-a',
+        });
+        storage['fitbit_credentials_user-b_study-1'] = jsonEncode({
+          'userID': 'participant-b',
+          'fitbitAccessToken': 'access-b',
+          'fitbitRefreshToken': 'refresh-b',
+        });
+
+        await ParticipantFitbitCredentialsService.clearLocalFallbackCredentialsForRecovery(
+          'user-b',
+        );
+
+        expect(storage.containsKey('fitbit_credentials_study-1'), isFalse);
+        expect(
+          storage.containsKey('fitbit_credentials_user-a_study-1'),
+          isFalse,
+        );
+        expect(
+          storage.containsKey('fitbit_credentials_user-b_study-1'),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'recovered participant keeps own scoped Fitbit fallback after recovery cleanup',
+      () async {
+        storage['fitbit_credentials_user-1_study-1'] = jsonEncode({
+          'userID': scopedCredentials.userID,
+          'fitbitAccessToken': scopedCredentials.fitbitAccessToken,
+          'fitbitRefreshToken': scopedCredentials.fitbitRefreshToken,
+        });
+        storage['fitbit_credentials_user-2_study-1'] = jsonEncode({
+          'userID': 'participant-b',
+          'fitbitAccessToken': 'access-b',
+          'fitbitRefreshToken': 'refresh-b',
+        });
+
+        await ParticipantFitbitCredentialsService.clearLocalFallbackCredentialsForRecovery(
+          'user-1',
+        );
+
+        final loaded =
+            await ParticipantFitbitCredentialsService.debugLoadCredentialsForTesting(
+              'study-1',
+            );
+
+        expect(loaded?.userID, 'local-user');
+        expect(
+          storage.containsKey('fitbit_credentials_user-2_study-1'),
+          isFalse,
+        );
+      },
+    );
   });
 }
 

--- a/app/test/services/participant_study_exit_service_test.dart
+++ b/app/test/services/participant_study_exit_service_test.dart
@@ -1,0 +1,165 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/services/participant_study_exit_service.dart';
+import 'package:studyu_app/util/fitbit_handler.dart';
+import 'package:studyu_core/core.dart';
+
+void main() {
+  group('ParticipantStudyExitService', () {
+    tearDown(ParticipantStudyExitService.debugResetTestingOverrides);
+
+    test(
+      'remote Fitbit deletion failure does not leave flow half completed',
+      () async {
+        final events = <String>[];
+        final subject = _FakeStudySubject(
+          onSoftDelete: () async {
+            events.add('soft_delete');
+          },
+        );
+        ParticipantStudyExitService.debugRemoteFitbitDeletionForTesting =
+            (_) async => throw const FitbitCredentialDeletionException(
+              remoteDeletionFailed: true,
+              localDeletionFailed: false,
+            );
+
+        final result = await ParticipantStudyExitService.exitStudy(
+          subject: subject,
+          mode: StudyExitMode.softDelete,
+          notificationCleanup: () async {
+            events.add('notifications');
+          },
+        );
+
+        expect(result.success, isFalse);
+        expect(events, isEmpty);
+      },
+    );
+
+    test(
+      'local Fitbit cleanup failure does not undo successful server deletion',
+      () async {
+        final events = <String>[];
+        final subject = _FakeStudySubject(
+          onDelete: () async {
+            events.add('delete');
+          },
+        );
+        ParticipantStudyExitService.debugRemoteFitbitDeletionForTesting =
+            (_) async {
+              events.add('remote_fitbit_delete');
+            };
+        ParticipantStudyExitService.debugLocalFitbitCleanupForTesting =
+            (_) async => throw const FitbitCredentialDeletionException(
+              remoteDeletionFailed: false,
+              localDeletionFailed: true,
+            );
+        ParticipantStudyExitService.debugLocalDataDeletionForTesting =
+            () async {
+              events.add('delete_local_data');
+            };
+        ParticipantStudyExitService.debugRecoveryCacheClearerForTesting = () {
+          events.add('clear_recovery_cache');
+        };
+
+        final result = await ParticipantStudyExitService.exitStudy(
+          subject: subject,
+          mode: StudyExitMode.hardDelete,
+          notificationCleanup: () async {
+            events.add('notifications');
+          },
+        );
+
+        expect(result.success, isTrue);
+        expect(result.localFitbitCleanupFailed, isTrue);
+        expect(events, [
+          'remote_fitbit_delete',
+          'delete',
+          'clear_recovery_cache',
+          'delete_local_data',
+          'notifications',
+        ]);
+      },
+    );
+
+    test('offline subject deletion failure is handled', () async {
+      final subject = _FakeStudySubject(
+        onSoftDelete: () {
+          throw const SocketException('offline');
+        },
+      );
+      ParticipantStudyExitService.debugRemoteFitbitDeletionForTesting =
+          (_) async {};
+
+      final result = await ParticipantStudyExitService.exitStudy(
+        subject: subject,
+        mode: StudyExitMode.softDelete,
+        notificationCleanup: () async {},
+      );
+
+      expect(result.success, isFalse);
+      expect(result.isOfflineFailure, isTrue);
+    });
+
+    test('successful deletion still completes cleanup order', () async {
+      final events = <String>[];
+      final subject = _FakeStudySubject(
+        onSoftDelete: () async {
+          events.add('soft_delete');
+        },
+      );
+      ParticipantStudyExitService.debugRemoteFitbitDeletionForTesting =
+          (_) async {
+            events.add('remote_fitbit_delete');
+          };
+      ParticipantStudyExitService.debugLocalFitbitCleanupForTesting =
+          (_) async {
+            events.add('local_fitbit_cleanup');
+          };
+      ParticipantStudyExitService.debugActiveStudyReferenceDeletionForTesting =
+          () async {
+            events.add('clear_active_subject');
+          };
+
+      final result = await ParticipantStudyExitService.exitStudy(
+        subject: subject,
+        mode: StudyExitMode.softDelete,
+        notificationCleanup: () async {
+          events.add('notifications');
+        },
+      );
+
+      expect(result.success, isTrue);
+      expect(events, [
+        'remote_fitbit_delete',
+        'soft_delete',
+        'clear_active_subject',
+        'local_fitbit_cleanup',
+        'notifications',
+      ]);
+    });
+  });
+}
+
+class _FakeStudySubject extends StudySubject {
+  final Future<void> Function()? onDelete;
+  final Future<void> Function()? onSoftDelete;
+
+  _FakeStudySubject({this.onDelete, this.onSoftDelete})
+    : super('subject-1', 'study-1', 'user-1', const []) {
+    study = Study('study-1', 'owner-1');
+  }
+
+  @override
+  Future<StudySubject> delete() async {
+    await onDelete?.call();
+    return this;
+  }
+
+  @override
+  Future<StudySubject> softDelete() async {
+    await onSoftDelete?.call();
+    return this;
+  }
+}

--- a/app/test/services/participant_study_exit_service_test.dart
+++ b/app/test/services/participant_study_exit_service_test.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/services/participant_fitbit_credentials_service.dart';
 import 'package:studyu_app/services/participant_study_exit_service.dart';
-import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_core/core.dart';
 
 void main() {

--- a/app/test/services/recovery_local_transition_service_test.dart
+++ b/app/test/services/recovery_local_transition_service_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/services/recovery_local_transition_service.dart';
+
+void main() {
+  group('RecoveryLocalTransitionService', () {
+    setUp(() {
+      RecoveryLocalTransitionService.debugStoredEmailReaderForTesting =
+          () async => null;
+      RecoveryLocalTransitionService.debugStoredPasswordReaderForTesting =
+          () async => null;
+      RecoveryLocalTransitionService.debugActiveSubjectReaderForTesting =
+          () async => null;
+      RecoveryLocalTransitionService.debugStoredEmailDeleterForTesting =
+          () async {};
+      RecoveryLocalTransitionService.debugStoredPasswordDeleterForTesting =
+          () async {};
+      RecoveryLocalTransitionService.debugParticipantSignOutExecutorForTesting =
+          () async {};
+      RecoveryLocalTransitionService.debugActiveSubjectClearerForTesting =
+          () async {};
+      RecoveryLocalTransitionService.debugActiveSubjectWriterForTesting =
+          (_) async {};
+    });
+
+    tearDown(RecoveryLocalTransitionService.debugResetTestingOverrides);
+
+    test('captureSnapshot reads previous local identity state', () async {
+      RecoveryLocalTransitionService.debugStoredEmailReaderForTesting =
+          () async => 'old@test.local';
+      RecoveryLocalTransitionService.debugStoredPasswordReaderForTesting =
+          () async => 'old-password';
+      RecoveryLocalTransitionService.debugActiveSubjectReaderForTesting =
+          () async => 'subject-1';
+
+      final snapshot = await RecoveryLocalTransitionService.captureSnapshot();
+
+      expect(snapshot.previousEmail, 'old@test.local');
+      expect(snapshot.previousPassword, 'old-password');
+      expect(snapshot.previousActiveSubjectId, 'subject-1');
+    });
+
+    test('captureSnapshot fails when previous email read fails', () {
+      RecoveryLocalTransitionService.debugStoredEmailReaderForTesting =
+          () async => throw Exception('email read failed');
+
+      expect(
+        RecoveryLocalTransitionService.captureSnapshot,
+        throwsA(isA<RecoveryLocalTransitionException>()),
+      );
+    });
+
+    test('captureSnapshot fails when previous password read fails', () {
+      RecoveryLocalTransitionService.debugStoredPasswordReaderForTesting =
+          () async => throw Exception('password read failed');
+
+      expect(
+        RecoveryLocalTransitionService.captureSnapshot,
+        throwsA(isA<RecoveryLocalTransitionException>()),
+      );
+    });
+
+    test(
+      'password write failure restores previous credentials and active subject',
+      () async {
+        final restored = <String>[];
+        var signOutCalls = 0;
+
+        RecoveryLocalTransitionService.debugStoredEmailWriterForTesting =
+            (email) async {
+              restored.add('email:$email');
+            };
+        RecoveryLocalTransitionService.debugStoredPasswordWriterForTesting =
+            (password) async {
+              if (password == 'recovered-password') {
+                throw Exception('password write failed');
+              }
+              restored.add('password:$password');
+            };
+        RecoveryLocalTransitionService.debugActiveSubjectWriterForTesting =
+            (subjectId) async {
+              restored.add('subject:$subjectId');
+            };
+        RecoveryLocalTransitionService
+            .debugParticipantSignOutExecutorForTesting = () async {
+          signOutCalls++;
+        };
+
+        await expectLater(
+          RecoveryLocalTransitionService.prepareForRecoveredAccount(
+            snapshot: const RecoveryTransitionSnapshot(
+              previousEmail: 'old@test.local',
+              previousPassword: 'old-password',
+              previousActiveSubjectId: 'subject-1',
+            ),
+            email: 'recovered@test.local',
+            password: 'recovered-password',
+          ),
+          throwsA(isA<RecoveryLocalTransitionException>()),
+        );
+
+        expect(restored, [
+          'email:recovered@test.local',
+          'email:old@test.local',
+          'password:old-password',
+          'subject:subject-1',
+        ]);
+        expect(signOutCalls, 1);
+      },
+    );
+
+    test(
+      'active subject clear failure restores previous credentials and subject',
+      () async {
+        final restored = <String>[];
+        var signOutCalls = 0;
+
+        RecoveryLocalTransitionService.debugStoredEmailWriterForTesting =
+            (email) async {
+              restored.add('email:$email');
+            };
+        RecoveryLocalTransitionService.debugStoredPasswordWriterForTesting =
+            (password) async {
+              restored.add('password:$password');
+            };
+        RecoveryLocalTransitionService.debugActiveSubjectClearerForTesting =
+            () async => throw Exception('clear failed');
+        RecoveryLocalTransitionService.debugActiveSubjectWriterForTesting =
+            (subjectId) async {
+              restored.add('subject:$subjectId');
+            };
+        RecoveryLocalTransitionService
+            .debugParticipantSignOutExecutorForTesting = () async {
+          signOutCalls++;
+        };
+
+        await expectLater(
+          RecoveryLocalTransitionService.prepareForRecoveredAccount(
+            snapshot: const RecoveryTransitionSnapshot(
+              previousEmail: 'old@test.local',
+              previousPassword: 'old-password',
+              previousActiveSubjectId: 'subject-1',
+            ),
+            email: 'recovered@test.local',
+            password: 'recovered-password',
+          ),
+          throwsA(isA<RecoveryLocalTransitionException>()),
+        );
+
+        expect(restored, [
+          'email:recovered@test.local',
+          'password:recovered-password',
+          'email:old@test.local',
+          'password:old-password',
+          'subject:subject-1',
+        ]);
+        expect(signOutCalls, 1);
+      },
+    );
+
+    test(
+      'failed password rollback deletes both credential keys to avoid mixed pair',
+      () async {
+        final deleted = <String>[];
+        final restored = <String>[];
+
+        RecoveryLocalTransitionService.debugStoredEmailWriterForTesting =
+            (email) async {
+              restored.add('email:$email');
+            };
+        RecoveryLocalTransitionService
+            .debugStoredPasswordWriterForTesting = (password) async {
+          if (password == 'recovered-password' || password == 'old-password') {
+            throw Exception('password write failed');
+          }
+        };
+        RecoveryLocalTransitionService.debugStoredEmailDeleterForTesting =
+            () async {
+              deleted.add('email');
+            };
+        RecoveryLocalTransitionService.debugStoredPasswordDeleterForTesting =
+            () async {
+              deleted.add('password');
+            };
+
+        await expectLater(
+          RecoveryLocalTransitionService.prepareForRecoveredAccount(
+            snapshot: const RecoveryTransitionSnapshot(
+              previousEmail: 'old@test.local',
+              previousPassword: 'old-password',
+              previousActiveSubjectId: null,
+            ),
+            email: 'recovered@test.local',
+            password: 'recovered-password',
+          ),
+          throwsA(isA<RecoveryLocalTransitionException>()),
+        );
+
+        expect(restored, [
+          'email:recovered@test.local',
+          'email:old@test.local',
+        ]);
+        expect(deleted, ['email', 'password']);
+      },
+    );
+  });
+}

--- a/app/test/services/restore_account_service_test.dart
+++ b/app/test/services/restore_account_service_test.dart
@@ -116,10 +116,12 @@ void main() {
         String? storedEmail;
         String? storedPassword;
         String? storedSubjectId;
+        final events = <String>[];
 
         RestoreAccountService.debugParticipantStateCleanupForTesting =
             () async {
               cleanupCalls++;
+              events.add('cleanup');
             };
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
             (_) async => RecoveryResult(
@@ -132,14 +134,19 @@ void main() {
             (email, password) async {
               storedEmail = email;
               storedPassword = password;
+              events.add('store_credentials');
             };
         RestoreAccountService.debugParticipantSignInExecutorForTesting =
-            () async => true;
+            (email, password) async {
+              events.add('sign_in:$email:$password');
+              return true;
+            };
         RestoreAccountService.debugSubjectValidatorForTesting = (_) async =>
             true;
         RestoreAccountService.debugActiveSubjectStorerForTesting =
             (subjectId) async {
               storedSubjectId = subjectId;
+              events.add('store_subject');
             };
 
         final result = await RestoreAccountService.performRecovery(BigInt.one);
@@ -149,6 +156,12 @@ void main() {
         expect(storedEmail, 'recovered@test.local');
         expect(storedPassword, 'password-1');
         expect(storedSubjectId, 'subject-1');
+        expect(events, [
+          'sign_in:recovered@test.local:password-1',
+          'cleanup',
+          'store_credentials',
+          'store_subject',
+        ]);
       },
     );
 
@@ -188,7 +201,7 @@ void main() {
             );
         RestoreAccountService.debugCredentialStorerForTesting = (_, _) async {};
         RestoreAccountService.debugParticipantSignInExecutorForTesting =
-            () async => true;
+            (_, _) async => true;
         RestoreAccountService.debugSubjectValidatorForTesting = (_) async =>
             false;
         RestoreAccountService.debugActiveSubjectClearerForTesting = () async {
@@ -218,7 +231,7 @@ void main() {
             );
         RestoreAccountService.debugCredentialStorerForTesting = (_, _) async {};
         RestoreAccountService.debugParticipantSignInExecutorForTesting =
-            () async => true;
+            (_, _) async => true;
         RestoreAccountService.debugActiveSubjectClearerForTesting = () async {
           clearedSubject++;
         };
@@ -227,6 +240,37 @@ void main() {
 
         expect(result.success, isTrue);
         expect(clearedSubject, 1);
+      },
+    );
+
+    test(
+      'performRecovery does not clear participant state on failed sign in',
+      () async {
+        var cleanupCalls = 0;
+        var credentialStoreCalls = 0;
+
+        RestoreAccountService.debugParticipantStateCleanupForTesting =
+            () async {
+              cleanupCalls++;
+            };
+        RestoreAccountService.debugRecoverAccountExecutorForTesting =
+            (_) async => RecoveryResult(
+              success: true,
+              email: 'recovered@test.local',
+              password: 'password-1',
+              subjectId: 'subject-1',
+            );
+        RestoreAccountService.debugCredentialStorerForTesting = (_, _) async {
+          credentialStoreCalls++;
+        };
+        RestoreAccountService.debugParticipantSignInExecutorForTesting =
+            (_, _) async => false;
+
+        final result = await RestoreAccountService.performRecovery(BigInt.one);
+
+        expect(result.success, isFalse);
+        expect(cleanupCalls, 0);
+        expect(credentialStoreCalls, 0);
       },
     );
   });

--- a/app/test/services/restore_account_service_test.dart
+++ b/app/test/services/restore_account_service_test.dart
@@ -141,6 +141,9 @@ void main() {
               events.add('sign_in:$email:$password');
               return true;
             };
+        RestoreAccountService.debugActiveSubjectClearerForTesting = () async {
+          events.add('clear_subject');
+        };
         RestoreAccountService.debugSubjectValidatorForTesting = (_) async =>
             true;
         RestoreAccountService.debugActiveSubjectStorerForTesting =
@@ -158,8 +161,9 @@ void main() {
         expect(storedSubjectId, 'subject-1');
         expect(events, [
           'sign_in:recovered@test.local:password-1',
-          'cleanup',
           'store_credentials',
+          'clear_subject',
+          'cleanup',
           'store_subject',
         ]);
       },
@@ -202,11 +206,11 @@ void main() {
         RestoreAccountService.debugCredentialStorerForTesting = (_, _) async {};
         RestoreAccountService.debugParticipantSignInExecutorForTesting =
             (_, _) async => true;
-        RestoreAccountService.debugSubjectValidatorForTesting = (_) async =>
-            false;
         RestoreAccountService.debugActiveSubjectClearerForTesting = () async {
           clearedSubject++;
         };
+        RestoreAccountService.debugSubjectValidatorForTesting = (_) async =>
+            false;
 
         final result = await RestoreAccountService.performRecovery(BigInt.one);
 
@@ -271,6 +275,39 @@ void main() {
         expect(result.success, isFalse);
         expect(cleanupCalls, 0);
         expect(credentialStoreCalls, 0);
+      },
+    );
+
+    test(
+      'performRecovery returns cleanup failure after successful sign in',
+      () async {
+        var credentialStoreCalls = 0;
+        var activeSubjectClearCalls = 0;
+
+        RestoreAccountService.debugRecoverAccountExecutorForTesting =
+            (_) async => RecoveryResult(
+              success: true,
+              email: 'recovered@test.local',
+              password: 'password-1',
+              subjectId: 'subject-1',
+            );
+        RestoreAccountService.debugParticipantSignInExecutorForTesting =
+            (_, _) async => true;
+        RestoreAccountService.debugCredentialStorerForTesting = (_, _) async {
+          credentialStoreCalls++;
+        };
+        RestoreAccountService.debugActiveSubjectClearerForTesting = () async {
+          activeSubjectClearCalls++;
+        };
+        RestoreAccountService.debugParticipantStateCleanupForTesting =
+            () async => throw Exception('cleanup failed');
+
+        final result = await RestoreAccountService.performRecovery(BigInt.one);
+
+        expect(result.success, isFalse);
+        expect(result.error, 'recovery_cleanup_failed');
+        expect(credentialStoreCalls, 1);
+        expect(activeSubjectClearCalls, 1);
       },
     );
   });

--- a/app/test/services/restore_account_service_test.dart
+++ b/app/test/services/restore_account_service_test.dart
@@ -4,7 +4,19 @@ import 'package:studyu_core/core.dart';
 
 void main() {
   group('RestoreAccountService', () {
-    tearDown(RestoreAccountService.clearCache);
+    tearDown(() {
+      RestoreAccountService.clearCache();
+      RestoreAccountService.debugResetCurrentUserIdGetterForTesting();
+      RestoreAccountService.debugResetRecoveryIdGetterForTesting();
+      RestoreAccountService.debugResetRecoveryIdRotatorForTesting();
+      RestoreAccountService.debugResetRecoverAccountExecutorForTesting();
+      RestoreAccountService.debugResetCredentialStorerForTesting();
+      RestoreAccountService.debugResetParticipantSignInExecutorForTesting();
+      RestoreAccountService.debugResetSubjectValidatorForTesting();
+      RestoreAccountService.debugResetActiveSubjectStorerForTesting();
+      RestoreAccountService.debugResetActiveSubjectClearerForTesting();
+      RestoreAccountService.debugResetParticipantStateCleanupForTesting();
+    });
 
     test('decodeRecoveryPhrase accepts German recovery phrases', () {
       final recoveryId = BigInt.parse(
@@ -94,6 +106,127 @@ void main() {
 
         expect(firstPhrase, isNot(secondPhrase));
         expect(secondPhrase, encode(BigInt.two));
+      },
+    );
+
+    test(
+      'performRecovery cleans previous participant state before switching',
+      () async {
+        var cleanupCalls = 0;
+        String? storedEmail;
+        String? storedPassword;
+        String? storedSubjectId;
+
+        RestoreAccountService.debugParticipantStateCleanupForTesting =
+            () async {
+              cleanupCalls++;
+            };
+        RestoreAccountService.debugRecoverAccountExecutorForTesting =
+            (_) async => RecoveryResult(
+              success: true,
+              email: 'recovered@test.local',
+              password: 'password-1',
+              subjectId: 'subject-1',
+            );
+        RestoreAccountService.debugCredentialStorerForTesting =
+            (email, password) async {
+              storedEmail = email;
+              storedPassword = password;
+            };
+        RestoreAccountService.debugParticipantSignInExecutorForTesting =
+            () async => true;
+        RestoreAccountService.debugSubjectValidatorForTesting = (_) async =>
+            true;
+        RestoreAccountService.debugActiveSubjectStorerForTesting =
+            (subjectId) async {
+              storedSubjectId = subjectId;
+            };
+
+        final result = await RestoreAccountService.performRecovery(BigInt.one);
+
+        expect(result.success, isTrue);
+        expect(cleanupCalls, 1);
+        expect(storedEmail, 'recovered@test.local');
+        expect(storedPassword, 'password-1');
+        expect(storedSubjectId, 'subject-1');
+      },
+    );
+
+    test(
+      'performRecovery does not clear participant state on failed recovery',
+      () async {
+        var cleanupCalls = 0;
+
+        RestoreAccountService.debugParticipantStateCleanupForTesting =
+            () async {
+              cleanupCalls++;
+            };
+        RestoreAccountService.debugRecoverAccountExecutorForTesting =
+            (_) async =>
+                RecoveryResult(success: false, error: 'recovery_failed');
+
+        final result = await RestoreAccountService.performRecovery(BigInt.one);
+
+        expect(result.success, isFalse);
+        expect(cleanupCalls, 0);
+      },
+    );
+
+    test(
+      'performRecovery clears active subject when recovered subject is invalid',
+      () async {
+        var clearedSubject = 0;
+
+        RestoreAccountService.debugParticipantStateCleanupForTesting =
+            () async {};
+        RestoreAccountService.debugRecoverAccountExecutorForTesting =
+            (_) async => RecoveryResult(
+              success: true,
+              email: 'recovered@test.local',
+              password: 'password-1',
+              subjectId: 'subject-1',
+            );
+        RestoreAccountService.debugCredentialStorerForTesting = (_, _) async {};
+        RestoreAccountService.debugParticipantSignInExecutorForTesting =
+            () async => true;
+        RestoreAccountService.debugSubjectValidatorForTesting = (_) async =>
+            false;
+        RestoreAccountService.debugActiveSubjectClearerForTesting = () async {
+          clearedSubject++;
+        };
+
+        final result = await RestoreAccountService.performRecovery(BigInt.one);
+
+        expect(result.success, isTrue);
+        expect(result.subjectId, isNull);
+        expect(clearedSubject, 1);
+      },
+    );
+
+    test(
+      'performRecovery clears active subject when recovery has no subject',
+      () async {
+        var clearedSubject = 0;
+
+        RestoreAccountService.debugParticipantStateCleanupForTesting =
+            () async {};
+        RestoreAccountService.debugRecoverAccountExecutorForTesting =
+            (_) async => RecoveryResult(
+              success: true,
+              email: 'recovered@test.local',
+              password: 'password-1',
+            );
+        RestoreAccountService.debugCredentialStorerForTesting = (_, _) async {};
+        RestoreAccountService.debugParticipantSignInExecutorForTesting =
+            () async => true;
+        RestoreAccountService.debugActiveSubjectClearerForTesting = () async {
+          clearedSubject++;
+        };
+
+        final result = await RestoreAccountService.performRecovery(BigInt.one);
+
+        expect(result.success, isTrue);
+        expect(clearedSubject, 1);
       },
     );
   });

--- a/app/test/services/restore_account_service_test.dart
+++ b/app/test/services/restore_account_service_test.dart
@@ -1,21 +1,37 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/services/recovery_local_transition_service.dart';
 import 'package:studyu_app/services/restore_account_service.dart';
 import 'package:studyu_core/core.dart';
 
+const _recoveredEmail = 'recovered@test.local';
+const _recoveredPassword = 'password-1';
+
 void main() {
   group('RestoreAccountService', () {
+    setUp(() {
+      RecoveryLocalTransitionService.debugStoredEmailReaderForTesting =
+          () async => null;
+      RecoveryLocalTransitionService.debugStoredPasswordReaderForTesting =
+          () async => null;
+      RecoveryLocalTransitionService.debugStoredEmailDeleterForTesting =
+          () async {};
+      RecoveryLocalTransitionService.debugStoredPasswordDeleterForTesting =
+          () async {};
+      RecoveryLocalTransitionService.debugParticipantSignOutExecutorForTesting =
+          () async {};
+    });
+
     tearDown(() {
       RestoreAccountService.clearCache();
       RestoreAccountService.debugResetCurrentUserIdGetterForTesting();
       RestoreAccountService.debugResetRecoveryIdGetterForTesting();
       RestoreAccountService.debugResetRecoveryIdRotatorForTesting();
       RestoreAccountService.debugResetRecoverAccountExecutorForTesting();
-      RestoreAccountService.debugResetCredentialStorerForTesting();
       RestoreAccountService.debugResetParticipantSignInExecutorForTesting();
       RestoreAccountService.debugResetSubjectValidatorForTesting();
       RestoreAccountService.debugResetActiveSubjectStorerForTesting();
-      RestoreAccountService.debugResetActiveSubjectClearerForTesting();
       RestoreAccountService.debugResetParticipantStateCleanupForTesting();
+      RecoveryLocalTransitionService.debugResetTestingOverrides();
     });
 
     test('decodeRecoveryPhrase accepts German recovery phrases', () {
@@ -124,26 +140,26 @@ void main() {
               events.add('cleanup');
             };
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
-            (_) async => RecoveryResult(
-              success: true,
-              email: 'recovered@test.local',
-              password: 'password-1',
-              subjectId: 'subject-1',
-            );
-        RestoreAccountService.debugCredentialStorerForTesting =
-            (email, password) async {
+            (_) async => _successfulRecoveryResult();
+        RecoveryLocalTransitionService.debugStoredEmailWriterForTesting =
+            (email) async {
               storedEmail = email;
+              events.add('store_email');
+            };
+        RecoveryLocalTransitionService.debugStoredPasswordWriterForTesting =
+            (password) async {
               storedPassword = password;
-              events.add('store_credentials');
+              events.add('store_password');
             };
         RestoreAccountService.debugParticipantSignInExecutorForTesting =
             (email, password) async {
               events.add('sign_in:$email:$password');
               return true;
             };
-        RestoreAccountService.debugActiveSubjectClearerForTesting = () async {
-          events.add('clear_subject');
-        };
+        RecoveryLocalTransitionService.debugActiveSubjectClearerForTesting =
+            () async {
+              events.add('clear_subject');
+            };
         RestoreAccountService.debugSubjectValidatorForTesting = (_) async =>
             true;
         RestoreAccountService.debugActiveSubjectStorerForTesting =
@@ -161,7 +177,8 @@ void main() {
         expect(storedSubjectId, 'subject-1');
         expect(events, [
           'sign_in:recovered@test.local:password-1',
-          'store_credentials',
+          'store_email',
+          'store_password',
           'clear_subject',
           'cleanup',
           'store_subject',
@@ -197,18 +214,15 @@ void main() {
         RestoreAccountService.debugParticipantStateCleanupForTesting =
             () async {};
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
-            (_) async => RecoveryResult(
-              success: true,
-              email: 'recovered@test.local',
-              password: 'password-1',
-              subjectId: 'subject-1',
-            );
-        RestoreAccountService.debugCredentialStorerForTesting = (_, _) async {};
+            (_) async => _successfulRecoveryResult();
+        RecoveryLocalTransitionService.debugCredentialStorerForTesting =
+            (_, _) async {};
         RestoreAccountService.debugParticipantSignInExecutorForTesting =
             (_, _) async => true;
-        RestoreAccountService.debugActiveSubjectClearerForTesting = () async {
-          clearedSubject++;
-        };
+        RecoveryLocalTransitionService.debugActiveSubjectClearerForTesting =
+            () async {
+              clearedSubject++;
+            };
         RestoreAccountService.debugSubjectValidatorForTesting = (_) async =>
             false;
 
@@ -228,17 +242,15 @@ void main() {
         RestoreAccountService.debugParticipantStateCleanupForTesting =
             () async {};
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
-            (_) async => RecoveryResult(
-              success: true,
-              email: 'recovered@test.local',
-              password: 'password-1',
-            );
-        RestoreAccountService.debugCredentialStorerForTesting = (_, _) async {};
+            (_) async => _successfulRecoveryResult(subjectId: null);
+        RecoveryLocalTransitionService.debugCredentialStorerForTesting =
+            (_, _) async {};
         RestoreAccountService.debugParticipantSignInExecutorForTesting =
             (_, _) async => true;
-        RestoreAccountService.debugActiveSubjectClearerForTesting = () async {
-          clearedSubject++;
-        };
+        RecoveryLocalTransitionService.debugActiveSubjectClearerForTesting =
+            () async {
+              clearedSubject++;
+            };
 
         final result = await RestoreAccountService.performRecovery(BigInt.one);
 
@@ -258,15 +270,15 @@ void main() {
               cleanupCalls++;
             };
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
-            (_) async => RecoveryResult(
-              success: true,
-              email: 'recovered@test.local',
-              password: 'password-1',
-              subjectId: 'subject-1',
-            );
-        RestoreAccountService.debugCredentialStorerForTesting = (_, _) async {
-          credentialStoreCalls++;
-        };
+            (_) async => _successfulRecoveryResult();
+        RecoveryLocalTransitionService.debugStoredEmailWriterForTesting =
+            (email) async {
+              credentialStoreCalls++;
+            };
+        RecoveryLocalTransitionService.debugStoredPasswordWriterForTesting =
+            (password) async {
+              credentialStoreCalls++;
+            };
         RestoreAccountService.debugParticipantSignInExecutorForTesting =
             (_, _) async => false;
 
@@ -285,20 +297,21 @@ void main() {
         var activeSubjectClearCalls = 0;
 
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
-            (_) async => RecoveryResult(
-              success: true,
-              email: 'recovered@test.local',
-              password: 'password-1',
-              subjectId: 'subject-1',
-            );
+            (_) async => _successfulRecoveryResult();
         RestoreAccountService.debugParticipantSignInExecutorForTesting =
             (_, _) async => true;
-        RestoreAccountService.debugCredentialStorerForTesting = (_, _) async {
-          credentialStoreCalls++;
-        };
-        RestoreAccountService.debugActiveSubjectClearerForTesting = () async {
-          activeSubjectClearCalls++;
-        };
+        RecoveryLocalTransitionService.debugStoredEmailWriterForTesting =
+            (email) async {
+              credentialStoreCalls++;
+            };
+        RecoveryLocalTransitionService.debugStoredPasswordWriterForTesting =
+            (password) async {
+              credentialStoreCalls++;
+            };
+        RecoveryLocalTransitionService.debugActiveSubjectClearerForTesting =
+            () async {
+              activeSubjectClearCalls++;
+            };
         RestoreAccountService.debugParticipantStateCleanupForTesting =
             () async => throw Exception('cleanup failed');
 
@@ -306,9 +319,156 @@ void main() {
 
         expect(result.success, isFalse);
         expect(result.error, 'recovery_cleanup_failed');
-        expect(credentialStoreCalls, 1);
+        expect(credentialStoreCalls, 2);
         expect(activeSubjectClearCalls, 1);
       },
     );
+
+    test('previous credentials are restored when email write throws', () async {
+      final restored = <String>[];
+      var signOutCalls = 0;
+      var validateCalls = 0;
+
+      RestoreAccountService.debugRecoverAccountExecutorForTesting = (_) async =>
+          _successfulRecoveryResult();
+      RestoreAccountService.debugParticipantSignInExecutorForTesting =
+          (_, _) async => true;
+      RecoveryLocalTransitionService.debugStoredEmailReaderForTesting =
+          () async => 'old@test.local';
+      RecoveryLocalTransitionService.debugStoredPasswordReaderForTesting =
+          () async => 'old-password';
+      RecoveryLocalTransitionService
+          .debugStoredEmailWriterForTesting = (email) async {
+        if (email == 'recovered@test.local') throw Exception('email failed');
+        restored.add('email:$email');
+      };
+      RecoveryLocalTransitionService.debugStoredPasswordWriterForTesting =
+          (password) async {
+            restored.add('password:$password');
+          };
+      RecoveryLocalTransitionService.debugParticipantSignOutExecutorForTesting =
+          () async {
+            signOutCalls++;
+          };
+      RestoreAccountService.debugSubjectValidatorForTesting = (_) async {
+        validateCalls++;
+        return true;
+      };
+
+      final result = await RestoreAccountService.performRecovery(BigInt.one);
+
+      expect(result.success, isFalse);
+      expect(result.error, 'recovery_local_persistence_failed');
+      expect(restored, ['email:old@test.local', 'password:old-password']);
+      expect(signOutCalls, 1);
+      expect(validateCalls, 0);
+    });
+
+    test(
+      'previous credentials are restored when password write throws',
+      () async {
+        final restored = <String>[];
+        var signOutCalls = 0;
+        var validateCalls = 0;
+
+        RestoreAccountService.debugRecoverAccountExecutorForTesting =
+            (_) async => _successfulRecoveryResult();
+        RestoreAccountService.debugParticipantSignInExecutorForTesting =
+            (_, _) async => true;
+        RecoveryLocalTransitionService.debugStoredEmailReaderForTesting =
+            () async => 'old@test.local';
+        RecoveryLocalTransitionService.debugStoredPasswordReaderForTesting =
+            () async => 'old-password';
+        RecoveryLocalTransitionService.debugStoredEmailWriterForTesting =
+            (email) async {
+              restored.add('email:$email');
+            };
+        RecoveryLocalTransitionService.debugStoredPasswordWriterForTesting =
+            (password) async {
+              if (password == 'password-1') {
+                throw Exception('password failed');
+              }
+              restored.add('password:$password');
+            };
+        RecoveryLocalTransitionService
+            .debugParticipantSignOutExecutorForTesting = () async {
+          signOutCalls++;
+        };
+        RestoreAccountService.debugSubjectValidatorForTesting = (_) async {
+          validateCalls++;
+          return true;
+        };
+
+        final result = await RestoreAccountService.performRecovery(BigInt.one);
+
+        expect(result.success, isFalse);
+        expect(result.error, 'recovery_local_persistence_failed');
+        expect(restored, [
+          'email:recovered@test.local',
+          'email:old@test.local',
+          'password:old-password',
+        ]);
+        expect(signOutCalls, 1);
+        expect(validateCalls, 0);
+      },
+    );
+
+    test(
+      'previous credentials are restored when active subject clear throws',
+      () async {
+        final restored = <String>[];
+        var signOutCalls = 0;
+        var validateCalls = 0;
+
+        RestoreAccountService.debugRecoverAccountExecutorForTesting =
+            (_) async => _successfulRecoveryResult();
+        RestoreAccountService.debugParticipantSignInExecutorForTesting =
+            (_, _) async => true;
+        RecoveryLocalTransitionService.debugStoredEmailReaderForTesting =
+            () async => 'old@test.local';
+        RecoveryLocalTransitionService.debugStoredPasswordReaderForTesting =
+            () async => 'old-password';
+        RecoveryLocalTransitionService.debugStoredEmailWriterForTesting =
+            (email) async {
+              restored.add('email:$email');
+            };
+        RecoveryLocalTransitionService.debugStoredPasswordWriterForTesting =
+            (password) async {
+              restored.add('password:$password');
+            };
+        RecoveryLocalTransitionService.debugActiveSubjectClearerForTesting =
+            () async => throw Exception('clear failed');
+        RecoveryLocalTransitionService
+            .debugParticipantSignOutExecutorForTesting = () async {
+          signOutCalls++;
+        };
+        RestoreAccountService.debugSubjectValidatorForTesting = (_) async {
+          validateCalls++;
+          return true;
+        };
+
+        final result = await RestoreAccountService.performRecovery(BigInt.one);
+
+        expect(result.success, isFalse);
+        expect(result.error, 'recovery_local_persistence_failed');
+        expect(restored, [
+          'email:recovered@test.local',
+          'password:password-1',
+          'email:old@test.local',
+          'password:old-password',
+        ]);
+        expect(signOutCalls, 1);
+        expect(validateCalls, 0);
+      },
+    );
   });
+}
+
+RecoveryResult _successfulRecoveryResult({String? subjectId = 'subject-1'}) {
+  return RecoveryResult(
+    success: true,
+    email: _recoveredEmail,
+    password: _recoveredPassword,
+    subjectId: subjectId,
+  );
 }

--- a/app/test/services/restore_account_service_test.dart
+++ b/app/test/services/restore_account_service_test.dart
@@ -9,9 +9,12 @@ const _recoveredPassword = 'password-1';
 void main() {
   group('RestoreAccountService', () {
     setUp(() {
+      RestoreAccountService.debugCurrentUserIdGetterForTesting = () => null;
       RecoveryLocalTransitionService.debugStoredEmailReaderForTesting =
           () async => null;
       RecoveryLocalTransitionService.debugStoredPasswordReaderForTesting =
+          () async => null;
+      RecoveryLocalTransitionService.debugActiveSubjectReaderForTesting =
           () async => null;
       RecoveryLocalTransitionService.debugStoredEmailDeleterForTesting =
           () async {};
@@ -135,9 +138,9 @@ void main() {
         final events = <String>[];
 
         RestoreAccountService.debugParticipantStateCleanupForTesting =
-            () async {
+            (recoveredUserId, recoveredSubjectId) async {
               cleanupCalls++;
-              events.add('cleanup');
+              events.add('cleanup:$recoveredUserId:$recoveredSubjectId');
             };
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
             (_) async => _successfulRecoveryResult();
@@ -180,7 +183,7 @@ void main() {
           'store_email',
           'store_password',
           'clear_subject',
-          'cleanup',
+          'cleanup:null:subject-1',
           'store_subject',
         ]);
       },
@@ -192,7 +195,7 @@ void main() {
         var cleanupCalls = 0;
 
         RestoreAccountService.debugParticipantStateCleanupForTesting =
-            () async {
+            (_, _) async {
               cleanupCalls++;
             };
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
@@ -212,7 +215,7 @@ void main() {
         var clearedSubject = 0;
 
         RestoreAccountService.debugParticipantStateCleanupForTesting =
-            () async {};
+            (_, _) async {};
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
             (_) async => _successfulRecoveryResult();
         RecoveryLocalTransitionService.debugCredentialStorerForTesting =
@@ -240,7 +243,7 @@ void main() {
         var clearedSubject = 0;
 
         RestoreAccountService.debugParticipantStateCleanupForTesting =
-            () async {};
+            (_, _) async {};
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
             (_) async => _successfulRecoveryResult(subjectId: null);
         RecoveryLocalTransitionService.debugCredentialStorerForTesting =
@@ -266,7 +269,7 @@ void main() {
         var credentialStoreCalls = 0;
 
         RestoreAccountService.debugParticipantStateCleanupForTesting =
-            () async {
+            (_, _) async {
               cleanupCalls++;
             };
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
@@ -296,10 +299,16 @@ void main() {
         var credentialStoreCalls = 0;
         var activeSubjectClearCalls = 0;
 
+        String? cleanedUserId;
+        String? cleanedSubjectId;
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
             (_) async => _successfulRecoveryResult();
+        RestoreAccountService.debugCurrentUserIdGetterForTesting = () =>
+            'recovered-user';
         RestoreAccountService.debugParticipantSignInExecutorForTesting =
             (_, _) async => true;
+        RestoreAccountService.debugSubjectValidatorForTesting = (_) async =>
+            true;
         RecoveryLocalTransitionService.debugStoredEmailWriterForTesting =
             (email) async {
               credentialStoreCalls++;
@@ -313,7 +322,11 @@ void main() {
               activeSubjectClearCalls++;
             };
         RestoreAccountService.debugParticipantStateCleanupForTesting =
-            () async => throw Exception('cleanup failed');
+            (recoveredUserId, recoveredSubjectId) {
+              cleanedUserId = recoveredUserId;
+              cleanedSubjectId = recoveredSubjectId;
+              throw Exception('cleanup failed');
+            };
 
         final result = await RestoreAccountService.performRecovery(BigInt.one);
 
@@ -321,54 +334,61 @@ void main() {
         expect(result.error, 'recovery_cleanup_failed');
         expect(credentialStoreCalls, 2);
         expect(activeSubjectClearCalls, 1);
+        expect(cleanedUserId, 'recovered-user');
+        expect(cleanedSubjectId, 'subject-1');
       },
     );
 
-    test('previous credentials are restored when email write throws', () async {
-      final restored = <String>[];
-      var signOutCalls = 0;
-      var validateCalls = 0;
+    test(
+      'snapshot creation failure returns local persistence failure before sign in',
+      () async {
+        var signInCalls = 0;
 
-      RestoreAccountService.debugRecoverAccountExecutorForTesting = (_) async =>
-          _successfulRecoveryResult();
-      RestoreAccountService.debugParticipantSignInExecutorForTesting =
-          (_, _) async => true;
-      RecoveryLocalTransitionService.debugStoredEmailReaderForTesting =
-          () async => 'old@test.local';
-      RecoveryLocalTransitionService.debugStoredPasswordReaderForTesting =
-          () async => 'old-password';
-      RecoveryLocalTransitionService
-          .debugStoredEmailWriterForTesting = (email) async {
-        if (email == 'recovered@test.local') throw Exception('email failed');
-        restored.add('email:$email');
-      };
-      RecoveryLocalTransitionService.debugStoredPasswordWriterForTesting =
-          (password) async {
-            restored.add('password:$password');
-          };
-      RecoveryLocalTransitionService.debugParticipantSignOutExecutorForTesting =
-          () async {
-            signOutCalls++;
-          };
-      RestoreAccountService.debugSubjectValidatorForTesting = (_) async {
-        validateCalls++;
-        return true;
-      };
+        RestoreAccountService.debugRecoverAccountExecutorForTesting =
+            (_) async => _successfulRecoveryResult();
+        RecoveryLocalTransitionService.debugStoredEmailReaderForTesting =
+            () async => throw Exception('email read failed');
+        RestoreAccountService.debugParticipantSignInExecutorForTesting =
+            (_, _) async {
+              signInCalls++;
+              return true;
+            };
 
-      final result = await RestoreAccountService.performRecovery(BigInt.one);
+        final result = await RestoreAccountService.performRecovery(BigInt.one);
 
-      expect(result.success, isFalse);
-      expect(result.error, 'recovery_local_persistence_failed');
-      expect(restored, ['email:old@test.local', 'password:old-password']);
-      expect(signOutCalls, 1);
-      expect(validateCalls, 0);
-    });
+        expect(result.success, isFalse);
+        expect(result.error, 'recovery_local_persistence_failed');
+        expect(signInCalls, 0);
+      },
+    );
 
     test(
-      'previous credentials are restored when password write throws',
+      'password snapshot creation failure returns local persistence failure before sign in',
       () async {
-        final restored = <String>[];
-        var signOutCalls = 0;
+        var signInCalls = 0;
+
+        RestoreAccountService.debugRecoverAccountExecutorForTesting =
+            (_) async => _successfulRecoveryResult();
+        RecoveryLocalTransitionService.debugStoredPasswordReaderForTesting =
+            () async => throw Exception('password read failed');
+        RestoreAccountService.debugParticipantSignInExecutorForTesting =
+            (_, _) async {
+              signInCalls++;
+              return true;
+            };
+
+        final result = await RestoreAccountService.performRecovery(BigInt.one);
+
+        expect(result.success, isFalse);
+        expect(result.error, 'recovery_local_persistence_failed');
+        expect(signInCalls, 0);
+      },
+    );
+
+    test(
+      'cleanup and subject validation are skipped after local transition failure',
+      () async {
+        var cleanupCalls = 0;
         var validateCalls = 0;
 
         RestoreAccountService.debugRecoverAccountExecutorForTesting =
@@ -380,20 +400,13 @@ void main() {
         RecoveryLocalTransitionService.debugStoredPasswordReaderForTesting =
             () async => 'old-password';
         RecoveryLocalTransitionService.debugStoredEmailWriterForTesting =
-            (email) async {
-              restored.add('email:$email');
-            };
+            (_) async {};
         RecoveryLocalTransitionService.debugStoredPasswordWriterForTesting =
-            (password) async {
-              if (password == 'password-1') {
-                throw Exception('password failed');
-              }
-              restored.add('password:$password');
+            (_) => Future<void>.error(Exception('password write failed'));
+        RestoreAccountService.debugParticipantStateCleanupForTesting =
+            (_, _) async {
+              cleanupCalls++;
             };
-        RecoveryLocalTransitionService
-            .debugParticipantSignOutExecutorForTesting = () async {
-          signOutCalls++;
-        };
         RestoreAccountService.debugSubjectValidatorForTesting = (_) async {
           validateCalls++;
           return true;
@@ -403,61 +416,7 @@ void main() {
 
         expect(result.success, isFalse);
         expect(result.error, 'recovery_local_persistence_failed');
-        expect(restored, [
-          'email:recovered@test.local',
-          'email:old@test.local',
-          'password:old-password',
-        ]);
-        expect(signOutCalls, 1);
-        expect(validateCalls, 0);
-      },
-    );
-
-    test(
-      'previous credentials are restored when active subject clear throws',
-      () async {
-        final restored = <String>[];
-        var signOutCalls = 0;
-        var validateCalls = 0;
-
-        RestoreAccountService.debugRecoverAccountExecutorForTesting =
-            (_) async => _successfulRecoveryResult();
-        RestoreAccountService.debugParticipantSignInExecutorForTesting =
-            (_, _) async => true;
-        RecoveryLocalTransitionService.debugStoredEmailReaderForTesting =
-            () async => 'old@test.local';
-        RecoveryLocalTransitionService.debugStoredPasswordReaderForTesting =
-            () async => 'old-password';
-        RecoveryLocalTransitionService.debugStoredEmailWriterForTesting =
-            (email) async {
-              restored.add('email:$email');
-            };
-        RecoveryLocalTransitionService.debugStoredPasswordWriterForTesting =
-            (password) async {
-              restored.add('password:$password');
-            };
-        RecoveryLocalTransitionService.debugActiveSubjectClearerForTesting =
-            () async => throw Exception('clear failed');
-        RecoveryLocalTransitionService
-            .debugParticipantSignOutExecutorForTesting = () async {
-          signOutCalls++;
-        };
-        RestoreAccountService.debugSubjectValidatorForTesting = (_) async {
-          validateCalls++;
-          return true;
-        };
-
-        final result = await RestoreAccountService.performRecovery(BigInt.one);
-
-        expect(result.success, isFalse);
-        expect(result.error, 'recovery_local_persistence_failed');
-        expect(restored, [
-          'email:recovered@test.local',
-          'password:password-1',
-          'email:old@test.local',
-          'password:old-password',
-        ]);
-        expect(signOutCalls, 1);
+        expect(cleanupCalls, 0);
         expect(validateCalls, 0);
       },
     );

--- a/app/test/util/cache_test.dart
+++ b/app/test/util/cache_test.dart
@@ -137,6 +137,56 @@ void main() {
       expect(storage.containsKey(cacheSubjectKey), isTrue);
       expect(storage.containsKey('cache_subject_user-1_subject-1'), isFalse);
     });
+
+    test(
+      'clearRecoverySubjectCaches removes legacy and other-user caches but preserves recovered cache',
+      () async {
+        final recoveredSubject = _subject('subject-1', 'user-1');
+        recoveredSubject.progress = [_progress('subject-1', 1)];
+        final otherSubject = _subject('subject-2', 'user-2');
+        storage[cacheSubjectKey] = jsonEncode(_cachedSubjectJson(otherSubject));
+        storage['cache_subject_user-1_subject-1'] = jsonEncode(
+          _cachedSubjectJson(recoveredSubject),
+        );
+        storage['cache_subject_user-2_subject-2'] = jsonEncode(
+          _cachedSubjectJson(otherSubject),
+        );
+
+        await Cache.clearRecoverySubjectCaches(
+          recoveredUserId: 'user-1',
+          recoveredSubjectId: 'subject-1',
+        );
+
+        expect(storage.containsKey(cacheSubjectKey), isFalse);
+        expect(storage.containsKey('cache_subject_user-2_subject-2'), isFalse);
+        expect(storage.containsKey('cache_subject_user-1_subject-1'), isTrue);
+
+        final loaded = await Cache.loadSubject(backupSubject: recoveredSubject);
+        expect(loaded.progress, hasLength(1));
+      },
+    );
+
+    test(
+      'clearRecoverySubjectCaches preserves no cache when recovered subject is missing',
+      () async {
+        storage[cacheSubjectKey] = jsonEncode(
+          _cachedSubjectJson(_subject('subject-legacy', 'user-legacy')),
+        );
+        storage['cache_subject_user-1_subject-1'] = jsonEncode(
+          _cachedSubjectJson(_subject('subject-1', 'user-1')),
+        );
+        storage['cache_subject_user-2_subject-2'] = jsonEncode(
+          _cachedSubjectJson(_subject('subject-2', 'user-2')),
+        );
+
+        await Cache.clearRecoverySubjectCaches(
+          recoveredUserId: 'user-1',
+          recoveredSubjectId: null,
+        );
+
+        expect(storage, isEmpty);
+      },
+    );
   });
 }
 

--- a/app/test/util/cache_test.dart
+++ b/app/test/util/cache_test.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/util/cache.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+
+void main() {
+  group('Cache', () {
+    late Map<String, String> storage;
+
+    setUp(() {
+      storage = {};
+      Cache.debugContainsKeyForTesting = (key) =>
+          Future.value(storage.containsKey(key));
+      Cache.debugReadValueForTesting = (key) => Future.value(storage[key]);
+      Cache.debugWriteValueForTesting = (key, value) async {
+        storage[key] = value;
+      };
+      Cache.debugDeleteValueForTesting = (key) async {
+        storage.remove(key);
+      };
+      Cache.debugReadAllValuesForTesting = () =>
+          Future.value(Map<String, String>.from(storage));
+      Cache.debugCurrentUserIdGetterForTesting = () => 'user-1';
+      Cache.debugActiveSubjectIdGetterForTesting = () =>
+          Future.value('subject-1');
+    });
+
+    tearDown(Cache.debugResetTestingOverrides);
+
+    test('correct user and subject cache is accepted', () async {
+      final subject = _subject('subject-1', 'user-1');
+      storage['cache_subject_user-1_subject-1'] = jsonEncode(
+        _cachedSubjectJson(subject),
+      );
+
+      final loaded = await Cache.loadSubject(backupSubject: subject);
+
+      expect(loaded.id, 'subject-1');
+      expect(loaded.userId, 'user-1');
+    });
+
+    test('different user cache is rejected', () {
+      storage['cache_subject_user-1_subject-1'] = jsonEncode(
+        _cachedSubjectJson(_subject('subject-1', 'user-2')),
+      );
+
+      expect(
+        () => Cache.loadSubject(backupSubject: _subject('subject-1', 'user-1')),
+        throwsException,
+      );
+    });
+
+    test('same user but different subject cache is rejected', () {
+      storage['cache_subject_user-1_subject-1'] = jsonEncode(
+        _cachedSubjectJson(_subject('subject-2', 'user-1')),
+      );
+
+      expect(
+        () => Cache.loadSubject(backupSubject: _subject('subject-1', 'user-1')),
+        throwsException,
+      );
+    });
+
+    test('matching legacy cache is migrated to scoped key', () async {
+      final subject = _subject('subject-1', 'user-1');
+      storage[cacheSubjectKey] = jsonEncode(_cachedSubjectJson(subject));
+
+      final loaded = await Cache.loadSubject(backupSubject: subject);
+
+      expect(loaded.id, 'subject-1');
+      expect(storage.containsKey(cacheSubjectKey), isFalse);
+      expect(storage.containsKey('cache_subject_user-1_subject-1'), isTrue);
+    });
+
+    test(
+      'mismatched legacy cache is never merged into remote subject',
+      () async {
+        final remoteSubject = _subject('subject-1', 'user-1');
+        remoteSubject.progress = [_progress('subject-1', 1)];
+        final cachedSubject = _subject('subject-2', 'user-1');
+        cachedSubject.progress = [_progress('subject-2', 2)];
+        storage[cacheSubjectKey] = jsonEncode(
+          _cachedSubjectJson(cachedSubject),
+        );
+
+        final synchronized = await Cache.synchronize(remoteSubject);
+
+        expect(synchronized.progress, hasLength(1));
+        expect(storage.containsKey(cacheSubjectKey), isFalse);
+      },
+    );
+
+    test('parsed mismatched cache is rejected', () {
+      storage[cacheSubjectKey] = jsonEncode(
+        _cachedSubjectJson(_subject('subject-2', 'user-1')),
+      );
+
+      expect(
+        () => Cache.loadSubject(backupSubject: _subject('subject-1', 'user-1')),
+        throwsException,
+      );
+    });
+  });
+}
+
+StudySubject _subject(String subjectId, String userId) {
+  final subject = StudySubject(subjectId, 'study-1', userId, const []);
+  subject.startedAt = DateTime.utc(2026);
+  subject.study = Study('study-1', 'owner-1');
+  return subject;
+}
+
+SubjectProgress _progress(String subjectId, int day) {
+  return SubjectProgress(
+    subjectId: subjectId,
+    interventionId: 'intervention-1',
+    taskId: 'task-1',
+    resultType: 'bool',
+    result: Result<bool>('bool')..result = true,
+  )..completedAt = DateTime.utc(2026, 1, day);
+}
+
+Map<String, dynamic> _cachedSubjectJson(StudySubject subject) {
+  return subject.toFullJson();
+}

--- a/app/test/util/cache_test.dart
+++ b/app/test/util/cache_test.dart
@@ -102,6 +102,41 @@ void main() {
         throwsException,
       );
     });
+
+    test(
+      'storeSubject works before active subject id is stored during kickoff',
+      () async {
+        Cache.debugActiveSubjectIdGetterForTesting = () =>
+            Future<String?>.value();
+        final subject = _subject('subject-1', 'user-1');
+
+        await Cache.storeSubject(subject);
+
+        expect(storage.containsKey('cache_subject_user-1_subject-1'), isTrue);
+      },
+    );
+
+    test('successful legacy migration deletes legacy key', () async {
+      final subject = _subject('subject-1', 'user-1');
+      storage[cacheSubjectKey] = jsonEncode(_cachedSubjectJson(subject));
+
+      await Cache.loadSubject(backupSubject: subject);
+
+      expect(storage.containsKey(cacheSubjectKey), isFalse);
+      expect(storage.containsKey('cache_subject_user-1_subject-1'), isTrue);
+    });
+
+    test('failed scoped write preserves legacy key', () {
+      final subject = _subject('subject-1', 'user-1');
+      storage[cacheSubjectKey] = jsonEncode(_cachedSubjectJson(subject));
+      Cache.debugWriteValueForTesting = (key, value) {
+        throw Exception('write failed');
+      };
+
+      expect(() => Cache.loadSubject(backupSubject: subject), throwsException);
+      expect(storage.containsKey(cacheSubjectKey), isTrue);
+      expect(storage.containsKey('cache_subject_user-1_subject-1'), isFalse);
+    });
   });
 }
 

--- a/app/test/util/fitbit_handler_test.dart
+++ b/app/test/util/fitbit_handler_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/util/fitbit_handler.dart';
+
+void main() {
+  group('FitbitHandler', () {
+    test('discards legacy credentials when authenticated user is present', () {
+      expect(
+        FitbitHandler.shouldDiscardLegacyCredentialsForAuthenticatedUser(
+          'user-1',
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'keeps legacy credentials available before authentication is restored',
+      () {
+        expect(
+          FitbitHandler.shouldDiscardLegacyCredentialsForAuthenticatedUser(
+            null,
+          ),
+          isFalse,
+        );
+      },
+    );
+  });
+}

--- a/app/test/util/fitbit_handler_test.dart
+++ b/app/test/util/fitbit_handler_test.dart
@@ -60,6 +60,20 @@ void main() {
       );
     });
 
+    test('server credentials are returned when local caching throws', () async {
+      FitbitHandler.debugServerCredentialsLoaderForTesting =
+          ({required userId, required studyKey}) async => serverCredentials;
+      FitbitHandler.debugWriteLocalValueForTesting = (key, value) {
+        throw Exception('local cache failed');
+      };
+
+      final loaded = await FitbitHandler.debugLoadCredentialsForTesting(
+        'study-1',
+      );
+
+      expect(loaded?.userID, 'server-user');
+    });
+
     test(
       'server returns no row so scoped local credentials are used',
       () async {
@@ -116,6 +130,61 @@ void main() {
       },
     );
 
+    test('server upsert still occurs when local writing throws', () async {
+      var upsertCalls = 0;
+      FitbitHandler.debugWriteLocalValueForTesting = (key, value) {
+        throw Exception('local failed');
+      };
+      FitbitHandler.debugServerCredentialsUpserterForTesting =
+          ({
+            required userId,
+            required studyKey,
+            required credentialsJson,
+          }) async {
+            upsertCalls++;
+          };
+
+      await FitbitHandler.debugStoreCredentialsForTesting(
+        scopedCredentials,
+        'study-1',
+      );
+
+      expect(upsertCalls, 1);
+    });
+
+    test(
+      'both storage failures are surfaced without exposing tokens',
+      () async {
+        FitbitHandler.debugWriteLocalValueForTesting = (key, value) {
+          throw Exception('local failed');
+        };
+        FitbitHandler.debugServerCredentialsUpserterForTesting =
+            ({
+              required userId,
+              required studyKey,
+              required credentialsJson,
+            }) async => throw Exception('server failed');
+
+        try {
+          await FitbitHandler.debugStoreCredentialsForTesting(
+            scopedCredentials,
+            'study-1',
+          );
+          fail('Expected storage failure');
+        } catch (e) {
+          expect(e, isA<FitbitCredentialStorageException>());
+          expect(
+            e.toString(),
+            isNot(contains(scopedCredentials.fitbitAccessToken)),
+          );
+          expect(
+            e.toString(),
+            isNot(contains(scopedCredentials.fitbitRefreshToken)),
+          );
+        }
+      },
+    );
+
     test(
       'authenticated users never consume legacy unscoped credentials',
       () async {
@@ -160,6 +229,21 @@ void main() {
 
       expect(storage, isEmpty);
     });
+
+    test(
+      'clear local fallback for study can fail after remote deletion',
+      () async {
+        storage['fitbit_credentials_user-1_study-1'] = 'one';
+        FitbitHandler.debugDeleteLocalValueForTesting = (key) {
+          throw Exception('local delete failed');
+        };
+
+        await expectLater(
+          () => FitbitHandler.clearLocalFallbackCredentialsForStudy('study-1'),
+          throwsA(isA<FitbitCredentialDeletionException>()),
+        );
+      },
+    );
   });
 }
 

--- a/app/test/util/fitbit_handler_test.dart
+++ b/app/test/util/fitbit_handler_test.dart
@@ -1,27 +1,172 @@
+import 'dart:convert';
+
+import 'package:fitbitter/fitbitter.dart' as fitbitter;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:studyu_app/util/fitbit_handler.dart';
 
 void main() {
   group('FitbitHandler', () {
-    test('discards legacy credentials when authenticated user is present', () {
+    late Map<String, String> storage;
+    late fitbitter.FitbitCredentials serverCredentials;
+    late fitbitter.FitbitCredentials scopedCredentials;
+
+    setUp(() {
+      storage = {};
+      serverCredentials = _credentials('server-user');
+      scopedCredentials = _credentials('local-user');
+
+      FitbitHandler.debugCurrentUserIdGetterForTesting = () => 'user-1';
+      FitbitHandler.debugReadLocalValueForTesting = (key) async => storage[key];
+      FitbitHandler.debugWriteLocalValueForTesting = (key, value) async {
+        storage[key] = value;
+      };
+      FitbitHandler.debugDeleteLocalValueForTesting = (key) async {
+        storage.remove(key);
+      };
+      FitbitHandler.debugContainsLocalKeyForTesting = (key) async =>
+          storage.containsKey(key);
+      FitbitHandler.debugReadAllLocalValuesForTesting = () async =>
+          Map<String, String>.from(storage);
+      FitbitHandler.debugServerCredentialsLoaderForTesting =
+          ({required userId, required studyKey}) async => null;
+      FitbitHandler.debugServerCredentialsUpserterForTesting =
+          ({
+            required userId,
+            required studyKey,
+            required credentialsJson,
+          }) async {};
+      FitbitHandler.debugServerCredentialsDeleterForTesting =
+          ({required userId, required studyKey}) async {};
+    });
+
+    tearDown(FitbitHandler.debugResetTestingOverrides);
+
+    test('server credentials are preferred and cached locally', () async {
+      FitbitHandler.debugServerCredentialsLoaderForTesting =
+          ({required userId, required studyKey}) async => serverCredentials;
+
+      final loaded = await FitbitHandler.debugLoadCredentialsForTesting(
+        'study-1',
+      );
+
+      expect(loaded?.userID, 'server-user');
       expect(
-        FitbitHandler.shouldDiscardLegacyCredentialsForAuthenticatedUser(
-          'user-1',
-        ),
-        isTrue,
+        storage['fitbit_credentials_user-1_study-1'],
+        jsonEncode({
+          'userID': 'server-user',
+          'fitbitAccessToken': 'access-server-user',
+          'fitbitRefreshToken': 'refresh-server-user',
+        }),
       );
     });
 
     test(
-      'keeps legacy credentials available before authentication is restored',
-      () {
+      'server returns no row so scoped local credentials are used',
+      () async {
+        storage['fitbit_credentials_user-1_study-1'] = jsonEncode({
+          'userID': scopedCredentials.userID,
+          'fitbitAccessToken': scopedCredentials.fitbitAccessToken,
+          'fitbitRefreshToken': scopedCredentials.fitbitRefreshToken,
+        });
+
+        final loaded = await FitbitHandler.debugLoadCredentialsForTesting(
+          'study-1',
+        );
+
+        expect(loaded?.userID, 'local-user');
+      },
+    );
+
+    test('server read throws so scoped local credentials are used', () async {
+      storage['fitbit_credentials_user-1_study-1'] = jsonEncode({
+        'userID': scopedCredentials.userID,
+        'fitbitAccessToken': scopedCredentials.fitbitAccessToken,
+        'fitbitRefreshToken': scopedCredentials.fitbitRefreshToken,
+      });
+      FitbitHandler.debugServerCredentialsLoaderForTesting =
+          ({required userId, required studyKey}) async =>
+              throw Exception('network');
+
+      final loaded = await FitbitHandler.debugLoadCredentialsForTesting(
+        'study-1',
+      );
+
+      expect(loaded?.userID, 'local-user');
+    });
+
+    test(
+      'server upsert throws but scoped local credentials are still stored',
+      () async {
+        FitbitHandler.debugServerCredentialsUpserterForTesting =
+            ({
+              required userId,
+              required studyKey,
+              required credentialsJson,
+            }) async => throw Exception('server down');
+
+        await FitbitHandler.debugStoreCredentialsForTesting(
+          scopedCredentials,
+          'study-1',
+        );
+
         expect(
-          FitbitHandler.shouldDiscardLegacyCredentialsForAuthenticatedUser(
-            null,
-          ),
-          isFalse,
+          storage.containsKey('fitbit_credentials_user-1_study-1'),
+          isTrue,
         );
       },
     );
+
+    test(
+      'authenticated users never consume legacy unscoped credentials',
+      () async {
+        storage['fitbit_credentials_study-1'] = jsonEncode({
+          'userID': 'legacy-user',
+          'fitbitAccessToken': 'legacy-access',
+          'fitbitRefreshToken': 'legacy-refresh',
+        });
+
+        final loaded = await FitbitHandler.debugLoadCredentialsForTesting(
+          'study-1',
+        );
+
+        expect(loaded, isNull);
+        expect(storage.containsKey('fitbit_credentials_study-1'), isFalse);
+      },
+    );
+
+    test(
+      'participant A scoped value is never returned for participant B',
+      () async {
+        storage['fitbit_credentials_user-a_study-1'] = jsonEncode({
+          'userID': 'participant-a',
+          'fitbitAccessToken': 'access-a',
+          'fitbitRefreshToken': 'refresh-a',
+        });
+
+        final loaded = await FitbitHandler.debugLoadCredentialsForTesting(
+          'study-1',
+        );
+
+        expect(loaded, isNull);
+      },
+    );
+
+    test('local cleanup removes participant fitbit fallback keys', () async {
+      storage['fitbit_credentials_user-1_study-1'] = 'one';
+      storage['fitbit_credentials_user-2_study-2'] = 'two';
+      storage['fitbit_credentials_study-3'] = 'three';
+
+      await FitbitHandler.clearLocalFallbackCredentials();
+
+      expect(storage, isEmpty);
+    });
   });
+}
+
+fitbitter.FitbitCredentials _credentials(String userId) {
+  return fitbitter.FitbitCredentials(
+    userID: userId,
+    fitbitAccessToken: 'access-$userId',
+    fitbitRefreshToken: 'refresh-$userId',
+  );
 }

--- a/app/test/util/fitbit_handler_test.dart
+++ b/app/test/util/fitbit_handler_test.dart
@@ -1,242 +1,46 @@
-import 'dart:convert';
-
-import 'package:fitbitter/fitbitter.dart' as fitbitter;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/services/participant_fitbit_credentials_service.dart';
 import 'package:studyu_app/util/fitbit_handler.dart';
 
 void main() {
   group('FitbitHandler', () {
-    late Map<String, String> storage;
-    late fitbitter.FitbitCredentials serverCredentials;
-    late fitbitter.FitbitCredentials scopedCredentials;
-
-    setUp(() {
-      storage = {};
-      serverCredentials = _credentials('server-user');
-      scopedCredentials = _credentials('local-user');
-
-      FitbitHandler.debugCurrentUserIdGetterForTesting = () => 'user-1';
-      FitbitHandler.debugReadLocalValueForTesting = (key) async => storage[key];
-      FitbitHandler.debugWriteLocalValueForTesting = (key, value) async {
-        storage[key] = value;
-      };
-      FitbitHandler.debugDeleteLocalValueForTesting = (key) async {
-        storage.remove(key);
-      };
-      FitbitHandler.debugContainsLocalKeyForTesting = (key) async =>
-          storage.containsKey(key);
-      FitbitHandler.debugReadAllLocalValuesForTesting = () async =>
-          Map<String, String>.from(storage);
-      FitbitHandler.debugServerCredentialsLoaderForTesting =
-          ({required userId, required studyKey}) async => null;
-      FitbitHandler.debugServerCredentialsUpserterForTesting =
-          ({
-            required userId,
-            required studyKey,
-            required credentialsJson,
-          }) async {};
-      FitbitHandler.debugServerCredentialsDeleterForTesting =
-          ({required userId, required studyKey}) async {};
-    });
-
-    tearDown(FitbitHandler.debugResetTestingOverrides);
-
-    test('server credentials are preferred and cached locally', () async {
-      FitbitHandler.debugServerCredentialsLoaderForTesting =
-          ({required userId, required studyKey}) async => serverCredentials;
-
-      final loaded = await FitbitHandler.debugLoadCredentialsForTesting(
-        'study-1',
-      );
-
-      expect(loaded?.userID, 'server-user');
-      expect(
-        storage['fitbit_credentials_user-1_study-1'],
-        jsonEncode({
-          'userID': 'server-user',
-          'fitbitAccessToken': 'access-server-user',
-          'fitbitRefreshToken': 'refresh-server-user',
-        }),
-      );
-    });
-
-    test('server credentials are returned when local caching throws', () async {
-      FitbitHandler.debugServerCredentialsLoaderForTesting =
-          ({required userId, required studyKey}) async => serverCredentials;
-      FitbitHandler.debugWriteLocalValueForTesting = (key, value) {
-        throw Exception('local cache failed');
-      };
-
-      final loaded = await FitbitHandler.debugLoadCredentialsForTesting(
-        'study-1',
-      );
-
-      expect(loaded?.userID, 'server-user');
-    });
+    tearDown(ParticipantFitbitCredentialsService.debugResetTestingOverrides);
 
     test(
-      'server returns no row so scoped local credentials are used',
+      'clearLocalFallbackCredentials delegates to participant service',
       () async {
-        storage['fitbit_credentials_user-1_study-1'] = jsonEncode({
-          'userID': scopedCredentials.userID,
-          'fitbitAccessToken': scopedCredentials.fitbitAccessToken,
-          'fitbitRefreshToken': scopedCredentials.fitbitRefreshToken,
-        });
+        final deletedKeys = <String>[];
+        ParticipantFitbitCredentialsService.debugReadAllLocalValuesForTesting =
+            () async => {
+              'fitbit_credentials_user-1_study-1': 'one',
+              'fitbit_credentials_study-2': 'two',
+            };
+        ParticipantFitbitCredentialsService.debugDeleteLocalValueForTesting =
+            (key) async {
+              deletedKeys.add(key);
+            };
 
-        final loaded = await FitbitHandler.debugLoadCredentialsForTesting(
-          'study-1',
-        );
-
-        expect(loaded?.userID, 'local-user');
-      },
-    );
-
-    test('server read throws so scoped local credentials are used', () async {
-      storage['fitbit_credentials_user-1_study-1'] = jsonEncode({
-        'userID': scopedCredentials.userID,
-        'fitbitAccessToken': scopedCredentials.fitbitAccessToken,
-        'fitbitRefreshToken': scopedCredentials.fitbitRefreshToken,
-      });
-      FitbitHandler.debugServerCredentialsLoaderForTesting =
-          ({required userId, required studyKey}) async =>
-              throw Exception('network');
-
-      final loaded = await FitbitHandler.debugLoadCredentialsForTesting(
-        'study-1',
-      );
-
-      expect(loaded?.userID, 'local-user');
-    });
-
-    test(
-      'server upsert throws but scoped local credentials are still stored',
-      () async {
-        FitbitHandler.debugServerCredentialsUpserterForTesting =
-            ({
-              required userId,
-              required studyKey,
-              required credentialsJson,
-            }) async => throw Exception('server down');
-
-        await FitbitHandler.debugStoreCredentialsForTesting(
-          scopedCredentials,
-          'study-1',
-        );
+        await FitbitHandler.clearLocalFallbackCredentials();
 
         expect(
-          storage.containsKey('fitbit_credentials_user-1_study-1'),
-          isTrue,
+          deletedKeys,
+          containsAll([
+            'fitbit_credentials_user-1_study-1',
+            'fitbit_credentials_study-2',
+          ]),
         );
       },
     );
 
-    test('server upsert still occurs when local writing throws', () async {
-      var upsertCalls = 0;
-      FitbitHandler.debugWriteLocalValueForTesting = (key, value) {
-        throw Exception('local failed');
-      };
-      FitbitHandler.debugServerCredentialsUpserterForTesting =
-          ({
-            required userId,
-            required studyKey,
-            required credentialsJson,
-          }) async {
-            upsertCalls++;
-          };
-
-      await FitbitHandler.debugStoreCredentialsForTesting(
-        scopedCredentials,
-        'study-1',
-      );
-
-      expect(upsertCalls, 1);
-    });
-
     test(
-      'both storage failures are surfaced without exposing tokens',
+      'clearLocalFallbackCredentialsForStudy forwards typed failure',
       () async {
-        FitbitHandler.debugWriteLocalValueForTesting = (key, value) {
-          throw Exception('local failed');
-        };
-        FitbitHandler.debugServerCredentialsUpserterForTesting =
-            ({
-              required userId,
-              required studyKey,
-              required credentialsJson,
-            }) async => throw Exception('server failed');
-
-        try {
-          await FitbitHandler.debugStoreCredentialsForTesting(
-            scopedCredentials,
-            'study-1',
-          );
-          fail('Expected storage failure');
-        } catch (e) {
-          expect(e, isA<FitbitCredentialStorageException>());
-          expect(
-            e.toString(),
-            isNot(contains(scopedCredentials.fitbitAccessToken)),
-          );
-          expect(
-            e.toString(),
-            isNot(contains(scopedCredentials.fitbitRefreshToken)),
-          );
-        }
-      },
-    );
-
-    test(
-      'authenticated users never consume legacy unscoped credentials',
-      () async {
-        storage['fitbit_credentials_study-1'] = jsonEncode({
-          'userID': 'legacy-user',
-          'fitbitAccessToken': 'legacy-access',
-          'fitbitRefreshToken': 'legacy-refresh',
-        });
-
-        final loaded = await FitbitHandler.debugLoadCredentialsForTesting(
-          'study-1',
-        );
-
-        expect(loaded, isNull);
-        expect(storage.containsKey('fitbit_credentials_study-1'), isFalse);
-      },
-    );
-
-    test(
-      'participant A scoped value is never returned for participant B',
-      () async {
-        storage['fitbit_credentials_user-a_study-1'] = jsonEncode({
-          'userID': 'participant-a',
-          'fitbitAccessToken': 'access-a',
-          'fitbitRefreshToken': 'refresh-a',
-        });
-
-        final loaded = await FitbitHandler.debugLoadCredentialsForTesting(
-          'study-1',
-        );
-
-        expect(loaded, isNull);
-      },
-    );
-
-    test('local cleanup removes participant fitbit fallback keys', () async {
-      storage['fitbit_credentials_user-1_study-1'] = 'one';
-      storage['fitbit_credentials_user-2_study-2'] = 'two';
-      storage['fitbit_credentials_study-3'] = 'three';
-
-      await FitbitHandler.clearLocalFallbackCredentials();
-
-      expect(storage, isEmpty);
-    });
-
-    test(
-      'clear local fallback for study can fail after remote deletion',
-      () async {
-        storage['fitbit_credentials_user-1_study-1'] = 'one';
-        FitbitHandler.debugDeleteLocalValueForTesting = (key) {
-          throw Exception('local delete failed');
-        };
+        ParticipantFitbitCredentialsService.debugCurrentUserIdGetterForTesting =
+            () => 'user-1';
+        ParticipantFitbitCredentialsService.debugContainsLocalKeyForTesting =
+            (key) async => true;
+        ParticipantFitbitCredentialsService.debugDeleteLocalValueForTesting =
+            (key) async => throw Exception('local delete failed');
 
         await expectLater(
           () => FitbitHandler.clearLocalFallbackCredentialsForStudy('study-1'),
@@ -245,12 +49,4 @@ void main() {
       },
     );
   });
-}
-
-fitbitter.FitbitCredentials _credentials(String userId) {
-  return fitbitter.FitbitCredentials(
-    userID: userId,
-    fitbitAccessToken: 'access-$userId',
-    fitbitRefreshToken: 'refresh-$userId',
-  );
 }

--- a/flutter_common/lib/src/utils/localization.dart
+++ b/flutter_common/lib/src/utils/localization.dart
@@ -1,10 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/src/utils/storage.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class AppLanguage extends ChangeNotifier {
   static const String keyLanguageCode = 'language_code';
   final List<Locale> supportedLocales;
   Locale? _appLocale;
+  static bool Function() _hasAuthenticatedUser = _defaultHasAuthenticatedUser;
+  static Future<String?> Function() _localLanguageReader = _readLocalLanguage;
+  static Future<void> Function(String) _localLanguageWriter =
+      _writeLocalLanguage;
+  static Future<void> Function() _localLanguageClearer = _clearLocalLanguage;
+  static Future<StudyUUser?> Function() _currentUserLoader =
+      _loadCurrentUserFromServer;
+  static Future<void> Function(String) _languageSaver = _saveLanguageToServer;
 
   AppLanguage(this.supportedLocales) : super() {
     fetchLocale();
@@ -13,20 +23,180 @@ class AppLanguage extends ChangeNotifier {
   Locale? get appLocal => _appLocale;
 
   Future<void> fetchLocale() async {
-    final languageCode = await SecureStorage.read('language_code');
-    _appLocale = languageCode != null ? Locale(languageCode) : null;
+    final languageCode = await _localLanguageReader();
+    _appLocale = _resolveSupportedLocale(languageCode);
     notifyListeners();
+    await syncWithAuthenticatedUser();
   }
 
   Future<void> changeLanguage(Locale? locale) async {
     if (_appLocale == locale) return;
     if (locale == null || !supportedLocales.contains(locale)) {
       _appLocale = null;
-      await SecureStorage.delete(keyLanguageCode);
+      await _localLanguageClearer();
     } else {
       _appLocale = locale;
-      await SecureStorage.write(keyLanguageCode, locale.languageCode);
+      await _localLanguageWriter(locale.languageCode);
     }
+
+    if (_hasAuthenticatedUser()) {
+      try {
+        await _languageSaver(_appLocale?.languageCode ?? '');
+      } catch (e) {
+        StudyULogger.warning('Failed to persist app language on server: $e');
+      }
+    }
+
     notifyListeners();
+  }
+
+  Future<void> syncWithAuthenticatedUser() async {
+    if (!_hasAuthenticatedUser()) return;
+
+    try {
+      final user = await _currentUserLoader();
+      final remoteLocale = _resolveSupportedLocale(user?.preferences.language);
+      if (remoteLocale == null || _appLocale == remoteLocale) return;
+
+      _appLocale = remoteLocale;
+      await _localLanguageWriter(remoteLocale.languageCode);
+      notifyListeners();
+    } catch (e) {
+      StudyULogger.warning('Failed to hydrate app language from server: $e');
+    }
+  }
+
+  Locale? _resolveSupportedLocale(String? languageCode) {
+    final normalized = languageCode?.trim().toLowerCase();
+    if (normalized == null || normalized.isEmpty) return null;
+
+    for (final locale in supportedLocales) {
+      if (locale.toLanguageTag().toLowerCase() == normalized ||
+          locale.languageCode.toLowerCase() == normalized) {
+        return locale;
+      }
+    }
+    return null;
+  }
+
+  static Future<StudyUUser?> _loadCurrentUserFromServer() async {
+    final userId = Supabase.instance.client.auth.currentUser?.id;
+    if (userId == null) return null;
+    return await SupabaseQuery.getById<StudyUUser>(userId);
+  }
+
+  static Future<void> _saveLanguageToServer(String languageCode) async {
+    final user = await _loadCurrentUserFromServer();
+    if (user == null) return;
+    user.preferences.language = languageCode;
+    await user.save(onlyUpdate: true);
+  }
+
+  static Future<String?> _readLocalLanguage() async {
+    return await SecureStorage.read(keyLanguageCode);
+  }
+
+  static bool _defaultHasAuthenticatedUser() {
+    return Supabase.instance.client.auth.currentUser != null;
+  }
+
+  static Future<void> _writeLocalLanguage(String languageCode) async {
+    await SecureStorage.write(keyLanguageCode, languageCode);
+  }
+
+  static Future<void> _clearLocalLanguage() async {
+    await SecureStorage.delete(keyLanguageCode);
+  }
+
+  @visibleForTesting
+  static bool Function() get debugHasAuthenticatedUserForTesting =>
+      _hasAuthenticatedUser;
+
+  @visibleForTesting
+  static set debugHasAuthenticatedUserForTesting(bool Function() checker) {
+    _hasAuthenticatedUser = checker;
+  }
+
+  @visibleForTesting
+  static void debugResetHasAuthenticatedUserForTesting() {
+    _hasAuthenticatedUser = _defaultHasAuthenticatedUser;
+  }
+
+  @visibleForTesting
+  static Future<String?> Function() get debugLocalLanguageReaderForTesting =>
+      _localLanguageReader;
+
+  @visibleForTesting
+  static set debugLocalLanguageReaderForTesting(
+    Future<String?> Function() reader,
+  ) {
+    _localLanguageReader = reader;
+  }
+
+  @visibleForTesting
+  static void debugResetLocalLanguageReaderForTesting() {
+    _localLanguageReader = _readLocalLanguage;
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String) get debugLocalLanguageWriterForTesting =>
+      _localLanguageWriter;
+
+  @visibleForTesting
+  static set debugLocalLanguageWriterForTesting(
+    Future<void> Function(String) writer,
+  ) {
+    _localLanguageWriter = writer;
+  }
+
+  @visibleForTesting
+  static void debugResetLocalLanguageWriterForTesting() {
+    _localLanguageWriter = _writeLocalLanguage;
+  }
+
+  @visibleForTesting
+  static Future<void> Function() get debugLocalLanguageClearerForTesting =>
+      _localLanguageClearer;
+
+  @visibleForTesting
+  static set debugLocalLanguageClearerForTesting(
+    Future<void> Function() clearer,
+  ) {
+    _localLanguageClearer = clearer;
+  }
+
+  @visibleForTesting
+  static void debugResetLocalLanguageClearerForTesting() {
+    _localLanguageClearer = _clearLocalLanguage;
+  }
+
+  @visibleForTesting
+  static Future<StudyUUser?> Function() get debugCurrentUserLoaderForTesting =>
+      _currentUserLoader;
+
+  @visibleForTesting
+  static set debugCurrentUserLoaderForTesting(
+    Future<StudyUUser?> Function() loader,
+  ) {
+    _currentUserLoader = loader;
+  }
+
+  @visibleForTesting
+  static void debugResetCurrentUserLoaderForTesting() {
+    _currentUserLoader = _loadCurrentUserFromServer;
+  }
+
+  @visibleForTesting
+  static Future<void> Function(String) get debugLanguageSaverForTesting =>
+      _languageSaver;
+
+  @visibleForTesting
+  static set debugLanguageSaverForTesting(Future<void> Function(String) saver) {
+    _languageSaver = saver;
+  }
+
+  @visibleForTesting
+  static void debugResetLanguageSaverForTesting() {
+    _languageSaver = _saveLanguageToServer;
   }
 }

--- a/flutter_common/lib/src/utils/localization.dart
+++ b/flutter_common/lib/src/utils/localization.dart
@@ -15,6 +15,7 @@ class AppLanguage extends ChangeNotifier {
   static Future<StudyUUser?> Function() _currentUserLoader =
       _loadCurrentUserFromServer;
   static Future<void> Function(String) _languageSaver = _saveLanguageToServer;
+  static Future<void> Function(StudyUUser) _userSaver = _persistUserToServer;
 
   AppLanguage(this.supportedLocales) : super() {
     fetchLocale();
@@ -86,9 +87,13 @@ class AppLanguage extends ChangeNotifier {
   }
 
   static Future<void> _saveLanguageToServer(String languageCode) async {
-    final user = await _loadCurrentUserFromServer();
+    final user = await _currentUserLoader();
     if (user == null) return;
     user.preferences.language = languageCode;
+    await _userSaver(user);
+  }
+
+  static Future<void> _persistUserToServer(StudyUUser user) async {
     await user.save(onlyUpdate: true);
   }
 
@@ -198,5 +203,19 @@ class AppLanguage extends ChangeNotifier {
   @visibleForTesting
   static void debugResetLanguageSaverForTesting() {
     _languageSaver = _saveLanguageToServer;
+  }
+
+  @visibleForTesting
+  static Future<void> Function(StudyUUser) get debugUserSaverForTesting =>
+      _userSaver;
+
+  @visibleForTesting
+  static set debugUserSaverForTesting(Future<void> Function(StudyUUser) saver) {
+    _userSaver = saver;
+  }
+
+  @visibleForTesting
+  static void debugResetUserSaverForTesting() {
+    _userSaver = _persistUserToServer;
   }
 }

--- a/flutter_common/lib/src/utils/storage.dart
+++ b/flutter_common/lib/src/utils/storage.dart
@@ -84,6 +84,12 @@ class SecureStorage {
     });
   }
 
+  static Future<Map<String, String>> readAll() async {
+    return await storageLock.synchronized(() async {
+      return await storage.readAll();
+    });
+  }
+
   /// Migrates all non-null key-value pairs from SharedPreferences to FlutterSecureStorage.
   ///
   /// This function retrieves all keys from SharedPreferences, reads the corresponding values,

--- a/flutter_common/lib/src/utils/user.dart
+++ b/flutter_common/lib/src/utils/user.dart
@@ -91,6 +91,13 @@ Future<void> deleteLocalData() async {
   await SecureStorage.delete(userPasswordKey);
   await SecureStorage.delete(selectedSubjectIdKey);
   await SecureStorage.delete(cacheSubjectKey);
+
+  final storedValues = await SecureStorage.readAll();
+  for (final key in storedValues.keys) {
+    if (key.startsWith('${cacheSubjectKey}_')) {
+      await SecureStorage.delete(key);
+    }
+  }
 }
 
 void previewSubjectIdKey() {

--- a/flutter_common/test/localization_test.dart
+++ b/flutter_common/test/localization_test.dart
@@ -12,6 +12,7 @@ void main() {
       AppLanguage.debugResetLocalLanguageClearerForTesting();
       AppLanguage.debugResetCurrentUserLoaderForTesting();
       AppLanguage.debugResetLanguageSaverForTesting();
+      AppLanguage.debugResetUserSaverForTesting();
     });
 
     test(
@@ -64,5 +65,36 @@ void main() {
       expect(localLanguage, 'de');
       expect(savedLanguages, ['de']);
     });
+
+    test(
+      'changing language preserves pinned studies and study filtering',
+      () async {
+        final savedUsers = <StudyUUser>[];
+        final existingUser = StudyUUser(
+          id: 'user-1',
+          email: 'user@test.local',
+          preferences: Preferences(
+            language: 'en',
+            pinnedStudies: {'study-a'},
+            studyFiltering: {'status': 'active'},
+          ),
+        );
+
+        AppLanguage.debugHasAuthenticatedUserForTesting = () => false;
+        AppLanguage.debugCurrentUserLoaderForTesting = () async => existingUser;
+        AppLanguage.debugUserSaverForTesting = (user) async {
+          savedUsers.add(user);
+        };
+
+        await AppLanguage.debugLanguageSaverForTesting('de');
+
+        expect(savedUsers, hasLength(1));
+        expect(savedUsers.single.preferences.language, 'de');
+        expect(savedUsers.single.preferences.pinnedStudies, {'study-a'});
+        expect(savedUsers.single.preferences.studyFiltering, {
+          'status': 'active',
+        });
+      },
+    );
   });
 }

--- a/flutter_common/test/localization_test.dart
+++ b/flutter_common/test/localization_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/src/utils/localization.dart';
+
+void main() {
+  group('AppLanguage', () {
+    tearDown(() {
+      AppLanguage.debugResetHasAuthenticatedUserForTesting();
+      AppLanguage.debugResetLocalLanguageReaderForTesting();
+      AppLanguage.debugResetLocalLanguageWriterForTesting();
+      AppLanguage.debugResetLocalLanguageClearerForTesting();
+      AppLanguage.debugResetCurrentUserLoaderForTesting();
+      AppLanguage.debugResetLanguageSaverForTesting();
+    });
+
+    test(
+      'hydrates signed-in language from server after local fallback',
+      () async {
+        String? localLanguage = 'en';
+
+        AppLanguage.debugHasAuthenticatedUserForTesting = () => true;
+        AppLanguage.debugLocalLanguageReaderForTesting = () async =>
+            localLanguage;
+        AppLanguage.debugLocalLanguageWriterForTesting = (value) async {
+          localLanguage = value;
+        };
+        AppLanguage.debugCurrentUserLoaderForTesting = () async => StudyUUser(
+          id: 'user-1',
+          email: 'user@test.local',
+          preferences: Preferences(language: 'de'),
+        );
+
+        final language = AppLanguage(const [Locale('en'), Locale('de')]);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(language.appLocal?.languageCode, 'de');
+        expect(localLanguage, 'de');
+      },
+    );
+
+    test('persists language remotely when signed in', () async {
+      final savedLanguages = <String>[];
+      String? localLanguage;
+
+      AppLanguage.debugHasAuthenticatedUserForTesting = () => true;
+      AppLanguage.debugLocalLanguageReaderForTesting = () async => null;
+      AppLanguage.debugLocalLanguageWriterForTesting = (value) async {
+        localLanguage = value;
+      };
+      AppLanguage.debugCurrentUserLoaderForTesting = () async =>
+          StudyUUser(id: 'user-1', email: 'user@test.local');
+      AppLanguage.debugLanguageSaverForTesting = (value) async {
+        savedLanguages.add(value);
+      };
+
+      final language = AppLanguage(const [Locale('en'), Locale('de')]);
+      await Future<void>.delayed(Duration.zero);
+
+      await language.changeLanguage(const Locale('de'));
+
+      expect(language.appLocal?.languageCode, 'de');
+      expect(localLanguage, 'de');
+      expect(savedLanguages, ['de']);
+    });
+  });
+}

--- a/supabase/migrations/20260803113000_participant_fitbit_credentials.sql
+++ b/supabase/migrations/20260803113000_participant_fitbit_credentials.sql
@@ -1,0 +1,28 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.participant_fitbit_credentials (
+    user_id uuid NOT NULL REFERENCES public."user" (id) ON DELETE CASCADE,
+    study_id uuid NOT NULL REFERENCES public.study (id) ON DELETE CASCADE,
+    fitbit_credentials jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, study_id)
+);
+
+ALTER TABLE public.participant_fitbit_credentials OWNER TO postgres;
+
+COMMENT ON TABLE public.participant_fitbit_credentials IS
+'Participant Fitbit OAuth credentials, scoped to authenticated user and study.';
+
+ALTER TABLE public.participant_fitbit_credentials ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Participants can manage their own Fitbit credentials"
+ON public.participant_fitbit_credentials
+TO authenticated
+USING ((SELECT auth.uid() AS uid) = user_id)
+WITH CHECK ((SELECT auth.uid() AS uid) = user_id);
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+ON TABLE public.participant_fitbit_credentials
+TO authenticated, service_role;
+
+COMMIT;

--- a/supabase/tests/rls/participant_fitbit_credentials_test.sql
+++ b/supabase/tests/rls/participant_fitbit_credentials_test.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(9);
+SELECT plan(12);
 
 SELECT tests.create_supabase_user('fitbit_owner', 'fitbit_owner@test.local');
 SELECT tests.create_supabase_user('fitbit_other', 'fitbit_other@test.local');
@@ -106,7 +106,38 @@ SELECT lives_ok(
   'other user update is filtered by RLS'
 );
 
+SELECT throws_ok(
+  $$
+    INSERT INTO public.participant_fitbit_credentials (user_id, study_id, fitbit_credentials)
+    VALUES (
+      tests.get_supabase_uid('fitbit_owner'),
+      (SELECT id FROM public.study WHERE title = 'Study: participant fitbit credentials'),
+      '{"userID":"other","fitbitAccessToken":"should-not-insert","fitbitRefreshToken":"refresh-other"}'
+    )
+  $$,
+  'new row violates row-level security policy for table "participant_fitbit_credentials"',
+  'other user cannot insert a row for owner user_id'
+);
+
+SELECT lives_ok(
+  $$
+    DELETE FROM public.participant_fitbit_credentials
+    WHERE user_id = tests.get_supabase_uid('fitbit_owner')
+  $$,
+  'other user delete is filtered by RLS'
+);
+
 SELECT tests.authenticate_as('fitbit_owner');
+
+SELECT is(
+  (
+    SELECT count(*)
+    FROM public.participant_fitbit_credentials
+    WHERE user_id = tests.get_supabase_uid('fitbit_owner')
+  ),
+  1::bigint,
+  'owner row remains after other user attempted delete'
+);
 
 SELECT is(
   (

--- a/supabase/tests/rls/participant_fitbit_credentials_test.sql
+++ b/supabase/tests/rls/participant_fitbit_credentials_test.sql
@@ -1,0 +1,147 @@
+BEGIN;
+
+SELECT plan(9);
+
+SELECT tests.create_supabase_user('fitbit_owner', 'fitbit_owner@test.local');
+SELECT tests.create_supabase_user('fitbit_other', 'fitbit_other@test.local');
+
+INSERT INTO public.study (
+  contact,
+  user_id,
+  title,
+  description,
+  icon_name,
+  status,
+  registry_published,
+  questionnaire,
+  eligibility_criteria,
+  observations,
+  interventions,
+  consent,
+  schedule,
+  report_specification,
+  results,
+  participation,
+  result_sharing,
+  collaborator_emails
+)
+VALUES (
+  '{"email":"fitbit@example.com","phone":"0123456789","website":"https://studyu.health","researchers":"StudyU Researcher","organization":"StudyU","institutionalReviewBoard":"N/A","institutionalReviewBoardNumber":"N/A"}',
+  tests.get_supabase_uid('fitbit_owner'),
+  'Study: participant fitbit credentials',
+  'Verifies participant Fitbit token isolation.',
+  'accountHeart',
+  'running',
+  false,
+  '[]',
+  '[]',
+  '[]',
+  '[]',
+  '[]',
+  '{"sequence":"alternating","phaseDuration":1,"numberOfCycles":1,"sequenceCustom":"AB","includeBaseline":false}',
+  '{"primary":{"id":"average","type":"average","title":"Average","aggregate":"day","description":"Average","resultProperty":{"task":"task","property":"value"}},"secondary":[]}',
+  '[]',
+  'open',
+  'private',
+  '{}'
+);
+
+SELECT tests.authenticate_as('fitbit_owner');
+
+SELECT lives_ok(
+  $$
+    INSERT INTO public.participant_fitbit_credentials (user_id, study_id, fitbit_credentials)
+    VALUES (
+      tests.get_supabase_uid('fitbit_owner'),
+      (SELECT id FROM public.study WHERE title = 'Study: participant fitbit credentials'),
+      '{"userID":"owner","fitbitAccessToken":"access-owner","fitbitRefreshToken":"refresh-owner"}'
+    )
+  $$,
+  'owner can insert own participant fitbit credentials'
+);
+
+SELECT is(
+  (
+    SELECT fitbit_credentials ->> 'fitbitAccessToken'
+    FROM public.participant_fitbit_credentials
+    WHERE user_id = tests.get_supabase_uid('fitbit_owner')
+  ),
+  'access-owner',
+  'owner can read own participant fitbit credentials'
+);
+
+SELECT lives_ok(
+  $$
+    UPDATE public.participant_fitbit_credentials
+    SET fitbit_credentials = '{"userID":"owner","fitbitAccessToken":"access-owner-updated","fitbitRefreshToken":"refresh-owner"}'
+    WHERE user_id = tests.get_supabase_uid('fitbit_owner')
+  $$,
+  'owner can update own participant fitbit credentials'
+);
+
+SELECT is(
+  (
+    SELECT fitbit_credentials ->> 'fitbitAccessToken'
+    FROM public.participant_fitbit_credentials
+    WHERE user_id = tests.get_supabase_uid('fitbit_owner')
+  ),
+  'access-owner-updated',
+  'updated participant fitbit credentials are visible to owner'
+);
+
+SELECT tests.authenticate_as('fitbit_other');
+
+SELECT is(
+  (SELECT count(*) FROM public.participant_fitbit_credentials),
+  0::bigint,
+  'other user cannot read another participant fitbit credential row'
+);
+
+SELECT lives_ok(
+  $$
+    UPDATE public.participant_fitbit_credentials
+    SET fitbit_credentials = '{"userID":"other","fitbitAccessToken":"should-not-apply","fitbitRefreshToken":"refresh-other"}'
+    WHERE user_id = tests.get_supabase_uid('fitbit_owner')
+  $$,
+  'other user update is filtered by RLS'
+);
+
+SELECT tests.authenticate_as('fitbit_owner');
+
+SELECT is(
+  (
+    SELECT fitbit_credentials ->> 'fitbitAccessToken'
+    FROM public.participant_fitbit_credentials
+    WHERE user_id = tests.get_supabase_uid('fitbit_owner')
+  ),
+  'access-owner-updated',
+  'other user update did not change owner credentials'
+);
+
+SELECT lives_ok(
+  $$
+    DELETE FROM public.participant_fitbit_credentials
+    WHERE user_id = tests.get_supabase_uid('fitbit_owner')
+  $$,
+  'owner can delete own participant fitbit credentials'
+);
+
+INSERT INTO public.participant_fitbit_credentials (user_id, study_id, fitbit_credentials)
+VALUES (
+  tests.get_supabase_uid('fitbit_owner'),
+  (SELECT id FROM public.study WHERE title = 'Study: participant fitbit credentials'),
+  '{"userID":"owner","fitbitAccessToken":"access-owner","fitbitRefreshToken":"refresh-owner"}'
+);
+
+DELETE FROM public.study
+WHERE title = 'Study: participant fitbit credentials';
+
+SELECT is(
+  (SELECT count(*) FROM public.participant_fitbit_credentials),
+  0::bigint,
+  'deleting study cascades to participant fitbit credentials'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
## Description
Stacked on top of #782. This change hardens participant-specific persistence during account recovery, account switching, and participant Fitbit cleanup flows.

### Summary
This change hardens participant-specific persistence during account recovery, account switching, and participant Fitbit cleanup flows.

### Main changes
- Participant language persists through `public.user.preferences.lang`.
- Local `language_code` remains as a fallback before authentication.
- Language is hydrated after normal session restoration and account recovery.
- Recovery signs in with recovered credentials first, stores those recovered credentials immediately after successful sign-in, clears the active subject before any recovered subject can be reloaded, and returns a distinct cleanup failure when participant cleanup fails.
- Recovery clears participant-specific state without clearing app-wide flags.
- Pending deferred-link state and in-memory recovery state are cleared.
- Subject cache is scoped by `userId` and `subjectId`.
- Cache ownership is validated before loading or synchronization.
- `Cache.storeSubject()` now verifies the exact subject it just wrote, so kickoff still works before `selected_study_object_id` has been stored.
- Legacy unscoped cache is only migrated after scoped write success; mismatched or invalid legacy cache can be dropped, but a failed scoped write preserves the legacy cache so local progress is not lost.
- Participant Fitbit OAuth credentials use `public.participant_fitbit_credentials`.
- `study_fitbit_credentials` remains unchanged and continues to contain study-level Fitbit client credentials.
- Participant Fitbit rows are protected through RLS using `auth.uid()`.
- Local Fitbit storage is scoped by participant identity.
- Server Fitbit reads now prefer server credentials even when local caching fails.
- Authenticated Fitbit writes now treat local and server persistence independently; either side can still succeed when the other fails, and double failure surfaces a typed error without exposing token contents.
- User-facing opt-out and delete flows delete the participant Fitbit server row before destructive subject deletion begins; local Fitbit cleanup is performed afterward and cannot silently claim full deletion when the server row remains.
- Legacy Fitbit local-key handling avoids assigning another participant’s credentials to a recovered account.

### Security considerations
- Participant A’s cache must not be loaded for participant B.
- Participant A’s Fitbit tokens must not be accessible to participant B.
- A recovered account with no valid subject must not inherit a stale subject ID.
- Failed recovery attempts must not clear the current participant’s local state.
- Participant OAuth tokens must not be stored in `public.user.preferences`.
- A failed participant Fitbit server-row deletion must block destructive user-facing opt-out/delete flows.

## Visuals
No visual changes.

## Testing Steps
1. `cd app && rtk fvm dart analyze` -> pass
2. `cd app && rtk fvm flutter test test/services/restore_account_service_test.dart` -> pass
3. `cd app && rtk fvm flutter test test/util/cache_test.dart` -> pass
4. `cd app && rtk fvm flutter test test/util/fitbit_handler_test.dart` -> pass
5. `cd app && rtk fvm flutter test test/services/participant_study_exit_service_test.dart` -> pass
6. `cd flutter_common && rtk fvm flutter analyze` -> pass
7. `cd flutter_common && rtk fvm flutter test test/localization_test.dart` -> pass
8. `./scripts/reset-test-db.sh --yes` -> pass
9. `supabase test db supabase/tests` -> pass
10. `rtk fvm exec melos qualitycheck` -> pass
11. `scripts/pre-commit-check` -> pass

Focused coverage added or verified:
- failed recovery does not clear participant A local state
- failed recovered sign-in does not replace the current participant credentials
- cleanup failure after successful recovered sign-in returns a distinct recovery cleanup failure
- kickoff cache storage works before `selected_study_object_id` exists
- matching legacy cache migrates only after successful scoped write
- failed scoped cache migration preserves legacy progress data
- participant Fitbit server credentials are still returned when local caching fails
- participant Fitbit server upsert still runs when local scoped write fails
- double Fitbit storage failure surfaces a typed error without exposing tokens
- remote Fitbit deletion failure does not start destructive opt-out/delete flows
- local Fitbit cleanup failure does not undo successful server-side deletion or notification cleanup
- RLS prevents selecting, updating, deleting, or inserting another user’s participant Fitbit row
- language is restored from Supabase after recovery/session restore

### PR Checklist
- [x] `fvm exec melos qualitycheck` passes
- [x] Screenshot or video attached, or this item removed for non-visual changes
- [ ] Description links related issues, or this item removed when no issue exists
