### PR TITLE
STUDYU-100: chore(ci): disable dart file lines workflow

### DIFF
--- a/.github/workflows/dart_file_lines.yml
+++ b/.github/workflows/dart_file_lines.yml
@@ -1,8 +1,7 @@
 name: Dart File Lines
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description
Disable the `Dart File Lines` workflow for automatic pull request events by changing its trigger from `pull_request` to `workflow_dispatch`.

Jira: https://studyu.atlassian.net/browse/STUDYU-100

## Testing Steps
1. Run `rtk ./scripts/pre-commit-check`.
2. Confirm `.github/workflows/dart_file_lines.yml` no longer contains the `pull_request` trigger.
3. Confirm the workflow still exists and can be run manually via `workflow_dispatch`.

### PR Checklist
- [ ] `fvm exec melos qualitycheck` passes
- [ ] Screenshot or video attached, or this item removed for non-visual changes
- [x] Description links related issues, or this item removed when no issue exists
