### PR TITLE
fix(designer): center studies empty state

### DIFF
--- a/designer_v2/lib/features/dashboard/dashboard_page.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_page.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_designer_v2/common_views/async_value_widget.dart';
 import 'package:studyu_designer_v2/common_views/empty_body.dart';
+import 'package:studyu_designer_v2/common_views/layout_two_column.dart';
 import 'package:studyu_designer_v2/common_views/primary_button.dart';
 import 'package:studyu_designer_v2/common_views/search.dart';
 import 'package:studyu_designer_v2/features/dashboard/dashboard_controller.dart';
@@ -529,6 +530,23 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
             future: ref.read(userRepositoryProvider).fetchUser(),
             builder: (context, snapshot) {
               if (snapshot.hasData) {
+                final viewportHeight = MediaQuery.sizeOf(context).height;
+                final contentPadding =
+                    TwoColumnLayout.defaultContentPadding.vertical * 2;
+                const headerHeight = 36.0;
+                const spacingBelowHeader = 24.0;
+                final activeFilterSpacing =
+                    state.activeFilter != null &&
+                        state.activeFilter!.children.isNotEmpty
+                    ? 64.0
+                    : 0.0;
+                final emptyStateMinHeight =
+                    viewportHeight -
+                    contentPadding -
+                    headerHeight -
+                    spacingBelowHeader -
+                    activeFilterSpacing;
+
                 return AsyncValueWidget<List<Study>>(
                   loading: () =>
                       const Center(child: CircularProgressIndicator()),
@@ -547,25 +565,24 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
                     emptyWidget:
                         (widget.filter == null ||
                             widget.filter == StudiesFilter.owned)
-                        ? (state.query.isNotEmpty)
-                              ? Padding(
-                                  padding: const EdgeInsets.only(top: 24.0),
-                                  child: EmptyBody(
+                        ? ConstrainedBox(
+                            constraints: BoxConstraints(
+                              minHeight: emptyStateMinHeight,
+                            ),
+                            child: state.query.isNotEmpty
+                                ? EmptyBody(
                                     icon: Icons.content_paste_search_rounded,
                                     title: tr.studies_not_found,
                                     description: tr.modify_query,
-                                  ),
-                                )
-                              : Padding(
-                                  padding: const EdgeInsets.only(top: 24.0),
-                                  child: EmptyBody(
+                                  )
+                                : EmptyBody(
                                     icon: Icons.content_paste_search_rounded,
                                     title: tr.studies_empty,
                                     description: tr.studies_empty_description,
                                     // "...or create a new draft copy from an already published study!",
                                     /* button: PrimaryButton(text: "From template",); */
                                   ),
-                                )
+                          )
                         : const SizedBox.shrink(),
                   ),
                 );

--- a/designer_v2/lib/features/dashboard/dashboard_page.dart
+++ b/designer_v2/lib/features/dashboard/dashboard_page.dart
@@ -532,7 +532,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
               if (snapshot.hasData) {
                 final viewportHeight = MediaQuery.sizeOf(context).height;
                 final contentPadding =
-                    TwoColumnLayout.defaultContentPadding.vertical * 2;
+                    TwoColumnLayout.defaultContentPadding.vertical;
                 const headerHeight = 36.0;
                 const spacingBelowHeader = 24.0;
                 final activeFilterSpacing =


### PR DESCRIPTION
## Description
Centers the dashboard empty state more naturally within the visible content area when there are no studies to show.

Changes:
- compute a bounded empty-state height from the current viewport
- let the existing `EmptyBody` center itself vertically within that available space
- avoid the earlier unbounded flex layout issue in the dashboard content area

## Visuals
- Static UI change; screenshot attachment required before merge.

## Testing Steps
1. Run `rtk fvm exec melos run qualitycheck` from repo root.
2. Open the Designer dashboard with no owned studies.
3. Verify the `You don't have any studies yet` empty state appears centered more naturally in the page content area.
4. Verify the dashboard still loads normally and no layout/assertion errors appear.

### PR Checklist
- [x] `fvm exec melos qualitycheck` passes
- [x] Screenshot or video attached, or this item removed for non-visual changes
- [ ] Description links related issues, or this item removed when no issue exists

<img width="1680" height="879" alt="image" src="https://github.com/user-attachments/assets/9bb393d6-e583-4922-901b-9444c898a463" />
