### PR TITLE
fix(designer): remove dashboard drawer divider

### DIFF
--- a/designer_v2/lib/features/dashboard/dashboard_scaffold.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_scaffold.dart
@@ -32,7 +32,7 @@ class DashboardScaffold extends StatelessWidget {
             ? const SizedBox.shrink()
             : const AppDrawer(autoCloseDrawer: false),
         rightWidget: body,
-        dividerWidget: const VerticalDivider(width: 1, thickness: 0.3),
+        dividerWidget: null,
         scrollLeft: false,
         paddingLeft: null,
       ),


### PR DESCRIPTION
## Description
Removes the vertical divider between the desktop dashboard drawer and content area so the drawer's rounded outer edge renders cleanly instead of showing a straight border line.

## Visuals
- After fix screenshot captured locally: `/var/folders/x7/9h4c4d5914964vbp1j_gb0z40000gn/T/codex-clipboard-1fea13c9-0840-4bec-82d6-d9a40d35a0e9.png`
- GitHub cannot render local temporary file paths. Manual screenshot attachment still required before merge.

## Testing Steps
1. Run `rtk fvm exec melos run qualitycheck` from repo root.
2. Open Designer dashboard on desktop width.
3. Verify no straight vertical divider appears between left drawer and main content.
4. Confirm drawer rounded right edge remains intact with no layout regressions.

### PR Checklist
- [x] `fvm exec melos run qualitycheck` passes
- [x] Screenshot or video of the changes attached
- [ ] Description links related issues

<img width="604" height="878" alt="image" src="https://github.com/user-attachments/assets/0006e545-145d-4a4c-bb3e-856669ac1ead" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the vertical divider between columns in the dashboard layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->