### PR TITLE
fix(designer): refine participation and sidesheet behavior

### DIFF
--- a/designer_v2/lib/common_views/form_buttons.dart
+++ b/designer_v2/lib/common_views/form_buttons.dart
@@ -7,10 +7,17 @@ import 'package:studyu_designer_v2/features/forms/form_validation.dart';
 import 'package:studyu_designer_v2/features/forms/form_view_model.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
 
+typedef FormDismissHandler = Future<void> Function(BuildContext context);
+
 /// A cancel / dismiss button for use with [FormScaffold] [showFormSideSheet)
 /// Heavily inspired by [CloseButton]
 class DismissButton extends StatelessWidget {
-  const DismissButton({this.text, this.onPressed, super.key});
+  const DismissButton({
+    this.text,
+    this.onPressed,
+    this.onPressedAsync,
+    super.key,
+  });
 
   /// An override callback to perform instead of the default behavior which is
   /// to pop the [Navigator].
@@ -21,6 +28,7 @@ class DismissButton extends StatelessWidget {
   ///
   /// Defaults to null.
   final VoidCallback? onPressed;
+  final FormDismissHandler? onPressedAsync;
 
   final String? text;
 
@@ -40,7 +48,11 @@ class DismissButton extends StatelessWidget {
         text: text ?? tr.dialog_cancel,
         icon: null,
         //tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
-        onPressed: () {
+        onPressed: () async {
+          if (onPressedAsync != null) {
+            await onPressedAsync!(context);
+            return;
+          }
           if (onPressed != null) {
             onPressed!();
           } else {
@@ -52,7 +64,11 @@ class DismissButton extends StatelessWidget {
   }
 }
 
-List<Widget> buildFormButtons(FormViewModel formViewModel, FormMode formMode) {
+List<Widget> buildFormButtons(
+  FormViewModel formViewModel,
+  FormMode formMode, {
+  FormDismissHandler? onDismiss,
+}) {
   final modifyActionButtons = [
     ReactiveFormConsumer(
       // enable re-rendering based on form validation status
@@ -60,7 +76,9 @@ List<Widget> buildFormButtons(FormViewModel formViewModel, FormMode formMode) {
         return retainSizeInAppBar(
           DismissButton(
             key: const ValueKey('form_cancel_button'),
-            onPressed: () => Navigator.maybePop(context),
+            onPressedAsync:
+                onDismiss ??
+                (context) => Navigator.maybePop(context).then((_) {}),
           ),
         );
       },
@@ -98,7 +116,9 @@ List<Widget> buildFormButtons(FormViewModel formViewModel, FormMode formMode) {
           DismissButton(
             key: const ValueKey('form_close_button'),
             text: tr.dialog_close,
-            onPressed: () => Navigator.maybePop(context),
+            onPressedAsync:
+                onDismiss ??
+                (context) => Navigator.maybePop(context).then((_) {}),
           ),
         );
       },

--- a/designer_v2/lib/common_views/icon_picker.dart
+++ b/designer_v2/lib/common_views/icon_picker.dart
@@ -73,18 +73,37 @@ class ReactiveIconPicker
            // Unsupported: showErrors, validationMessages
            final isDisabled = readOnly || field.control.disabled;
 
-           return IconPicker(
-             iconOptions: iconOptions,
-             isDisabled: isDisabled,
-             focusNode: focusNode,
-             selectedOption: field.value,
-             galleryIconSize: galleryIconSize,
-             selectedIconSize: selectedIconSize,
-             onSelect: (iconOption) {
-               if (isDisabled) return;
-               field.didChange(iconOption);
-               onSelect?.call(field.control);
-             },
+           return Listener(
+             onPointerDown: (_) => field.control.markAsTouched(),
+             child: Column(
+               crossAxisAlignment: CrossAxisAlignment.start,
+               mainAxisSize: MainAxisSize.min,
+               children: [
+                 IconPicker(
+                   iconOptions: iconOptions,
+                   isDisabled: isDisabled,
+                   focusNode: focusNode,
+                   selectedOption: field.value,
+                   galleryIconSize: galleryIconSize,
+                   selectedIconSize: selectedIconSize,
+                   onSelect: (iconOption) {
+                     if (isDisabled) return;
+                     field.didChange(iconOption);
+                     onSelect?.call(field.control);
+                   },
+                 ),
+                 if (field.errorText != null) ...[
+                   const SizedBox(height: 8.0),
+                   Text(
+                     field.errorText!,
+                     style: Theme.of(field.context).textTheme.bodySmall
+                         ?.copyWith(
+                           color: Theme.of(field.context).colorScheme.error,
+                         ),
+                   ),
+                 ],
+               ],
+             ),
            );
          },
        );

--- a/designer_v2/lib/common_views/sidesheet/sidesheet.dart
+++ b/designer_v2/lib/common_views/sidesheet/sidesheet.dart
@@ -251,6 +251,9 @@ Future<T?> showModalSideSheet<T extends Object?>({
   Widget Function(Widget)? wrapRoute,
 }) {
   assert(!barrierDismissible || barrierLabel != null);
+  debugPrint(
+    '[showModalSideSheet] open title="$title" barrierDismissible=$barrierDismissible useRootNavigator=$useRootNavigator',
+  );
   return showGeneralDialog(
     barrierDismissible: barrierDismissible,
     barrierColor:
@@ -261,6 +264,7 @@ Future<T?> showModalSideSheet<T extends Object?>({
     routeSettings: routeSettings,
     context: context,
     pageBuilder: (BuildContext context, _, _) {
+      debugPrint('[showModalSideSheet] pageBuilder title="$title"');
       final sidesheet = Sidesheet(
         body: body,
         tabs: tabs,

--- a/designer_v2/lib/common_views/sidesheet/sidesheet.dart
+++ b/designer_v2/lib/common_views/sidesheet/sidesheet.dart
@@ -251,9 +251,6 @@ Future<T?> showModalSideSheet<T extends Object?>({
   Widget Function(Widget)? wrapRoute,
 }) {
   assert(!barrierDismissible || barrierLabel != null);
-  debugPrint(
-    '[showModalSideSheet] open title="$title" barrierDismissible=$barrierDismissible useRootNavigator=$useRootNavigator',
-  );
   return showGeneralDialog(
     barrierDismissible: barrierDismissible,
     barrierColor:
@@ -264,7 +261,6 @@ Future<T?> showModalSideSheet<T extends Object?>({
     routeSettings: routeSettings,
     context: context,
     pageBuilder: (BuildContext context, _, _) {
-      debugPrint('[showModalSideSheet] pageBuilder title="$title"');
       final sidesheet = Sidesheet(
         body: body,
         tabs: tabs,

--- a/designer_v2/lib/common_views/sidesheet/sidesheet_form.dart
+++ b/designer_v2/lib/common_views/sidesheet/sidesheet_form.dart
@@ -66,9 +66,6 @@ class _FormSidesheetPopEntryState<T extends FormViewModel>
     super.didChangeDependencies();
     _route?.unregisterPopEntry(this);
     _route = ModalRoute.of(context);
-    debugPrint(
-      '[PopEntry] registering route=${_route.runtimeType} isCurrent=${_route?.isCurrent} canPop=${Navigator.of(context, rootNavigator: true).canPop()}',
-    );
     _route?.registerPopEntry(this);
   }
 
@@ -85,9 +82,6 @@ class _FormSidesheetPopEntryState<T extends FormViewModel>
 
   @override
   void onPopInvokedWithResult(bool didPop, Object? result) {
-    debugPrint(
-      '[PopEntry] onPopInvokedWithResult didPop=$didPop result=$result canPopNotifier=${_canPopNotifier.value} isDirty=${widget.formViewModel.isDirty}',
-    );
     if (didPop) {
       return;
     }
@@ -101,30 +95,17 @@ class _FormSidesheetPopEntryState<T extends FormViewModel>
 
   Future<void> _handleDismiss({required bool completePop}) async {
     if (_isDismissing) {
-      debugPrint(
-        '[PopEntry] _handleDismiss skipped completePop=$completePop reason=already_dismissing',
-      );
       return;
     }
     _isDismissing = true;
-    debugPrint(
-      '[PopEntry] _handleDismiss start completePop=$completePop isDirty=${widget.formViewModel.isDirty} mounted=$mounted rootCanPop=${Navigator.of(context, rootNavigator: true).canPop()} localCanPop=${Navigator.of(context).canPop()}',
-    );
 
     try {
       if (!widget.formViewModel.isDirty) {
         await widget.formViewModel.cancel();
-        debugPrint(
-          '[PopEntry] _handleDismiss after cancel clean mounted=$mounted completePop=$completePop',
-        );
         if (mounted) {
           _canPopNotifier.value = true;
           if (completePop) {
             _scheduleManualPop(label: 'clean');
-          } else {
-            debugPrint(
-              '[PopEntry] clean dismiss unlocked for original pop attempt',
-            );
           }
         }
         return;
@@ -134,9 +115,6 @@ class _FormSidesheetPopEntryState<T extends FormViewModel>
         context: context,
         barrierColor: ThemeConfig.modalBarrierColor(Theme.of(context)),
         builder: (context) => const UnsavedChangesDialog(),
-      );
-      debugPrint(
-        '[PopEntry] unsaved dialog result=$shouldDiscard mounted=$mounted completePop=$completePop',
       );
 
       if (!mounted) {
@@ -148,21 +126,13 @@ class _FormSidesheetPopEntryState<T extends FormViewModel>
         if (!mounted) {
           return;
         }
-        final rootNavigator = Navigator.of(context, rootNavigator: true);
         final localNavigator = Navigator.of(context);
-        debugPrint(
-          '[PopEntry] _handleDismiss after cancel dirty mounted=$mounted completePop=$completePop rootCanPop=${rootNavigator.canPop()} localCanPop=${localNavigator.canPop()}',
-        );
         if (!localNavigator.canPop()) {
           return;
         }
         _canPopNotifier.value = true;
         if (completePop) {
           _scheduleManualPop(label: 'dirty');
-        } else {
-          debugPrint(
-            '[PopEntry] dirty dismiss unlocked for original pop attempt',
-          );
         }
       }
     } finally {
@@ -176,9 +146,6 @@ class _FormSidesheetPopEntryState<T extends FormViewModel>
         return;
       }
       final navigator = Navigator.of(context, rootNavigator: true);
-      debugPrint(
-        '[PopEntry] $label dismiss scheduled pop canPop=${navigator.canPop()}',
-      );
       if (navigator.canPop()) {
         navigator.pop();
       }

--- a/designer_v2/lib/common_views/sidesheet/sidesheet_form.dart
+++ b/designer_v2/lib/common_views/sidesheet/sidesheet_form.dart
@@ -36,18 +36,39 @@ class _FormSidesheetPopEntry<T extends FormViewModel> extends StatefulWidget {
       _FormSidesheetPopEntryState<T>();
 }
 
+class _FormSidesheetDismissScope extends InheritedWidget {
+  const _FormSidesheetDismissScope({
+    required this.dismiss,
+    required super.child,
+  });
+
+  final Future<void> Function() dismiss;
+
+  static _FormSidesheetDismissScope? maybeOf(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<_FormSidesheetDismissScope>();
+  }
+
+  @override
+  bool updateShouldNotify(_FormSidesheetDismissScope oldWidget) =>
+      dismiss != oldWidget.dismiss;
+}
+
 class _FormSidesheetPopEntryState<T extends FormViewModel>
     extends State<_FormSidesheetPopEntry<T>>
     implements PopEntry {
   ModalRoute<dynamic>? _route;
   final ValueNotifier<bool> _canPopNotifier = ValueNotifier(false);
+  bool _isDismissing = false;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _route?.unregisterPopEntry(this);
     _route = ModalRoute.of(context);
-    debugPrint('[PopEntry] registering with route: ${_route.runtimeType}');
+    debugPrint(
+      '[PopEntry] registering route=${_route.runtimeType} isCurrent=${_route?.isCurrent} canPop=${Navigator.of(context, rootNavigator: true).canPop()}',
+    );
     _route?.registerPopEntry(this);
   }
 
@@ -65,12 +86,12 @@ class _FormSidesheetPopEntryState<T extends FormViewModel>
   @override
   void onPopInvokedWithResult(bool didPop, Object? result) {
     debugPrint(
-      '[PopEntry] onPopInvokedWithResult didPop=$didPop canPop=${_canPopNotifier.value}',
+      '[PopEntry] onPopInvokedWithResult didPop=$didPop result=$result canPopNotifier=${_canPopNotifier.value} isDirty=${widget.formViewModel.isDirty}',
     );
     if (didPop) {
       return;
     }
-    _handleDismiss();
+    _handleDismiss(completePop: true);
   }
 
   @override
@@ -78,50 +99,99 @@ class _FormSidesheetPopEntryState<T extends FormViewModel>
     // Deprecated
   }
 
-  Future<void> _handleDismiss() async {
-    debugPrint(
-      '[PopEntry] _handleDismiss isDirty=${widget.formViewModel.isDirty}',
-    );
-
-    if (!widget.formViewModel.isDirty) {
-      await widget.formViewModel.cancel();
-      if (mounted) {
-        _canPopNotifier.value = true;
-
-        // CHANGE HERE: Wait for the frame to finish so Navigator is unlocked
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) {
-            Navigator.of(context, rootNavigator: true).pop();
-          }
-        });
-      }
+  Future<void> _handleDismiss({required bool completePop}) async {
+    if (_isDismissing) {
+      debugPrint(
+        '[PopEntry] _handleDismiss skipped completePop=$completePop reason=already_dismissing',
+      );
       return;
     }
-
-    // Dirty state logic
-    final shouldDiscard = await showDialog<bool>(
-      context: context,
-      barrierColor: ThemeConfig.modalBarrierColor(Theme.of(context)),
-      builder: (context) => const UnsavedChangesDialog(),
+    _isDismissing = true;
+    debugPrint(
+      '[PopEntry] _handleDismiss start completePop=$completePop isDirty=${widget.formViewModel.isDirty} mounted=$mounted rootCanPop=${Navigator.of(context, rootNavigator: true).canPop()} localCanPop=${Navigator.of(context).canPop()}',
     );
 
-    if (shouldDiscard == true && mounted) {
-      await widget.formViewModel.cancel();
-      if (mounted && Navigator.of(context).canPop()) {
-        _canPopNotifier.value = true;
-
-        // CHANGE HERE: Wait for the frame to finish
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) {
-            Navigator.of(context, rootNavigator: true).pop();
+    try {
+      if (!widget.formViewModel.isDirty) {
+        await widget.formViewModel.cancel();
+        debugPrint(
+          '[PopEntry] _handleDismiss after cancel clean mounted=$mounted completePop=$completePop',
+        );
+        if (mounted) {
+          _canPopNotifier.value = true;
+          if (completePop) {
+            _scheduleManualPop(label: 'clean');
+          } else {
+            debugPrint(
+              '[PopEntry] clean dismiss unlocked for original pop attempt',
+            );
           }
-        });
+        }
+        return;
       }
+
+      final shouldDiscard = await showDialog<bool>(
+        context: context,
+        barrierColor: ThemeConfig.modalBarrierColor(Theme.of(context)),
+        builder: (context) => const UnsavedChangesDialog(),
+      );
+      debugPrint(
+        '[PopEntry] unsaved dialog result=$shouldDiscard mounted=$mounted completePop=$completePop',
+      );
+
+      if (!mounted) {
+        return;
+      }
+
+      if (shouldDiscard == true) {
+        await widget.formViewModel.cancel();
+        if (!mounted) {
+          return;
+        }
+        final rootNavigator = Navigator.of(context, rootNavigator: true);
+        final localNavigator = Navigator.of(context);
+        debugPrint(
+          '[PopEntry] _handleDismiss after cancel dirty mounted=$mounted completePop=$completePop rootCanPop=${rootNavigator.canPop()} localCanPop=${localNavigator.canPop()}',
+        );
+        if (!localNavigator.canPop()) {
+          return;
+        }
+        _canPopNotifier.value = true;
+        if (completePop) {
+          _scheduleManualPop(label: 'dirty');
+        } else {
+          debugPrint(
+            '[PopEntry] dirty dismiss unlocked for original pop attempt',
+          );
+        }
+      }
+    } finally {
+      _isDismissing = false;
     }
   }
 
+  void _scheduleManualPop({required String label}) {
+    Future<void>.delayed(Duration.zero, () {
+      if (!mounted) {
+        return;
+      }
+      final navigator = Navigator.of(context, rootNavigator: true);
+      debugPrint(
+        '[PopEntry] $label dismiss scheduled pop canPop=${navigator.canPop()}',
+      );
+      if (navigator.canPop()) {
+        navigator.pop();
+      }
+    });
+  }
+
   @override
-  Widget build(BuildContext context) => widget.child;
+  Widget build(BuildContext context) {
+    return _FormSidesheetDismissScope(
+      dismiss: () => _handleDismiss(completePop: true),
+      child: widget.child,
+    );
+  }
 }
 
 Future<Object?> showFormSideSheet<T extends FormViewModel>({
@@ -162,7 +232,18 @@ Future<Object?> showFormSideSheet<T extends FormViewModel>({
     tabs: boundTabs,
     actionButtons:
         actionButtons ??
-        buildFormButtons(formViewModel, formViewModel.formMode),
+        buildFormButtons(
+          formViewModel,
+          formViewModel.formMode,
+          onDismiss: (context) async {
+            final dismissScope = _FormSidesheetDismissScope.maybeOf(context);
+            if (dismissScope != null) {
+              await dismissScope.dismiss();
+              return;
+            }
+            await Navigator.maybePop(context);
+          },
+        ),
     wrapContent: wrapInForm,
     width: width,
     withCloseButton: withCloseButton,

--- a/designer_v2/lib/common_views/text_hyperlink.dart
+++ b/designer_v2/lib/common_views/text_hyperlink.dart
@@ -82,20 +82,22 @@ class _HyperlinkState extends State<Hyperlink> {
         final textWidget = Text(widget.text, style: actualStyle);
 
         if (widget.icon != null) {
-          return Row(
-            children: [
-              Icon(
-                widget.icon,
-                color: actualColor,
-                size: widget.iconSize ?? (textTheme?.fontSize ?? 14.0) + 4.0,
-              ),
-              const SizedBox(width: 2.0),
-              textWidget,
-            ],
+          return SelectionContainer.disabled(
+            child: Row(
+              children: [
+                Icon(
+                  widget.icon,
+                  color: actualColor,
+                  size: widget.iconSize ?? (textTheme?.fontSize ?? 14.0) + 4.0,
+                ),
+                const SizedBox(width: 2.0),
+                textWidget,
+              ],
+            ),
           );
         }
 
-        return textWidget;
+        return SelectionContainer.disabled(child: textWidget);
       },
       onTap: () async {
         if (widget.url != null) {

--- a/designer_v2/lib/common_views/text_paragraph.dart
+++ b/designer_v2/lib/common_views/text_paragraph.dart
@@ -4,6 +4,7 @@ class TextParagraph extends StatelessWidget {
   TextParagraph({
     this.text,
     this.style,
+    this.textAlign,
     this.selectable = true,
     this.span,
     super.key,
@@ -15,6 +16,7 @@ class TextParagraph extends StatelessWidget {
 
   final String? text;
   final TextStyle? style;
+  final TextAlign? textAlign;
   final bool selectable;
   final List<TextSpan>? span;
 
@@ -27,11 +29,15 @@ class TextParagraph extends StatelessWidget {
       if (span != null) {
         return RichText(text: TextSpan(children: span));
       }
-      return Text(text!, style: textStyle);
+      return Text(text!, style: textStyle, textAlign: textAlign);
     }
     if (span != null) {
-      return SelectableText.rich(TextSpan(children: span), style: textStyle);
+      return SelectableText.rich(
+        TextSpan(children: span),
+        style: textStyle,
+        textAlign: textAlign,
+      );
     }
-    return SelectableText(text!, style: textStyle);
+    return SelectableText(text!, style: textStyle, textAlign: textAlign);
   }
 }

--- a/designer_v2/lib/features/design/enrollment/consent_item_form_controller.dart
+++ b/designer_v2/lib/features/design/enrollment/consent_item_form_controller.dart
@@ -29,9 +29,21 @@ class ConsentItemFormViewModel
 
   @override
   FormValidationConfigSet get sharedValidationConfig => {
-    StudyFormValidationSet.draft: [titleRequired, descriptionRequired],
-    StudyFormValidationSet.publish: [titleRequired, descriptionRequired],
-    StudyFormValidationSet.test: [titleRequired, descriptionRequired],
+    StudyFormValidationSet.draft: [
+      titleRequired,
+      descriptionRequired,
+      iconRequired,
+    ],
+    StudyFormValidationSet.publish: [
+      titleRequired,
+      descriptionRequired,
+      iconRequired,
+    ],
+    StudyFormValidationSet.test: [
+      titleRequired,
+      descriptionRequired,
+      iconRequired,
+    ],
   };
 
   FormControlValidation get titleRequired => FormControlValidation(
@@ -48,6 +60,14 @@ class ConsentItemFormViewModel
     validationMessages: {
       ValidationMessage.required: (error) =>
           tr.form_field_consent_text_required,
+    },
+  );
+  FormControlValidation get iconRequired => FormControlValidation(
+    control: iconControl,
+    validators: [Validators.required],
+    validationMessages: {
+      ValidationMessage.required: (error) =>
+          tr.form_field_consent_icon_required,
     },
   );
 

--- a/designer_v2/lib/features/design/enrollment/consent_item_form_view.dart
+++ b/designer_v2/lib/features/design/enrollment/consent_item_form_view.dart
@@ -69,6 +69,10 @@ class _ConsentItemFormViewState extends State<ConsentItemFormView> {
                         child: ReactiveIconPicker(
                           formControl: widget.formViewModel.iconControl,
                           iconOptions: IconPack.material,
+                          validationMessages: widget
+                              .formViewModel
+                              .iconControl
+                              .validationMessages,
                         ),
                       ),
                     ],

--- a/designer_v2/lib/features/design/enrollment/enrollment_form_data.dart
+++ b/designer_v2/lib/features/design/enrollment/enrollment_form_data.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_designer_v2/features/design/enrollment/consent_item_form_data.dart';
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/questionnaire_form_data.dart';
@@ -5,6 +6,20 @@ import 'package:studyu_designer_v2/features/design/study_form_data.dart';
 
 class EnrollmentFormData implements IStudyFormData {
   static const kDefaultEnrollmentType = Participation.invite;
+  static const _deepEquality = DeepCollectionEquality();
+
+  static List<Map<String, dynamic>> _eligibilityCriteriaComparableData(
+    List<EligibilityCriterion> criteria,
+  ) {
+    return criteria
+        .map(
+          (criterion) => {
+            'reason': criterion.reason,
+            'condition': criterion.condition.toJson(),
+          },
+        )
+        .toList();
+  }
 
   EnrollmentFormData({
     required this.enrollmentType,
@@ -43,10 +58,10 @@ class EnrollmentFormData implements IStudyFormData {
     // Only update eligibility criteria if they have changed
     final newEligibilityCriteria = questionnaireFormData
         .toEligibilityCriteria();
-    if (study.eligibilityCriteria.length != newEligibilityCriteria.length ||
-        !study.eligibilityCriteria.every(
-          (c) => newEligibilityCriteria.contains(c),
-        )) {
+    if (!_deepEquality.equals(
+      _eligibilityCriteriaComparableData(study.eligibilityCriteria),
+      _eligibilityCriteriaComparableData(newEligibilityCriteria),
+    )) {
       study.eligibilityCriteria = newEligibilityCriteria;
     }
     return study;

--- a/designer_v2/lib/features/design/enrollment/enrollment_form_view.dart
+++ b/designer_v2/lib/features/design/enrollment/enrollment_form_view.dart
@@ -304,6 +304,7 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
     WidgetRef ref,
     StudyUQuestionnaire questionnaire,
   ) {
+    debugPrint('[Enrollment] open screener sidesheet routeArgs=$routeArgs');
     final formViewModel = ref.watch(
       screenerQuestionFormViewModelProvider(routeArgs),
     );
@@ -345,6 +346,7 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
     BuildContext context,
     WidgetRef ref,
   ) {
+    debugPrint('[Enrollment] open consent sidesheet routeArgs=$routeArgs');
     final formViewModel = ref.watch(
       consentItemFormViewModelProvider(routeArgs),
     );

--- a/designer_v2/lib/features/design/enrollment/enrollment_form_view.dart
+++ b/designer_v2/lib/features/design/enrollment/enrollment_form_view.dart
@@ -304,7 +304,6 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
     WidgetRef ref,
     StudyUQuestionnaire questionnaire,
   ) {
-    debugPrint('[Enrollment] open screener sidesheet routeArgs=$routeArgs');
     final formViewModel = ref.watch(
       screenerQuestionFormViewModelProvider(routeArgs),
     );
@@ -346,7 +345,6 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
     BuildContext context,
     WidgetRef ref,
   ) {
-    debugPrint('[Enrollment] open consent sidesheet routeArgs=$routeArgs');
     final formViewModel = ref.watch(
       consentItemFormViewModelProvider(routeArgs),
     );

--- a/designer_v2/lib/features/design/enrollment/enrollment_form_view.dart
+++ b/designer_v2/lib/features/design/enrollment/enrollment_form_view.dart
@@ -44,6 +44,7 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
               children: <Widget>[
                 TextParagraph(
                   text: tr.form_study_design_enrollment_description,
+                  textAlign: TextAlign.justify,
                 ),
                 const SizedBox(height: 24.0),
                 FormTableLayout(
@@ -81,6 +82,7 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
                                       ? TextParagraph(
                                           text: option.description,
                                           selectable: false,
+                                          textAlign: TextAlign.justify,
                                           style: ThemeConfig.bodyTextMuted(
                                             theme,
                                           ),
@@ -126,6 +128,7 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
                       },
                       sectionDescription:
                           tr.form_array_screener_questions_description,
+                      sectionDescriptionTextAlign: TextAlign.justify,
                       onNewItemLabel: tr.form_array_screener_questions_new,
                       rowTitle: (viewModel) =>
                           viewModel.formData?.questionText ?? '',
@@ -226,6 +229,7 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
                       },
                       sectionDescription:
                           tr.form_array_consent_items_description,
+                      sectionDescriptionTextAlign: TextAlign.justify,
                       onNewItemLabel: tr.form_array_consent_items_new,
                       rowTitle: (viewModel) => viewModel.formData?.title ?? '',
                       leadingWidget: Row(

--- a/designer_v2/lib/features/design/enrollment/enrollment_form_view.dart
+++ b/designer_v2/lib/features/design/enrollment/enrollment_form_view.dart
@@ -68,6 +68,7 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
                                   enabled: !formViewModel.isReadonly,
                                   contentPadding: EdgeInsets.zero,
                                   horizontalTitleGap: 12.0,
+                                  titleAlignment: ListTileTitleAlignment.top,
                                   visualDensity: VisualDensity.compact,
                                   // disables in readonly mode
                                   title: Column(
@@ -137,7 +138,7 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
                       sectionDescription:
                           tr.form_array_screener_questions_description,
                       sectionDescriptionTextAlign: TextAlign.justify,
-                      buttonTopPadding: 8.0,
+                      buttonTopPadding: 4.0,
                       onNewItemLabel: tr.form_array_screener_questions_new,
                       rowTitle: (viewModel) =>
                           viewModel.formData?.questionText ?? '',
@@ -239,7 +240,7 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
                       sectionDescription:
                           tr.form_array_consent_items_description,
                       sectionDescriptionTextAlign: TextAlign.justify,
-                      buttonTopPadding: 8.0,
+                      buttonTopPadding: 4.0,
                       onNewItemLabel: tr.form_array_consent_items_new,
                       rowTitle: (viewModel) => viewModel.formData?.title ?? '',
                       leadingWidget: Row(

--- a/designer_v2/lib/features/design/enrollment/enrollment_form_view.dart
+++ b/designer_v2/lib/features/design/enrollment/enrollment_form_view.dart
@@ -141,7 +141,8 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
                       buttonTopPadding: 4.0,
                       onNewItemLabel: tr.form_array_screener_questions_new,
                       rowTitle: (viewModel) =>
-                          viewModel.formData?.questionText ?? '',
+                          (viewModel.formData?.questionText ?? '')
+                              .compactWhitespace(),
                       leadingWidget: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
@@ -242,7 +243,8 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
                       sectionDescriptionTextAlign: TextAlign.justify,
                       buttonTopPadding: 4.0,
                       onNewItemLabel: tr.form_array_consent_items_new,
-                      rowTitle: (viewModel) => viewModel.formData?.title ?? '',
+                      rowTitle: (viewModel) =>
+                          (viewModel.formData?.title ?? '').compactWhitespace(),
                       leadingWidget: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [

--- a/designer_v2/lib/features/design/enrollment/enrollment_form_view.dart
+++ b/designer_v2/lib/features/design/enrollment/enrollment_form_view.dart
@@ -66,6 +66,9 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
                                 (option) => RadioListTile<Participation>(
                                   value: option.value,
                                   enabled: !formViewModel.isReadonly,
+                                  contentPadding: EdgeInsets.zero,
+                                  horizontalTitleGap: 12.0,
+                                  visualDensity: VisualDensity.compact,
                                   // disables in readonly mode
                                   title: Column(
                                     crossAxisAlignment:
@@ -79,12 +82,17 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
                                     ],
                                   ),
                                   subtitle: (option.description) != null
-                                      ? TextParagraph(
-                                          text: option.description,
-                                          selectable: false,
-                                          textAlign: TextAlign.justify,
-                                          style: ThemeConfig.bodyTextMuted(
-                                            theme,
+                                      ? SizedBox(
+                                          width: double.infinity,
+                                          child: Text(
+                                            option.description!,
+                                            textAlign: TextAlign.justify,
+                                            style: theme.textTheme.bodyMedium
+                                                ?.merge(
+                                                  ThemeConfig.bodyTextMuted(
+                                                    theme,
+                                                  ),
+                                                ),
                                           ),
                                         )
                                       : null,
@@ -129,6 +137,7 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
                       sectionDescription:
                           tr.form_array_screener_questions_description,
                       sectionDescriptionTextAlign: TextAlign.justify,
+                      buttonTopPadding: 8.0,
                       onNewItemLabel: tr.form_array_screener_questions_new,
                       rowTitle: (viewModel) =>
                           viewModel.formData?.questionText ?? '',
@@ -230,6 +239,7 @@ class StudyDesignEnrollmentFormView extends StudyDesignPageWidget {
                       sectionDescription:
                           tr.form_array_consent_items_description,
                       sectionDescriptionTextAlign: TextAlign.justify,
+                      buttonTopPadding: 8.0,
                       onNewItemLabel: tr.form_array_consent_items_new,
                       rowTitle: (viewModel) => viewModel.formData?.title ?? '',
                       leadingWidget: Row(

--- a/designer_v2/lib/features/design/enrollment/screener_question_form_controller.dart
+++ b/designer_v2/lib/features/design/enrollment/screener_question_form_controller.dart
@@ -120,10 +120,10 @@ class ScreenerQuestionFormViewModel extends QuestionFormViewModel
     onResponseOptionsChanged(answerOptionsControls);
 
     for (final entry in data.responseOptionsValidity.entries) {
-      final responseOption = entry.key;
+      final responseOptionKey = entry.key;
       final responseValidity = entry.value;
       final logicControl = _findAssociatedLogicControlFor(
-        responseOption: responseOption,
+        responseOption: responseOptionKey,
       );
       if (logicControl != null) {
         logicControl.value = responseValidity;
@@ -139,8 +139,12 @@ class ScreenerQuestionFormViewModel extends QuestionFormViewModel
     for (var i = 0; i < answerOptionsControls.length; i++) {
       final optionControl = answerOptionsControls[i];
       final logicControl = responseOptionsLogicControls.controls[i];
-      responseOptionsValidity[optionControl.value] =
+      final normalizedKey = QuestionFormData.normalizeResponseOptionKey(
+        optionControl.value,
+      );
+      final normalizedValue =
           logicControl.value ?? defaultResponseOptionValidity;
+      responseOptionsValidity[normalizedKey] = normalizedValue;
     }
     data.responseOptionsValidity = responseOptionsValidity;
 
@@ -179,7 +183,13 @@ class ScreenerQuestionFormViewModel extends QuestionFormViewModel
     for (var i = 0; i < controls.length; i++) {
       final optionControl = answerOptionsControls[i];
       final associatedControl = controls[i];
-      if (optionControl.value == responseOption) {
+      final optionKey = QuestionFormData.normalizeResponseOptionKey(
+        optionControl.value,
+      );
+      final targetKey = QuestionFormData.normalizeResponseOptionKey(
+        responseOption,
+      );
+      if (optionKey == targetKey) {
         return associatedControl;
       }
     }

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_conditional_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_conditional_form_view.dart
@@ -14,6 +14,8 @@ import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:studyu_designer_v2/theme.dart';
 
 class ConditionalQuestionFormView extends FormConsumerWidget {
+  static const _questionTooltipMaxCharacters = 80;
+
   ConditionalQuestionFormView({
     required this.formViewModel,
     required this.allQuestions,
@@ -86,9 +88,17 @@ class ConditionalQuestionFormView extends FormConsumerWidget {
     return !oldIds.containsAll(newIds) || !newIds.containsAll(oldIds);
   }
 
+  String _buildQuestionTooltipMessage(String prompt) {
+    final normalizedPrompt = prompt.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (normalizedPrompt.length <= _questionTooltipMaxCharacters) {
+      return normalizedPrompt;
+    }
+    return '${normalizedPrompt.substring(0, _questionTooltipMaxCharacters - 3)}...';
+  }
+
   Widget _buildQuestionOptionContent(Question option, int index) {
     return Tooltip(
-      message: option.prompt ?? '',
+      message: _buildQuestionTooltipMessage(option.prompt ?? ''),
       child: SizedBox(
         width: double.infinity,
         child: Row(
@@ -102,7 +112,11 @@ class ConditionalQuestionFormView extends FormConsumerWidget {
             Text('${index + 1}.', style: const TextStyle(color: Colors.grey)),
             const SizedBox(width: 4),
             Expanded(
-              child: Text(option.prompt!, overflow: TextOverflow.ellipsis),
+              child: Text(
+                option.prompt!,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
           ],
         ),

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_conditional_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_conditional_form_view.dart
@@ -97,29 +97,29 @@ class ConditionalQuestionFormView extends FormConsumerWidget {
   }
 
   Widget _buildQuestionOptionContent(Question option, int index) {
-    return Tooltip(
-      message: _buildQuestionTooltipMessage(option.prompt ?? ''),
-      child: SizedBox(
-        width: double.infinity,
-        child: Row(
-          children: [
-            Icon(
-              SurveyQuestionType.of(option).icon,
-              size: 16,
-              color: Colors.grey,
-            ),
-            const SizedBox(width: 8),
-            Text('${index + 1}.', style: const TextStyle(color: Colors.grey)),
-            const SizedBox(width: 4),
-            Expanded(
+    return SizedBox(
+      width: double.infinity,
+      child: Row(
+        children: [
+          Icon(
+            SurveyQuestionType.of(option).icon,
+            size: 16,
+            color: Colors.grey,
+          ),
+          const SizedBox(width: 8),
+          Text('${index + 1}.', style: const TextStyle(color: Colors.grey)),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Tooltip(
+              message: _buildQuestionTooltipMessage(option.prompt ?? ''),
               child: Text(
                 option.prompt!,
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -243,40 +243,37 @@ class ConditionalQuestionFormView extends FormConsumerWidget {
         children: [
           Expanded(
             flex: 2,
-            child: Tooltip(
-              message: conditionVm.selectedQuestion?.prompt ?? '',
-              child: ReactiveDropdownField<String>(
-                formControl: conditionVm.questionIdControl,
-                isExpanded: true,
-                selectedItemBuilder: (context) => availableQuestions
-                    .asMap()
-                    .map(
-                      (index, option) => MapEntry(
-                        index,
-                        _buildQuestionOptionContent(option, index),
+            child: ReactiveDropdownField<String>(
+              formControl: conditionVm.questionIdControl,
+              isExpanded: true,
+              selectedItemBuilder: (context) => availableQuestions
+                  .asMap()
+                  .map(
+                    (index, option) => MapEntry(
+                      index,
+                      _buildQuestionOptionContent(option, index),
+                    ),
+                  )
+                  .values
+                  .toList(),
+              items: availableQuestions
+                  .asMap()
+                  .map(
+                    (index, option) => MapEntry(
+                      index,
+                      DropdownMenuItem(
+                        value: option.id,
+                        child: _buildQuestionOptionContent(option, index),
                       ),
-                    )
-                    .values
-                    .toList(),
-                items: availableQuestions
-                    .asMap()
-                    .map(
-                      (index, option) => MapEntry(
-                        index,
-                        DropdownMenuItem(
-                          value: option.id,
-                          child: _buildQuestionOptionContent(option, index),
-                        ),
-                      ),
-                    )
-                    .values
-                    .toList(),
-                decoration: InputDecoration(
-                  labelText:
-                      tr.form_array_question_visibility_logic_question_title,
-                  border: const OutlineInputBorder(),
-                  isDense: true,
-                ),
+                    ),
+                  )
+                  .values
+                  .toList(),
+              decoration: InputDecoration(
+                labelText:
+                    tr.form_array_question_visibility_logic_question_title,
+                border: const OutlineInputBorder(),
+                isDense: true,
               ),
             ),
           ),

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_conditional_live_preview.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_conditional_live_preview.dart
@@ -4,6 +4,8 @@ import 'package:studyu_core/core.dart';
 import 'package:studyu_designer_v2/localization/app_translation.dart';
 
 class LiveConditionPreview extends StatelessWidget {
+  static const _previewQuestionMaxCharacters = 80;
+
   final CompositeExpression? compositeExpression;
   final List<Question> allQuestions;
   final String currentQuestionId;
@@ -15,13 +17,23 @@ class LiveConditionPreview extends StatelessWidget {
     required this.currentQuestionId,
   });
 
+  String _truncatePreviewQuestionText(String prompt) {
+    final normalizedPrompt = prompt.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (normalizedPrompt.length <= _previewQuestionMaxCharacters) {
+      return normalizedPrompt;
+    }
+    return '${normalizedPrompt.substring(0, _previewQuestionMaxCharacters - 3)}...';
+  }
+
   String _getQuestionPreviewText(String questionId) {
     /*if (questionId == currentQuestionId) {
       // Use the specific question text from the ViewModel for clarity
       return tr.form_array_question_visibility_logic_this_question;
     }*/
     final question = allQuestions.firstWhereOrNull((q) => q.id == questionId);
-    return question != null ? 'Q[${question.prompt}]' : 'Q[$questionId]';
+    return question != null
+        ? 'Q[${_truncatePreviewQuestionText(question.prompt ?? '')}]'
+        : 'Q[$questionId]';
   }
 
   String _formatExpressionForPreview(Expression expression) {
@@ -144,9 +156,11 @@ class LiveConditionPreview extends StatelessWidget {
 
     return Padding(
       padding: const EdgeInsets.all(8.0),
-      child: SelectableText(
+      child: Text(
         previewText,
         style: const TextStyle(fontStyle: FontStyle.italic, color: Colors.grey),
+        maxLines: 12,
+        overflow: TextOverflow.ellipsis,
       ),
     );
   }

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
@@ -28,8 +28,6 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
         IListActionProvider<FormControl<dynamic>>,
         IConditionalQuestionProperties {
   static const defaultQuestionType = SurveyQuestionType.choice;
-  static const int questionTextMaxLength = 200;
-  static const int questionInfoTextMaxLength = 500;
 
   QuestionFormViewModel({
     super.formData,
@@ -601,14 +599,8 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
   };
 
   late final FormValidationConfigSet _sharedValidationConfig = {
-    StudyFormValidationSet.draft: [
-      questionTextRequired,
-      questionInfoTextMaxLengthValidation,
-    ],
-    StudyFormValidationSet.publish: [
-      questionTextRequired,
-      questionInfoTextMaxLengthValidation,
-    ],
+    StudyFormValidationSet.draft: [questionTextRequired],
+    StudyFormValidationSet.publish: [questionTextRequired],
   };
 
   late final Map<SurveyQuestionType, FormValidationConfigSet>
@@ -697,28 +689,12 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
 
   FormControlValidation get questionTextRequired => FormControlValidation(
     control: questionTextControl,
-    validators: [
-      Validators.required,
-      Validators.minLength(1),
-      Validators.maxLength(questionTextMaxLength),
-    ],
+    validators: [Validators.required, Validators.minLength(1)],
     validationMessages: {
       ValidationMessage.required: (error) => tr.form_field_question_required,
       ValidationMessage.minLength: (error) => tr.form_field_question_required,
-      ValidationMessage.maxLength: (error) =>
-          tr.free_text_validation_max_length(questionTextMaxLength),
     },
   );
-
-  FormControlValidation get questionInfoTextMaxLengthValidation =>
-      FormControlValidation(
-        control: questionInfoTextControl,
-        validators: [Validators.maxLength(questionInfoTextMaxLength)],
-        validationMessages: {
-          ValidationMessage.maxLength: (error) =>
-              tr.free_text_validation_max_length(questionInfoTextMaxLength),
-        },
-      );
 
   FormControlValidation get numValidChoiceOptions => FormControlValidation(
     control: choiceResponseOptionsArray,

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
@@ -28,6 +28,9 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
         IListActionProvider<FormControl<dynamic>>,
         IConditionalQuestionProperties {
   static const defaultQuestionType = SurveyQuestionType.choice;
+  static const Set<SurveyQuestionType> _hiddenQuestionTypes = {
+    SurveyQuestionType.fitbit,
+  };
 
   QuestionFormViewModel({
     super.formData,
@@ -150,6 +153,11 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
 
   List<FormControlOption<SurveyQuestionType>> get questionTypeControlOptions =>
       QuestionFormData.questionTypeFormDataFactories.keys
+          .where(
+            (questionType) =>
+                !_hiddenQuestionTypes.contains(questionType) ||
+                questionType == questionTypeControl.value,
+          )
           .map(
             (questionType) =>
                 FormControlOption(questionType, questionType.string),

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
@@ -28,6 +28,8 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
         IListActionProvider<FormControl<dynamic>>,
         IConditionalQuestionProperties {
   static const defaultQuestionType = SurveyQuestionType.choice;
+  static const int questionTextMaxLength = 200;
+  static const int questionInfoTextMaxLength = 500;
 
   QuestionFormViewModel({
     super.formData,
@@ -599,8 +601,14 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
   };
 
   late final FormValidationConfigSet _sharedValidationConfig = {
-    StudyFormValidationSet.draft: [questionTextRequired],
-    StudyFormValidationSet.publish: [questionTextRequired],
+    StudyFormValidationSet.draft: [
+      questionTextRequired,
+      questionInfoTextMaxLengthValidation,
+    ],
+    StudyFormValidationSet.publish: [
+      questionTextRequired,
+      questionInfoTextMaxLengthValidation,
+    ],
   };
 
   late final Map<SurveyQuestionType, FormValidationConfigSet>
@@ -689,12 +697,28 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
 
   FormControlValidation get questionTextRequired => FormControlValidation(
     control: questionTextControl,
-    validators: [Validators.required, Validators.minLength(1)],
+    validators: [
+      Validators.required,
+      Validators.minLength(1),
+      Validators.maxLength(questionTextMaxLength),
+    ],
     validationMessages: {
       ValidationMessage.required: (error) => tr.form_field_question_required,
       ValidationMessage.minLength: (error) => tr.form_field_question_required,
+      ValidationMessage.maxLength: (error) =>
+          tr.free_text_validation_max_length(questionTextMaxLength),
     },
   );
+
+  FormControlValidation get questionInfoTextMaxLengthValidation =>
+      FormControlValidation(
+        control: questionInfoTextControl,
+        validators: [Validators.maxLength(questionInfoTextMaxLength)],
+        validationMessages: {
+          ValidationMessage.maxLength: (error) =>
+              tr.free_text_validation_max_length(questionInfoTextMaxLength),
+        },
+      );
 
   FormControlValidation get numValidChoiceOptions => FormControlValidation(
     control: choiceResponseOptionsArray,

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_controller.dart
@@ -216,6 +216,7 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
       .toList();
   late final FormArray<String> boolResponseOptionsArray = FormArray(
     boolOptions,
+    disabled: true,
   );
 
   // Image
@@ -226,6 +227,7 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
       .toList();
   late final FormArray<String> imageResponseOptionsArray = FormArray(
     imageOptions,
+    disabled: true,
   );
 
   //Pain
@@ -237,6 +239,7 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
 
   late final FormArray<String> painResponseOptionsArray = FormArray(
     painOptions,
+    disabled: true,
   );
 
   // Date
@@ -903,6 +906,27 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
     onResponseOptionsChanged(answerOptionsControls);
   }
 
+  void _syncFixedResponseOptionStates() {
+    final fixedArrays = [
+      ('bool', boolResponseOptionsArray),
+      ('image', imageResponseOptionsArray),
+      ('audio', audioResponseOptionsArray),
+      ('pain', painResponseOptionsArray),
+    ];
+
+    for (final (_, formArray) in fixedArrays) {
+      if (formArray.enabled) {
+        formArray.markAsDisabled(emitEvent: false, updateParent: false);
+      }
+      for (final control in formArray.controls) {
+        if (control.enabled) {
+          control.markAsDisabled(emitEvent: false, updateParent: false);
+        }
+      }
+    }
+    form.updateValueAndValidity(updateParent: false, emitEvent: false);
+  }
+
   void attachFitbitCredentialsFormViewModel(
     FitbitCredentialsFormViewModel fitbitCredentialsFormViewModel,
   ) {
@@ -921,6 +945,13 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
   @override
   void initControls() {
     _updateScaleMidValueControls();
+    _syncFixedResponseOptionStates();
+  }
+
+  @override
+  void markFormGroupChanged() {
+    super.markFormGroupChanged();
+    _syncFixedResponseOptionStates();
   }
 
   @override
@@ -939,7 +970,6 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
     // Type-specific controls
     switch (data.questionType) {
       case SurveyQuestionType.bool:
-        break;
       case SurveyQuestionType.image:
         break;
       case SurveyQuestionType.audio:
@@ -1001,6 +1031,7 @@ class QuestionFormViewModel extends ManagedFormViewModel<QuestionFormData>
         dateDefaultSpecificDateControl.value = data.defaultSpecificDate;
         dateDefaultSpecificTimeControl.value = data.defaultSpecificTime;
     }
+    _syncFixedResponseOptionStates();
   }
 
   @override

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_data.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_data.dart
@@ -14,6 +14,22 @@ typedef SurveyQuestionFormDataFactory =
     );
 
 abstract class QuestionFormData implements IFormData {
+  static Object? normalizeResponseOptionKey(dynamic responseOption) {
+    if (responseOption is Choice) {
+      return responseOption.id;
+    }
+    return responseOption;
+  }
+
+  static bool isSupportedEligibilityValue(dynamic value) {
+    return switch (value) {
+      null => false,
+      String() || num() || bool() || DateTime() => true,
+      List<dynamic>() => value.every(isSupportedEligibilityValue),
+      _ => false,
+    };
+  }
+
   static Map<SurveyQuestionType, SurveyQuestionFormDataFactory>
   questionTypeFormDataFactories = {
     SurveyQuestionType.scale: (question, eligibilityCriteria) {
@@ -135,16 +151,24 @@ abstract class QuestionFormData implements IFormData {
     // app (as of now), so we need to generate conditions for the qualifying
     // response options here
     for (final responseOption in responseOptions) {
-      final isQualifying = responseOptionsValidity[responseOption] ?? true;
+      final isQualifying =
+          responseOptionsValidity[normalizeResponseOptionKey(responseOption)] ??
+          true;
       if (isQualifying) {
         final answer = constructAnswerFor(responseOption);
         final selectedValue = answer.response;
+        if (!isSupportedEligibilityValue(selectedValue)) {
+          continue;
+        }
         if (selectedValue is List) {
           expression.choices.addAll(selectedValue);
         } else {
           expression.choices.add(selectedValue);
         }
       }
+    }
+    if (expression.choices.isEmpty) {
+      return null;
     }
     criterion.condition = expression;
     return criterion;
@@ -173,7 +197,8 @@ abstract class QuestionFormData implements IFormData {
             responseOptionValidity ||
             (criterion.condition.evaluate(questionnaireState) ?? false);
       }
-      result[responseOption] = responseOptionValidity;
+      result[normalizeResponseOptionKey(responseOption)] =
+          responseOptionValidity;
     }
 
     responseOptionsValidity = result;

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_view.dart
@@ -93,39 +93,41 @@ class _SurveyQuestionFormViewState
   @override
   Widget build(BuildContext context) {
     return PointerInterceptor(
-      child: SelectionArea(
-        child: Column(
-          children: [
-            _buildQuestionText(context),
-            if (isQuestionHelpTextFieldVisible)
-              Column(
-                children: [
-                  const SizedBox(height: 16.0),
-                  _buildQuestionHelpText(context),
-                ],
-              )
-            else
-              const SizedBox.shrink(),
-            if (widget.isHtmlStyleable)
-              HtmlStylingBanner(
-                isDismissed: isStylingInformationDismissed,
-                onDismissed: onDismissedCallback,
-              ),
-            const SizedBox(height: 24.0),
-            ReactiveFormConsumer(
-              builder: (context, formGroup, child) {
-                return Column(
-                  children: [
-                    _buildResponseTypeHeader(context),
-                    const SizedBox(height: 16.0),
-                    questionTypeBodyBuilder(context),
-                  ],
-                );
-              },
+      child: Column(
+        children: [
+          _buildQuestionText(context),
+          if (isQuestionHelpTextFieldVisible)
+            Column(
+              children: [
+                const SizedBox(height: 16.0),
+                _buildQuestionHelpText(context),
+              ],
+            )
+          else
+            const SizedBox.shrink(),
+          if (widget.isHtmlStyleable)
+            HtmlStylingBanner(
+              isDismissed: isStylingInformationDismissed,
+              onDismissed: onDismissedCallback,
             ),
-          ],
-        ),
+          const SizedBox(height: 24.0),
+          _buildResponseTypeSection(context),
+        ],
       ),
+    );
+  }
+
+  Widget _buildResponseTypeSection(BuildContext context) {
+    return Column(
+      children: [
+        _buildResponseTypeHeader(context),
+        const SizedBox(height: 16.0),
+        ReactiveValueListenableBuilder<SurveyQuestionType>(
+          formControl: formViewModel.questionTypeControl,
+          builder: (context, control, child) =>
+              questionTypeBodyBuilder(context),
+        ),
+      ],
     );
   }
 
@@ -353,9 +355,10 @@ class _SurveyQuestionFormViewState
   }
 
   Widget _buildCharacterCounter(FormControl<String> control, int maxLength) {
-    return ReactiveFormConsumer(
-      builder: (context, form, child) {
-        final currentLength = control.value?.length ?? 0;
+    return ReactiveValueListenableBuilder<String>(
+      formControl: control,
+      builder: (context, reactiveControl, child) {
+        final currentLength = reactiveControl.value?.length ?? 0;
         return Align(
           alignment: Alignment.centerRight,
           child: Text('$currentLength/$maxLength'),

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_view.dart
@@ -282,6 +282,22 @@ class _SurveyQuestionFormViewState
                     ),
                 ],
               ),
+              if (!formViewModel.isReadonly)
+                Opacity(
+                  opacity: ThemeConfig.kMuteFadeFactor,
+                  child: Hyperlink(
+                    text: tr.action_remove,
+                    onClick: () {
+                      formViewModel.questionInfoTextControl.value = '';
+                      setState(() {
+                        isQuestionHelpTextFieldVisible = false;
+                      });
+                    },
+                    visitedColor: null,
+                  ),
+                )
+              else
+                const SizedBox.shrink(),
             ],
           ),
           input: ReactiveTextField(

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:reactive_forms/reactive_forms.dart';
@@ -43,6 +44,8 @@ class SurveyQuestionFormView extends ConsumerStatefulWidget {
 class _SurveyQuestionFormViewState
     extends ConsumerState<SurveyQuestionFormView> {
   QuestionFormViewModel get formViewModel => widget.formViewModel;
+  static const int _questionFieldVisibleLines = 5;
+  static const int _questionHelpFieldVisibleLines = 5;
 
   late bool isQuestionHelpTextFieldVisible =
       formViewModel.questionInfoTextControl.value?.isNotEmpty ?? false;
@@ -175,9 +178,13 @@ class _SurveyQuestionFormViewState
           ],
         ),
         const SizedBox(height: 16.0),
-        TextParagraph(
-          text: tr.form_field_question_response_options_description,
-          style: ThemeConfig.bodyTextMuted(theme),
+        SizedBox(
+          width: double.infinity,
+          child: TextParagraph(
+            text: tr.form_field_question_response_options_description,
+            style: ThemeConfig.bodyTextMuted(theme),
+            textAlign: TextAlign.justify,
+          ),
         ),
       ],
     );
@@ -234,13 +241,28 @@ class _SurveyQuestionFormViewState
                 const SizedBox.shrink(),
             ],
           ),
-          input: ReactiveTextField(
-            formControl: formViewModel.questionTextControl,
-            decoration: InputDecoration(hintText: tr.form_field_question),
-            validationMessages:
-                formViewModel.questionTextControl.validationMessages,
-            minLines: 3,
-            maxLines: 3,
+          input: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ReactiveTextField(
+                formControl: formViewModel.questionTextControl,
+                decoration: InputDecoration(hintText: tr.form_field_question),
+                validationMessages:
+                    formViewModel.questionTextControl.validationMessages,
+                minLines: _questionFieldVisibleLines,
+                maxLines: _questionFieldVisibleLines,
+                inputFormatters: [
+                  LengthLimitingTextInputFormatter(
+                    QuestionFormViewModel.questionTextMaxLength,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8.0),
+              _buildCharacterCounter(
+                formViewModel.questionTextControl,
+                QuestionFormViewModel.questionTextMaxLength,
+              ),
+            ],
           ),
         ),
       ],
@@ -300,19 +322,45 @@ class _SurveyQuestionFormViewState
                 const SizedBox.shrink(),
             ],
           ),
-          input: ReactiveTextField(
-            formControl: formViewModel.questionInfoTextControl,
-            validationMessages:
-                formViewModel.questionInfoTextControl.validationMessages,
-            minLines: 3,
-            maxLines: 3,
-            decoration: InputDecoration(
-              hintText: tr.form_field_question_help_text_hint,
-              //helperText: "", // reserve space
-            ),
+          input: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ReactiveTextField(
+                formControl: formViewModel.questionInfoTextControl,
+                validationMessages:
+                    formViewModel.questionInfoTextControl.validationMessages,
+                minLines: _questionHelpFieldVisibleLines,
+                maxLines: _questionHelpFieldVisibleLines,
+                inputFormatters: [
+                  LengthLimitingTextInputFormatter(
+                    QuestionFormViewModel.questionInfoTextMaxLength,
+                  ),
+                ],
+                decoration: InputDecoration(
+                  hintText: tr.form_field_question_help_text_hint,
+                ),
+              ),
+              const SizedBox(height: 8.0),
+              _buildCharacterCounter(
+                formViewModel.questionInfoTextControl,
+                QuestionFormViewModel.questionInfoTextMaxLength,
+              ),
+            ],
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildCharacterCounter(FormControl<String> control, int maxLength) {
+    return ReactiveFormConsumer(
+      builder: (context, form, child) {
+        final currentLength = control.value?.length ?? 0;
+        return Align(
+          alignment: Alignment.centerRight,
+          child: Text('$currentLength/$maxLength'),
+        );
+      },
     );
   }
 }

--- a/designer_v2/lib/features/design/shared/questionnaire/question/question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/question_form_view.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:reactive_forms/reactive_forms.dart';
@@ -253,16 +252,6 @@ class _SurveyQuestionFormViewState
                     formViewModel.questionTextControl.validationMessages,
                 minLines: _questionFieldVisibleLines,
                 maxLines: _questionFieldVisibleLines,
-                inputFormatters: [
-                  LengthLimitingTextInputFormatter(
-                    QuestionFormViewModel.questionTextMaxLength,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 8.0),
-              _buildCharacterCounter(
-                formViewModel.questionTextControl,
-                QuestionFormViewModel.questionTextMaxLength,
               ),
             ],
           ),
@@ -333,37 +322,14 @@ class _SurveyQuestionFormViewState
                     formViewModel.questionInfoTextControl.validationMessages,
                 minLines: _questionHelpFieldVisibleLines,
                 maxLines: _questionHelpFieldVisibleLines,
-                inputFormatters: [
-                  LengthLimitingTextInputFormatter(
-                    QuestionFormViewModel.questionInfoTextMaxLength,
-                  ),
-                ],
                 decoration: InputDecoration(
                   hintText: tr.form_field_question_help_text_hint,
                 ),
-              ),
-              const SizedBox(height: 8.0),
-              _buildCharacterCounter(
-                formViewModel.questionInfoTextControl,
-                QuestionFormViewModel.questionInfoTextMaxLength,
               ),
             ],
           ),
         ),
       ],
-    );
-  }
-
-  Widget _buildCharacterCounter(FormControl<String> control, int maxLength) {
-    return ReactiveValueListenableBuilder<String>(
-      formControl: control,
-      builder: (context, reactiveControl, child) {
-        final currentLength = reactiveControl.value?.length ?? 0;
-        return Align(
-          alignment: Alignment.centerRight,
-          child: Text('$currentLength/$maxLength'),
-        );
-      },
     );
   }
 }

--- a/designer_v2/lib/features/design/shared/questionnaire/question/types/bool_question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/types/bool_question_form_view.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:reactive_forms/reactive_forms.dart';
 import 'package:studyu_designer_v2/common_views/standard_table.dart';
 import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/question_form_controller.dart';
-import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/types/choice_question_form_view.dart';
+import 'package:studyu_designer_v2/features/design/shared/questionnaire/question/question_form_data.dart';
+import 'package:studyu_designer_v2/localization/app_translation.dart';
 
 class BoolQuestionFormView extends ConsumerWidget {
   const BoolQuestionFormView({required this.formViewModel, super.key});
@@ -16,8 +16,8 @@ class BoolQuestionFormView extends ConsumerWidget {
       children: [
         Opacity(
           opacity: 0.5,
-          child: StandardTable<AbstractControl>(
-            items: formViewModel.answerOptionsControls,
+          child: StandardTable<String>(
+            items: BoolQuestionFormData.kResponseOptions.keys.toList(),
             columns: [
               StandardTableColumn(
                 label: '', // don't care (showTableHeader=false)
@@ -28,9 +28,9 @@ class BoolQuestionFormView extends ConsumerWidget {
               ),
             ],
             onSelectItem: (_) => {}, // no-op
-            buildCellsAt: (context, control, _, _) =>
-                buildChoiceOptionRow(context, control),
-            trailingActionsAt: (control, _) => [],
+            buildCellsAt: (context, option, _, _) =>
+                _buildBoolOptionRow(context, option),
+            trailingActionsAt: (option, _) => [],
             cellSpacing: 0.0,
             rowSpacing: 8.0,
             minRowHeight: null,
@@ -42,5 +42,28 @@ class BoolQuestionFormView extends ConsumerWidget {
         ),
       ],
     );
+  }
+
+  List<Widget> _buildBoolOptionRow(BuildContext context, String option) {
+    final theme = Theme.of(context);
+    return [
+      Center(
+        child: Icon(
+          Icons.radio_button_off_outlined,
+          color: theme.dividerTheme.color ?? theme.dividerColor,
+          size: 12.0,
+        ),
+      ),
+      IgnorePointer(
+        child: TextFormField(
+          initialValue: option,
+          enabled: false,
+          readOnly: true,
+          decoration: InputDecoration(
+            hintText: tr.form_array_response_options_choice_hint,
+          ),
+        ),
+      ),
+    ];
   }
 }

--- a/designer_v2/lib/features/design/shared/questionnaire/question/types/choice_question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/types/choice_question_form_view.dart
@@ -90,15 +90,9 @@ List<Widget> buildChoiceOptionRow(
 ) {
   final theme = Theme.of(context);
   final isReadonly = formControl.disabled;
-  final fieldKey = ValueKey(
-    'question-option-${formControl.runtimeType}-${formControl.value}-$isReadonly',
-  );
 
   Widget buildOptionField(Widget child) {
-    return IgnorePointer(
-      ignoring: isReadonly,
-      child: KeyedSubtree(key: fieldKey, child: child),
-    );
+    return IgnorePointer(ignoring: isReadonly, child: child);
   }
 
   return [

--- a/designer_v2/lib/features/design/shared/questionnaire/question/types/choice_question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/types/choice_question_form_view.dart
@@ -90,6 +90,17 @@ List<Widget> buildChoiceOptionRow(
 ) {
   final theme = Theme.of(context);
   final isReadonly = formControl.disabled;
+  final fieldKey = ValueKey(
+    'question-option-${formControl.runtimeType}-${formControl.value}-$isReadonly',
+  );
+
+  Widget buildOptionField(Widget child) {
+    return IgnorePointer(
+      ignoring: isReadonly,
+      child: KeyedSubtree(key: fieldKey, child: child),
+    );
+  }
+
   return [
     Center(
       child: Icon(
@@ -99,20 +110,26 @@ List<Widget> buildChoiceOptionRow(
       ),
     ),
     if (formControl is FormControl<Choice>)
-      ReactiveTextField<Choice>(
-        formControl: formControl,
-        valueAccessor: ChoiceValueAccessor(formControl),
-        readOnly: isReadonly,
-        decoration: InputDecoration(
-          hintText: tr.form_array_response_options_choice_hint,
+      buildOptionField(
+        ReactiveTextField<Choice>(
+          formControl: formControl,
+          valueAccessor: ChoiceValueAccessor(formControl),
+          readOnly: isReadonly,
+          decoration: InputDecoration(
+            hintText: tr.form_array_response_options_choice_hint,
+            enabled: !isReadonly,
+          ),
         ),
       )
     else
-      ReactiveTextField<String>(
-        formControl: formControl as FormControl<String>,
-        readOnly: isReadonly,
-        decoration: InputDecoration(
-          hintText: tr.form_array_response_options_choice_hint,
+      buildOptionField(
+        ReactiveTextField<String>(
+          formControl: formControl as FormControl<String>,
+          readOnly: isReadonly,
+          decoration: InputDecoration(
+            hintText: tr.form_array_response_options_choice_hint,
+            enabled: !isReadonly,
+          ),
         ),
       ),
   ];

--- a/designer_v2/lib/features/design/shared/questionnaire/question/types/choice_question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/types/choice_question_form_view.dart
@@ -89,6 +89,7 @@ List<Widget> buildChoiceOptionRow(
   AbstractControl formControl,
 ) {
   final theme = Theme.of(context);
+  final isReadonly = formControl.disabled;
   return [
     Center(
       child: Icon(
@@ -101,6 +102,7 @@ List<Widget> buildChoiceOptionRow(
       ReactiveTextField<Choice>(
         formControl: formControl,
         valueAccessor: ChoiceValueAccessor(formControl),
+        readOnly: isReadonly,
         decoration: InputDecoration(
           hintText: tr.form_array_response_options_choice_hint,
         ),
@@ -108,6 +110,7 @@ List<Widget> buildChoiceOptionRow(
     else
       ReactiveTextField<String>(
         formControl: formControl as FormControl<String>,
+        readOnly: isReadonly,
         decoration: InputDecoration(
           hintText: tr.form_array_response_options_choice_hint,
         ),

--- a/designer_v2/lib/features/design/shared/questionnaire/question/types/choice_question_form_view.dart
+++ b/designer_v2/lib/features/design/shared/questionnaire/question/types/choice_question_form_view.dart
@@ -10,12 +10,16 @@ import 'package:studyu_designer_v2/localization/app_translation.dart';
 import 'package:studyu_designer_v2/theme.dart';
 
 class ChoiceQuestionFormView extends ConsumerWidget {
+  static const double _multipleChoiceSwitchScale = 0.66;
+
   const ChoiceQuestionFormView({required this.formViewModel, super.key});
 
   final QuestionFormViewModel formViewModel;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+
     return Column(
       children: [
         FormTableLayout(
@@ -23,8 +27,33 @@ class ChoiceQuestionFormView extends ConsumerWidget {
             FormTableRow(
               label: tr.form_field_response_choice_multiple,
               labelHelpText: tr.form_field_response_choice_multiple_tooltip,
-              input: ReactiveSwitch(
-                formControl: formViewModel.isMultipleChoiceControl,
+              input: Align(
+                alignment: Alignment.centerLeft,
+                child: MouseRegion(
+                  cursor: SystemMouseCursors.click,
+                  child: Transform.translate(
+                    offset: const Offset(-8.0, 0),
+                    child: Transform.scale(
+                      scale: _multipleChoiceSwitchScale,
+                      alignment: Alignment.centerLeft,
+                      child: Theme(
+                        data: theme.copyWith(
+                          switchTheme: theme.switchTheme.copyWith(
+                            overlayColor: const WidgetStatePropertyAll(
+                              Colors.transparent,
+                            ),
+                            splashRadius: 0,
+                            materialTapTargetSize:
+                                MaterialTapTargetSize.shrinkWrap,
+                          ),
+                        ),
+                        child: ReactiveSwitch(
+                          formControl: formViewModel.isMultipleChoiceControl,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
               ),
             ),
           ],

--- a/designer_v2/lib/features/forms/form_list_view.dart
+++ b/designer_v2/lib/features/forms/form_list_view.dart
@@ -8,7 +8,7 @@ import 'package:studyu_designer_v2/common_views/standard_table.dart';
 import 'package:studyu_designer_v2/features/forms/form_array_table.dart';
 
 class FormListView<T> extends StatelessWidget {
-  static const int kRowTitleMaxLines = 3;
+  static const int kRowTitleMaxLines = 2;
 
   const FormListView({
     required this.control,
@@ -56,6 +56,10 @@ class FormListView<T> extends StatelessWidget {
   final bool hideLeadingTrailingWhenEmpty;
   final bool reorderable;
   final void Function(int oldIndex, int newIndex)? onReorder;
+
+  String _normalizedRowTitle(T item) {
+    return rowTitle(item).replaceAll(RegExp(r'\s+'), ' ').trim();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -131,7 +135,7 @@ class FormListView<T> extends StatelessWidget {
                         if (rowPrefix != null) rowPrefix!(context, item, index),
                         Expanded(
                           child: Text(
-                            rowTitle(item),
+                            _normalizedRowTitle(item),
                             style: theme.textTheme.bodyMedium,
                             maxLines: kRowTitleMaxLines,
                             overflow: TextOverflow.ellipsis,
@@ -174,7 +178,7 @@ class FormListView<T> extends StatelessWidget {
                         if (rowPrefix != null) rowPrefix!(context, item, index),
                         Expanded(
                           child: Text(
-                            rowTitle(item),
+                            _normalizedRowTitle(item),
                             style: theme.textTheme.bodyMedium,
                             maxLines: kRowTitleMaxLines,
                             overflow: TextOverflow.ellipsis,

--- a/designer_v2/lib/features/forms/form_list_view.dart
+++ b/designer_v2/lib/features/forms/form_list_view.dart
@@ -21,6 +21,7 @@ class FormListView<T> extends StatelessWidget {
     this.leadingWidget,
     this.sectionTitle,
     this.sectionDescription,
+    this.sectionDescriptionTextAlign,
     this.emptyIcon,
     this.emptyTitle,
     this.emptyDescription,
@@ -40,6 +41,7 @@ class FormListView<T> extends StatelessWidget {
   final String onNewItemLabel;
   final String? sectionTitle;
   final String? sectionDescription;
+  final TextAlign? sectionDescriptionTextAlign;
   final IconData? emptyIcon;
   final String? emptyTitle;
   final String? emptyDescription;
@@ -68,7 +70,11 @@ class FormListView<T> extends StatelessWidget {
         if (sectionDescription != null && !(hasEmptyWidget && items.isEmpty))
           Padding(
             padding: const EdgeInsets.only(bottom: 16.0),
-            child: Text(sectionDescription!, style: theme.textTheme.bodyMedium),
+            child: Text(
+              sectionDescription!,
+              style: theme.textTheme.bodyMedium,
+              textAlign: sectionDescriptionTextAlign,
+            ),
           ),
         if (items.isEmpty && hasEmptyWidget)
           EmptyBody(

--- a/designer_v2/lib/features/forms/form_list_view.dart
+++ b/designer_v2/lib/features/forms/form_list_view.dart
@@ -26,6 +26,7 @@ class FormListView<T> extends StatelessWidget {
     this.emptyTitle,
     this.emptyDescription,
     this.itemsPadding = const EdgeInsets.symmetric(vertical: 8.0),
+    this.buttonTopPadding = 16.0,
     this.hideLeadingTrailingWhenEmpty = false,
     this.reorderable = false,
     this.onReorder,
@@ -49,6 +50,7 @@ class FormListView<T> extends StatelessWidget {
   final WidgetBuilderAt<T>? rowSuffix;
   final Widget? leadingWidget;
   final EdgeInsets itemsPadding;
+  final double buttonTopPadding;
   final bool hideLeadingTrailingWhenEmpty;
   final bool reorderable;
   final void Function(int oldIndex, int newIndex)? onReorder;
@@ -186,7 +188,7 @@ class FormListView<T> extends StatelessWidget {
           ),
         if (!hideLeadingTrailingWhenEmpty || items.isNotEmpty)
           Padding(
-            padding: const EdgeInsets.only(top: 16.0),
+            padding: EdgeInsets.only(top: buttonTopPadding),
             child: _newItemButton(),
           ),
       ],

--- a/designer_v2/lib/features/forms/form_list_view.dart
+++ b/designer_v2/lib/features/forms/form_list_view.dart
@@ -8,6 +8,8 @@ import 'package:studyu_designer_v2/common_views/standard_table.dart';
 import 'package:studyu_designer_v2/features/forms/form_array_table.dart';
 
 class FormListView<T> extends StatelessWidget {
+  static const int kRowTitleMaxLines = 3;
+
   const FormListView({
     required this.control,
     required this.items,
@@ -131,6 +133,8 @@ class FormListView<T> extends StatelessWidget {
                           child: Text(
                             rowTitle(item),
                             style: theme.textTheme.bodyMedium,
+                            maxLines: kRowTitleMaxLines,
+                            overflow: TextOverflow.ellipsis,
                           ),
                         ),
                         if (rowSuffix != null) rowSuffix!(context, item, index),
@@ -172,6 +176,8 @@ class FormListView<T> extends StatelessWidget {
                           child: Text(
                             rowTitle(item),
                             style: theme.textTheme.bodyMedium,
+                            maxLines: kRowTitleMaxLines,
+                            overflow: TextOverflow.ellipsis,
                           ),
                         ),
                         if (rowSuffix != null) rowSuffix!(context, item, index),

--- a/designer_v2/lib/localization/app_de.arb
+++ b/designer_v2/lib/localization/app_de.arb
@@ -539,6 +539,7 @@
   "form_field_consent_text_tooltip": "Gib den Text ein, der bei der Anmeldung zur Studie in der StudyU App gelesen & bestätigt werden muss",
   "form_field_consent_text_hint": "Gib den Text ein, der gelesen & bestätigt werden muss",
   "form_field_consent_text_required": "Die Einwilligungserklärung darf nicht leer sein",
+  "form_field_consent_icon_required": "Du musst ein Icon für die Einwilligungserklärung auswählen",
   "@__________________STUDYPAGE_DESIGN_INTERVENTIONS_________________": {},
   "form_study_design_interventions_description": "Auf dieser Seite legst du die in der Studie zu untersuchenden Interventionen und deren zeitliche Abfolge fest. In N-of-1 Studien durchläuft der gleiche Teilnehmer eine festgelegte Abfolge von Interventionsphasen in einem oder mehreren Durchläufen (diese Art von Studienplan wird auch als Cross-over Studie bezeichnet). Jede Interventionsphase besteht aus einer oder mehreren Maßnahmen, die während der jeweils aktiven Phasen vom Teilnehmer erfüllt werden müssen.\n\nBitte beachte: wenn du mehr als zwei Interventionsphasen festlegst, können Teilnehmer bei der Anmeldung zur Studie zwei beliebige Interventionen auswählen, die im weiteren Verlauf miteinander verglichen werden.",
   "link_n_of_1_learn_more": "Mehr über N-of-1 Studien erfahren",

--- a/designer_v2/lib/localization/app_en.arb
+++ b/designer_v2/lib/localization/app_en.arb
@@ -543,6 +543,7 @@
   "form_field_consent_text_tooltip": "Enter the terms the participant must read & accept when enrolling in the study.\nThe terms are shown when clicking on the corresponding card in the app's consent screen.",
   "form_field_consent_text_hint": "Enter the full terms to be read & accepted",
   "form_field_consent_text_required": "The text for your participant consent must not be empty",
+  "form_field_consent_icon_required": "You must select an icon for your participant consent",
   "@__________________STUDYPAGE_DESIGN_INTERVENTIONS_________________": {},
   "form_study_design_interventions_description": "Define the different phases of interventions to be studied, as well as the their sequence and frequency. In N-of-1 trials, a single participant will go through the intervention phases once or multiple times in a pre-specified order (so called multi-crossover trial). Each intervention consists of one or more tasks which are administered during the corresponding phase.\n\nNote: If you specify more than two interventions, participants are free to choose any two interventions to compare when they begin the study.",
   "link_n_of_1_learn_more": "Learn more about N-of-1 trials",

--- a/designer_v2/lib/localization/app_localizations.dart
+++ b/designer_v2/lib/localization/app_localizations.dart
@@ -2607,6 +2607,12 @@ abstract class AppLocalizations {
   /// **'The text for your participant consent must not be empty'**
   String get form_field_consent_text_required;
 
+  /// No description provided for @form_field_consent_icon_required.
+  ///
+  /// In en, this message translates to:
+  /// **'You must select an icon for your participant consent'**
+  String get form_field_consent_icon_required;
+
   /// No description provided for @form_study_design_interventions_description.
   ///
   /// In en, this message translates to:

--- a/designer_v2/lib/localization/app_localizations_de.dart
+++ b/designer_v2/lib/localization/app_localizations_de.dart
@@ -1464,6 +1464,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Die Einwilligungserklärung darf nicht leer sein';
 
   @override
+  String get form_field_consent_icon_required =>
+      'Du musst ein Icon für die Einwilligungserklärung auswählen';
+
+  @override
   String get form_study_design_interventions_description =>
       'Auf dieser Seite legst du die in der Studie zu untersuchenden Interventionen und deren zeitliche Abfolge fest. In N-of-1 Studien durchläuft der gleiche Teilnehmer eine festgelegte Abfolge von Interventionsphasen in einem oder mehreren Durchläufen (diese Art von Studienplan wird auch als Cross-over Studie bezeichnet). Jede Interventionsphase besteht aus einer oder mehreren Maßnahmen, die während der jeweils aktiven Phasen vom Teilnehmer erfüllt werden müssen.\n\nBitte beachte: wenn du mehr als zwei Interventionsphasen festlegst, können Teilnehmer bei der Anmeldung zur Studie zwei beliebige Interventionen auswählen, die im weiteren Verlauf miteinander verglichen werden.';
 

--- a/designer_v2/lib/localization/app_localizations_en.dart
+++ b/designer_v2/lib/localization/app_localizations_en.dart
@@ -1452,6 +1452,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'The text for your participant consent must not be empty';
 
   @override
+  String get form_field_consent_icon_required =>
+      'You must select an icon for your participant consent';
+
+  @override
   String get form_study_design_interventions_description =>
       'Define the different phases of interventions to be studied, as well as the their sequence and frequency. In N-of-1 trials, a single participant will go through the intervention phases once or multiple times in a pre-specified order (so called multi-crossover trial). Each intervention consists of one or more tasks which are administered during the corresponding phase.\n\nNote: If you specify more than two interventions, participants are free to choose any two interventions to compare when they begin the study.';
 

--- a/designer_v2/lib/utils/extensions.dart
+++ b/designer_v2/lib/utils/extensions.dart
@@ -72,6 +72,10 @@ extension StringX on String {
     }
     return this;
   }
+
+  String compactWhitespace() {
+    return trim().replaceAll(RegExp(r'\s+'), ' ');
+  }
 }
 
 extension DurationX on Duration {


### PR DESCRIPTION
## Description
Refines Designer participation-page copy and spacing, fixes sidesheet dismissal behavior, and prevents editing locked yes/no screener response options.

## Visuals
Please attach the required screenshot or screen recording before merging.

## Testing Steps
1. Run `rtk fvm exec melos run designer_v2`.
2. Open Participation tab and verify participant-pool copy is justified, radio rows are top aligned, and screener/consent buttons sit closer to their descriptive text.
3. Open a screener question or consent sidesheet and verify `Cancel` and outside-click each dismiss the overlay with one interaction.
4. Edit a yes/no screener question and verify the predefined `Yes` and `No` option fields are not editable.

### PR Checklist
- [x] `fvm exec melos qualitycheck` passes
- [x] Screenshot or video attached, or this item removed for non-visual changes

THis screenshot shows that the yes/no in-editable fields are editable under certain actions.
<img width="738" height="582" alt="image" src="https://github.com/user-attachments/assets/fa37d5c4-5500-44c3-87a0-f364ebcb7b71" />

This screenshot shows that there is now a button "Remove" for removing additional text as it is not the best UI/UX design to hide this from the user and let them figure it out on their own that leaving this field empty will lead to no additional description.
<img width="748" height="874" alt="image" src="https://github.com/user-attachments/assets/c2d578c7-1142-424f-b61b-ed0afe02e1c5" />

This screenshot just shows some alignment and justifications along with space saving. 
<img width="858" height="434" alt="image" src="https://github.com/user-attachments/assets/802e5d45-ebbf-43e9-9475-5979cbccf263" />

Here, screening was not working, the overlay would close and everything but the choices were not saved. 
<img width="1107" height="841" alt="image" src="https://github.com/user-attachments/assets/39b54225-3a89-4474-aa57-0574d6e57222" />

