### PR TITLE
STUDYU-95: fix(app): restore cached studies safely

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -72,21 +72,23 @@ Future<void> main() async {
   usePathUrlStrategy();
   AppConfig? appConfig;
   String initialRoute = '/${RouteNames.loading}';
-  try {
-    appConfig = await AppConfig.getAppConfig();
-  } on PostgrestException catch (e) {
-    debugPrint('Postgres exception: $e');
-    if (e.code == 'PGRST301') {
-      // Unauthorized - likely due to wrong supabase environment variables
-      initialRoute = '/${RouteNames.appErrorScreen}';
+  if (appConnectionStatusController.status == AppConnectionStatus.healthy) {
+    try {
+      appConfig = await AppConfig.getAppConfig();
+    } on PostgrestException catch (e) {
+      debugPrint('Postgres exception: $e');
+      if (e.code == 'PGRST301') {
+        // Unauthorized - likely due to wrong supabase environment variables
+        initialRoute = '/${RouteNames.appErrorScreen}';
+      }
+    } catch (error) {
+      // device could be offline
+      final status = connectionStatusFromError(error);
+      if (status != null) {
+        appConnectionStatusController.setStatus(status);
+      }
+      debugPrint('Error fetching app config: $error');
     }
-  } catch (error) {
-    // device could be offline
-    final status = connectionStatusFromError(error);
-    if (status != null) {
-      appConnectionStatusController.setStatus(status);
-    }
-    debugPrint('Error fetching app config: $error');
   }
 
   if (appConfig != null && await isAppOutdated(appConfig)) {
@@ -106,6 +108,10 @@ Future<void> main() async {
         final currentLocation =
             router.routerDelegate.currentConfiguration.uri.path;
         if (currentLocation == '/${RouteNames.appOutdated}') return;
+        if (appConnectionStatusController.status !=
+            AppConnectionStatus.healthy) {
+          return;
+        }
 
         final appConfig = await AppConfig.getAppConfig();
         if (await isAppOutdated(appConfig)) {

--- a/app/lib/models/app_state.dart
+++ b/app/lib/models/app_state.dart
@@ -6,6 +6,7 @@ import 'package:studyu_app/util/notifications.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 const _activeSubjectSyncRetryDelay = Duration(seconds: 5);
 const _activeSubjectSyncSelectedColumns = [
@@ -198,9 +199,15 @@ class AppState with ChangeNotifier {
       if (!shouldAttemptParticipantAuthRecovery(error)) {
         return;
       }
-      final didRestoreSession =
-          await (debugRestoreParticipantSessionForSync ??
-              _restoreParticipantSessionForSync)();
+      final bool didRestoreSession;
+      try {
+        didRestoreSession =
+            await (debugRestoreParticipantSessionForSync ??
+                _restoreParticipantSessionForSync)();
+      } on AuthApiException catch (error) {
+        if (error.code == 'invalid_credentials') return;
+        rethrow;
+      }
       if (!didRestoreSession || activeSubject?.id != currentSubject.id) {
         return;
       }

--- a/app/lib/models/app_state.dart
+++ b/app/lib/models/app_state.dart
@@ -1,9 +1,18 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/notifications.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+
+const _activeSubjectSyncRetryDelay = Duration(seconds: 5);
+const _activeSubjectSyncSelectedColumns = [
+  '*',
+  'study!study_subject_studyId_fkey(*, study_fitbit_credentials:study_fitbit_credentials_studyId_fkey(*))',
+  'subject_progress(*)',
+];
 
 class AppState with ChangeNotifier {
   Study? selectedStudy;
@@ -18,6 +27,20 @@ class AppState with ChangeNotifier {
   String? pendingDeepLinkInviteCode;
   late final VoidCallback _connectionStatusListener;
   AppConnectionStatus _connectionStatus = appConnectionStatusController.status;
+  Timer? _activeSubjectSyncRetryTimer;
+  bool _activeSubjectSyncInFlight = false;
+  StreamSubscription<StudySubject>? _activeSubjectCacheSubscription;
+  StudySubject? _activeSubjectCacheSource;
+
+  @visibleForTesting
+  Future<StudySubject?> Function(String subjectId)?
+  debugFetchRemoteSubjectForSync;
+
+  @visibleForTesting
+  Duration? debugActiveSubjectSyncRetryDelay;
+
+  @visibleForTesting
+  Future<bool> Function()? debugRestoreParticipantSessionForSync;
 
   bool get hasPendingDeepLink =>
       pendingDeepLinkStudyId != null || pendingDeepLinkInviteCode != null;
@@ -46,13 +69,48 @@ class AppState with ChangeNotifier {
 
   void init(BuildContext context) {
     scheduleNotifications(context);
-    initCache();
+    _syncActiveSubjectCache();
+    scheduleActiveSubjectSyncRetryIfNeeded();
   }
 
-  void initCache() {
-    activeSubject!.onSave.listen((StudySubject subject) async {
+  void _syncActiveSubjectCache() {
+    final currentSubject = activeSubject;
+    if (currentSubject == null) return;
+    if (identical(_activeSubjectCacheSource, currentSubject) &&
+        _activeSubjectCacheSubscription != null) {
+      return;
+    }
+
+    _activeSubjectCacheSubscription?.cancel();
+    _activeSubjectCacheSource = currentSubject;
+
+    _activeSubjectCacheSubscription = currentSubject.onSave.listen((
+      StudySubject subject,
+    ) async {
+      activeSubject = subject;
+      if (selectedStudy == null || selectedStudy?.id == subject.study.id) {
+        selectedStudy = subject.study;
+      }
       await Cache.storeSubject(subject);
+      scheduleActiveSubjectSyncRetryIfNeeded();
+      notifyListeners();
     });
+  }
+
+  void updateActiveSubject(
+    StudySubject? subject, {
+    bool notifyListenersNow = true,
+    bool updateSelectedStudy = true,
+  }) {
+    activeSubject = subject;
+    if (updateSelectedStudy) {
+      selectedStudy = subject?.study;
+    }
+    _syncActiveSubjectCache();
+    scheduleActiveSubjectSyncRetryIfNeeded();
+    if (notifyListenersNow) {
+      notifyListeners();
+    }
   }
 
   void updateStudy(Study study) {
@@ -79,14 +137,119 @@ class AppState with ChangeNotifier {
     appConnectionStatusController.setStatus(status);
   }
 
+  void clearActiveStudyState() {
+    _cancelActiveSubjectSyncRetry();
+    _activeSubjectCacheSubscription?.cancel();
+    _activeSubjectCacheSubscription = null;
+    _activeSubjectCacheSource = null;
+    selectedStudy = null;
+    selectedInterventions = null;
+    activeSubject = null;
+    inviteCode = null;
+    preselectedInterventionIds = null;
+    studyNotifications = null;
+    notifyListeners();
+  }
+
   void _applyConnectionStatus(AppConnectionStatus status) {
     if (_connectionStatus == status) return;
     _connectionStatus = status;
+    if (status == AppConnectionStatus.healthy) {
+      _cancelActiveSubjectSyncRetry();
+    } else {
+      scheduleActiveSubjectSyncRetryIfNeeded();
+    }
     notifyListeners();
+  }
+
+  void scheduleActiveSubjectSyncRetryIfNeeded() {
+    if (_connectionStatus == AppConnectionStatus.healthy ||
+        activeSubject == null) {
+      _cancelActiveSubjectSyncRetry();
+      return;
+    }
+    _activeSubjectSyncRetryTimer ??= Timer.periodic(
+      debugActiveSubjectSyncRetryDelay ?? _activeSubjectSyncRetryDelay,
+      (_) => unawaited(retryCachedSubjectSynchronization()),
+    );
+  }
+
+  void _cancelActiveSubjectSyncRetry() {
+    _activeSubjectSyncRetryTimer?.cancel();
+    _activeSubjectSyncRetryTimer = null;
+  }
+
+  Future<void> retryCachedSubjectSynchronization() async {
+    if (_activeSubjectSyncInFlight) return;
+    final currentSubject = activeSubject;
+    if (currentSubject == null) {
+      _cancelActiveSubjectSyncRetry();
+      return;
+    }
+    _activeSubjectSyncInFlight = true;
+    try {
+      await _synchronizeCachedSubject(currentSubject);
+    } catch (error) {
+      final status = connectionStatusFromError(error);
+      if (status != null) {
+        appConnectionStatusController.setStatus(status);
+        return;
+      }
+      if (!shouldAttemptParticipantAuthRecovery(error)) {
+        return;
+      }
+      final didRestoreSession =
+          await (debugRestoreParticipantSessionForSync ??
+              _restoreParticipantSessionForSync)();
+      if (!didRestoreSession || activeSubject?.id != currentSubject.id) {
+        return;
+      }
+      try {
+        await _synchronizeCachedSubject(currentSubject);
+      } catch (recoveryError) {
+        final recoveryStatus = connectionStatusFromError(recoveryError);
+        if (recoveryStatus != null) {
+          appConnectionStatusController.setStatus(recoveryStatus);
+        }
+      }
+    } finally {
+      _activeSubjectSyncInFlight = false;
+    }
+  }
+
+  Future<void> _synchronizeCachedSubject(StudySubject currentSubject) async {
+    final fetchRemoteSubject =
+        debugFetchRemoteSubjectForSync ?? _fetchRemoteSubjectForSync;
+    final remoteSubject = await fetchRemoteSubject(currentSubject.id);
+    if (remoteSubject == null || activeSubject?.id != currentSubject.id) {
+      return;
+    }
+    final synchronizedSubject = await Cache.synchronize(remoteSubject);
+    if (activeSubject?.id != currentSubject.id) return;
+    appConnectionStatusController.setStatus(AppConnectionStatus.healthy);
+    updateActiveSubject(synchronizedSubject);
+    if (appConnectionStatusController.status == AppConnectionStatus.healthy) {
+      _cancelActiveSubjectSyncRetry();
+    }
+  }
+
+  Future<bool> _restoreParticipantSessionForSync() async {
+    await clearParticipantSession();
+    return signInParticipant();
+  }
+
+  Future<StudySubject?> _fetchRemoteSubjectForSync(String subjectId) {
+    return SupabaseQuery.getById<StudySubject>(
+      subjectId,
+      selectedColumns: _activeSubjectSyncSelectedColumns,
+    );
   }
 
   @override
   void dispose() {
+    _cancelActiveSubjectSyncRetry();
+    _activeSubjectCacheSubscription?.cancel();
+    _activeSubjectCacheSource = null;
     appConnectionStatusController.removeListener(_connectionStatusListener);
     super.dispose();
   }

--- a/app/lib/screens/app_onboarding/app_error_screen.dart
+++ b/app/lib/screens/app_onboarding/app_error_screen.dart
@@ -313,9 +313,9 @@ class _AppErrorScreenState extends State<AppErrorScreen> {
       await cancelNotifications(context);
 
       if (widget.reason == AppErrorReason.deletedStudy) {
-        StudyULogger.info("Clearing active study reference");
-        await deleteActiveStudyReference();
-        StudyULogger.info("Active study reference cleared");
+        StudyULogger.info("Clearing deleted subject local state");
+        await clearDeletedSubjectLocalState();
+        StudyULogger.info("Deleted subject local state cleared");
       } else {
         StudyULogger.info("Deleting all secure storage data");
         await SecureStorage.deleteAll();

--- a/app/lib/screens/app_onboarding/app_error_screen.dart
+++ b/app/lib/screens/app_onboarding/app_error_screen.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
+import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';
+import 'package:studyu_app/util/study_local_cleanup.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_core/env.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
@@ -284,6 +287,7 @@ class _AppErrorScreenState extends State<AppErrorScreen> {
   }
 
   Future<void> _showDeleteDataDialog(BuildContext context) async {
+    final appState = context.read<AppState>();
     final result = await showDialog<bool>(
       context: context,
       barrierDismissible: false,
@@ -309,12 +313,16 @@ class _AppErrorScreenState extends State<AppErrorScreen> {
     );
 
     if (result == true) {
-      if (!context.mounted) return;
-      await cancelNotifications(context);
+      if (!mounted) return;
 
       if (widget.reason == AppErrorReason.deletedStudy) {
         StudyULogger.info("Clearing deleted subject local state");
-        await clearDeletedSubjectLocalState();
+        final currentSubject = appState.activeSubject;
+        try {
+          await clearStudyLocalData(fallbackSubject: currentSubject);
+        } finally {
+          appState.clearActiveStudyState();
+        }
         StudyULogger.info("Deleted subject local state cleared");
       } else {
         StudyULogger.info("Deleting all secure storage data");
@@ -322,8 +330,17 @@ class _AppErrorScreenState extends State<AppErrorScreen> {
         StudyULogger.info("Secure storage data deleted");
       }
 
-      if (!context.mounted) return;
-      context.goNamed(RouteNames.welcome);
+      if (!mounted) return;
+      try {
+        await cancelNotifications(this.context);
+      } catch (error) {
+        StudyULogger.warning(
+          'Could not cancel notifications during app reset: $error',
+        );
+      }
+
+      if (!mounted) return;
+      this.context.goNamed(RouteNames.welcome);
       return;
     }
 

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -161,26 +161,32 @@ Future<T?> restoreCachedValueForStartup<T>({
 }
 
 @visibleForTesting
-Future<void> tryRestoreParticipantSession({
+Future<AuthApiException?> tryRestoreParticipantSession({
   required bool Function() isLoggedIn,
   required Future<bool> Function() hasStoredCredentials,
   required Future<void> Function() signIn,
   void Function(AppConnectionStatus status)? onConnectionStatusChanged,
   void Function(Object error)? onError,
 }) async {
-  if (hasDegradedConnectionStatus()) return;
-  if (isLoggedIn()) return;
-  if (!await hasStoredCredentials()) return;
+  if (hasDegradedConnectionStatus()) return null;
+  if (isLoggedIn()) return null;
+  if (!await hasStoredCredentials()) return null;
 
   try {
     await signIn();
   } catch (error) {
+    if (error is AuthApiException && error.code == 'invalid_credentials') {
+      await clearParticipantCredentials();
+      onError?.call(error);
+      return error;
+    }
     final status = connectionStatusFromError(error);
     if (status != null) {
       onConnectionStatusChanged?.call(status);
     }
     onError?.call(error);
   }
+  return null;
 }
 
 class LoadingScreen extends StatefulWidget {
@@ -208,9 +214,10 @@ class _LoadingScreenState extends State<LoadingScreen> {
   bool _previewNavigationInProgress = false;
   String? _pendingPreviewRoute;
   String? _error;
+  AuthApiException? _rejectedParticipantCredentialsError;
 
   Future<void> _restoreParticipantSession() async {
-    await tryRestoreParticipantSession(
+    _rejectedParticipantCredentialsError ??= await tryRestoreParticipantSession(
       isLoggedIn: isUserLoggedIn,
       hasStoredCredentials: () async =>
           await SecureStorage.containsKey(userEmailKey) &&
@@ -580,7 +587,13 @@ class _LoadingScreenState extends State<LoadingScreen> {
     return restoreCachedValueForStartup<StudySubject>(
       fetchRemote: () => _fetchRemoteSubject(selectedStudyObjectId),
       loadCached: Cache.loadSubject,
-      signIn: signInParticipant,
+      signIn: () {
+        final rejectedCredentialsError = _rejectedParticipantCredentialsError;
+        if (rejectedCredentialsError != null) {
+          throw rejectedCredentialsError;
+        }
+        return signInParticipant();
+      },
       isDeletedRemoteError: (error) =>
           error is PostgrestException && error.code == 'PGRST116',
     );

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -87,6 +87,16 @@ Future<T?> restoreCachedValueForStartup<T>({
   required Future<bool> Function() signIn,
   required bool Function(Object error) isDeletedRemoteError,
 }) async {
+  if (appConnectionStatusController.status != AppConnectionStatus.healthy) {
+    try {
+      final cached = await loadCached();
+      StudyULogger.info("Loaded startup value from cache: $cached");
+      return cached;
+    } catch (error) {
+      StudyULogger.warning("No usable startup value found in cache: $error");
+    }
+  }
+
   var shouldRetryAuth = true;
 
   try {
@@ -157,6 +167,7 @@ Future<void> tryRestoreParticipantSession({
   void Function(AppConnectionStatus status)? onConnectionStatusChanged,
   void Function(Object error)? onError,
 }) async {
+  if (hasDegradedConnectionStatus()) return;
   if (isLoggedIn()) return;
   if (!await hasStoredCredentials()) return;
 
@@ -446,8 +457,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
       return false;
     }
 
-    state.activeSubject = null;
-    state.selectedStudy = null;
+    state.clearActiveStudyState();
     return true;
   }
 
@@ -484,6 +494,8 @@ class _LoadingScreenState extends State<LoadingScreen> {
     try {
       subject = await _retrieveSubject(selectedSubjectId);
     } on SubjectDeletedException catch (error) {
+      await clearDeletedSubjectLocalState();
+      state.clearActiveStudyState();
       StudyULogger.warning(
         "Subject $selectedSubjectId was deleted from backend. Showing recovery screen.",
       );
@@ -518,7 +530,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
         context.go('/${RouteNames.studyUnavailable}');
         return;
       }
-      state.activeSubject = subject;
+      state.updateActiveSubject(subject);
       state.init(context);
       context.go('/${RouteNames.dashboard}');
     } else {
@@ -531,6 +543,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
   Future<void> noSubjectFound(AppState state) async {
     StudyULogger.info("No subject found");
     await cancelNotifications(context);
+    state.clearActiveStudyState();
 
     await _restoreParticipantSession();
     if (isUserLoggedIn() && !state.isPreview) {
@@ -637,9 +650,8 @@ class _LoadingScreenState extends State<LoadingScreen> {
         return true;
       }
 
-      state.activeSubject = await preview.getStudySubject(
-        state,
-        createSubject: true,
+      state.updateActiveSubject(
+        await preview.getStudySubject(state, createSubject: true),
       );
 
       // CONSENT
@@ -706,7 +718,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
       if (isUserLoggedIn()) {
         final subject = await preview.getStudySubject(state);
         if (subject != null) {
-          state.activeSubject = subject;
+          state.updateActiveSubject(subject);
           if (!mounted) return true;
           _iFrameHelper.postPreviewStatus(status: 'loaded');
           context.go('/${RouteNames.dashboard}');
@@ -757,9 +769,8 @@ class _LoadingScreenState extends State<LoadingScreen> {
         // Prefer the already-fetched study from state over the one from
         // handleAuthorization so the designer's latest edits are used.
         if (state.selectedStudy != null) preview.study = state.selectedStudy;
-        state.activeSubject = await preview.getStudySubject(
-          state,
-          createSubject: true,
+        state.updateActiveSubject(
+          await preview.getStudySubject(state, createSubject: true),
         );
         return state.activeSubject != null;
       }

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -18,6 +18,7 @@ import 'package:studyu_app/services/deep_link_service.dart';
 import 'package:studyu_app/services/deferred_link_service.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';
+import 'package:studyu_app/util/study_local_cleanup.dart';
 import 'package:studyu_app/widgets/deep_link_onboarding_widgets.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
@@ -494,7 +495,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
     try {
       subject = await _retrieveSubject(selectedSubjectId);
     } on SubjectDeletedException catch (error) {
-      await clearDeletedSubjectLocalState();
+      await clearStudyLocalData(fallbackSubject: state.activeSubject);
       state.clearActiveStudyState();
       StudyULogger.warning(
         "Subject $selectedSubjectId was deleted from backend. Showing recovery screen.",

--- a/app/lib/screens/app_onboarding/study_switch_dialogs.dart
+++ b/app/lib/screens/app_onboarding/study_switch_dialogs.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
+import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';
 import 'package:studyu_core/core.dart';
@@ -174,7 +176,10 @@ class StudySwitchDialogs {
     }
 
     await currentSubject.softDelete();
-    await deleteActiveStudyReference();
+    await clearDeletedSubjectLocalState();
+    if (context.mounted) {
+      context.read<AppState>().clearActiveStudyState();
+    }
     await FitbitHandler.deleteFitbitCredentials(currentSubject.studyId);
     if (context.mounted) {
       await cancelNotifications(context);
@@ -215,6 +220,9 @@ class StudySwitchDialogs {
 
     await currentSubject.delete();
     await deleteLocalData();
+    if (context.mounted) {
+      context.read<AppState>().clearActiveStudyState();
+    }
     await FitbitHandler.deleteFitbitCredentials(currentSubject.studyId);
     if (context.mounted) {
       await cancelNotifications(context);

--- a/app/lib/screens/app_onboarding/study_switch_dialogs.dart
+++ b/app/lib/screens/app_onboarding/study_switch_dialogs.dart
@@ -3,10 +3,9 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
-import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';
+import 'package:studyu_app/util/study_local_cleanup.dart';
 import 'package:studyu_core/core.dart';
-import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 class StudySwitchDialogs {
   // Returns true if the user decides to continue with deeplink handling.
@@ -176,11 +175,10 @@ class StudySwitchDialogs {
     }
 
     await currentSubject.softDelete();
-    await clearDeletedSubjectLocalState();
+    await clearStudyLocalData(fallbackSubject: currentSubject);
     if (context.mounted) {
       context.read<AppState>().clearActiveStudyState();
     }
-    await FitbitHandler.deleteFitbitCredentials(currentSubject.studyId);
     if (context.mounted) {
       await cancelNotifications(context);
     }
@@ -219,11 +217,13 @@ class StudySwitchDialogs {
     }
 
     await currentSubject.delete();
-    await deleteLocalData();
+    await clearStudyLocalData(
+      fallbackSubject: currentSubject,
+      clearStoredParticipantCredentials: true,
+    );
     if (context.mounted) {
       context.read<AppState>().clearActiveStudyState();
     }
-    await FitbitHandler.deleteFitbitCredentials(currentSubject.studyId);
     if (context.mounted) {
       await cancelNotifications(context);
     }

--- a/app/lib/screens/study/dashboard/dashboard.dart
+++ b/app/lib/screens/study/dashboard/dashboard.dart
@@ -14,6 +14,7 @@ import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/screens/app_onboarding/study_unavailable_screen.dart';
 import 'package:studyu_app/screens/study/dashboard/task_overview_tab/task_overview.dart';
 import 'package:studyu_app/theme.dart' as app_theme;
+import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/dashboard_showcase.dart';
 import 'package:studyu_app/util/debug_screen.dart';
 import 'package:studyu_core/core.dart';
@@ -61,18 +62,16 @@ class _DashboardScreenState extends State<DashboardScreen>
       (kDebugMode || context.read<AppState>().isPreview) &&
       !subject!.completedStudy;
 
-  SnackBar _buildStatusSnackBar(String message) {
-    final theme = Theme.of(context);
-    return SnackBar(
-      backgroundColor: theme.colorScheme.primary,
-      content: Text(
-        message,
-        style: theme.textTheme.bodyMedium?.copyWith(
-          color: theme.colorScheme.onPrimary,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
+  Future<void> _moveToNextDayLocally() async {
+    subject!.progress = subject!.progress
+        .map((progress) => progress.setStartDateBackBy(days: 1))
+        .toList();
+    subject!.startedAt = subject!.startedAt!.subtract(const Duration(days: 1));
+    await Cache.storeSubject(subject);
+    if (!mounted) return;
+    setState(() {
+      scheduleToday = subject!.scheduleFor(DateTime.now());
+    });
   }
 
   @override
@@ -403,6 +402,11 @@ class _DashboardScreenState extends State<DashboardScreen>
               child: ElevatedButton.icon(
                 icon: const Icon(Icons.fast_forward_rounded),
                 onPressed: () async {
+                  if (context.read<AppState>().connectionStatus !=
+                      AppConnectionStatus.healthy) {
+                    await _moveToNextDayLocally();
+                    return;
+                  }
                   try {
                     await subject!.setStartDateBackBy(days: 1);
                     setState(() {
@@ -412,18 +416,9 @@ class _DashboardScreenState extends State<DashboardScreen>
                     final status = connectionStatusFromError(error);
                     if (status == null) rethrow;
                     appConnectionStatusController.setStatus(status);
-                    if (!context.mounted) return;
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      _buildStatusSnackBar(
-                        status == AppConnectionStatus.deviceOffline
-                            ? AppLocalizations.of(
-                                context,
-                              )!.no_internet_connection
-                            : AppLocalizations.of(
-                                context,
-                              )!.connection_banner_backend_unavailable,
-                      ),
-                    );
+                    if (status != AppConnectionStatus.healthy) {
+                      await _moveToNextDayLocally();
+                    }
                   }
                 },
                 label: Text(AppLocalizations.of(context)!.next_day),

--- a/app/lib/screens/study/dashboard/settings.dart
+++ b/app/lib/screens/study/dashboard/settings.dart
@@ -218,7 +218,10 @@ class OptOutAlertDialog extends StatelessWidget {
               }
               rethrow;
             }
-            await deleteActiveStudyReference();
+            await clearDeletedSubjectLocalState();
+            if (context.mounted) {
+              context.read<AppState>().clearActiveStudyState();
+            }
             await FitbitHandler.deleteFitbitCredentials(subject!.studyId);
             if (context.mounted) await cancelNotifications(context);
             if (context.mounted) {
@@ -282,6 +285,9 @@ class DeleteAlertDialog extends StatelessWidget {
           }
           // Reached when delete succeeded or subject was already gone from DB
           await deleteLocalData();
+          if (context.mounted) {
+            context.read<AppState>().clearActiveStudyState();
+          }
           await FitbitHandler.deleteFitbitCredentials(subject!.studyId);
           if (context.mounted) await cancelNotifications(context);
           if (context.mounted) {

--- a/app/lib/screens/study/dashboard/settings.dart
+++ b/app/lib/screens/study/dashboard/settings.dart
@@ -6,9 +6,9 @@ import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/util/dashboard_showcase.dart';
-import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_app/util/localization.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';
+import 'package:studyu_app/util/study_local_cleanup.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 import 'package:supabase/supabase.dart' show PostgrestException;
@@ -218,11 +218,10 @@ class OptOutAlertDialog extends StatelessWidget {
               }
               rethrow;
             }
-            await clearDeletedSubjectLocalState();
+            await clearStudyLocalData(fallbackSubject: subject);
             if (context.mounted) {
               context.read<AppState>().clearActiveStudyState();
             }
-            await FitbitHandler.deleteFitbitCredentials(subject!.studyId);
             if (context.mounted) await cancelNotifications(context);
             if (context.mounted) {
               context.go('/${RouteNames.studySelection}');
@@ -284,11 +283,13 @@ class DeleteAlertDialog extends StatelessWidget {
             rethrow;
           }
           // Reached when delete succeeded or subject was already gone from DB
-          await deleteLocalData();
+          await clearStudyLocalData(
+            fallbackSubject: subject,
+            clearStoredParticipantCredentials: true,
+          );
           if (context.mounted) {
             context.read<AppState>().clearActiveStudyState();
           }
-          await FitbitHandler.deleteFitbitCredentials(subject!.studyId);
           if (context.mounted) await cancelNotifications(context);
           if (context.mounted) {
             context.go('/${RouteNames.welcome}');

--- a/app/lib/screens/study/onboarding/intervention_selection.dart
+++ b/app/lib/screens/study/onboarding/intervention_selection.dart
@@ -92,11 +92,13 @@ class _InterventionSelectionScreenState
 
   Future<void> onFinished() async {
     final appState = context.read<AppState>();
-    appState.activeSubject = StudySubject.fromStudy(
-      appState.selectedStudy!,
-      Supabase.instance.client.auth.currentUser!.id,
-      selectedInterventionIds,
-      appState.inviteCode,
+    appState.updateActiveSubject(
+      StudySubject.fromStudy(
+        appState.selectedStudy!,
+        Supabase.instance.client.auth.currentUser!.id,
+        selectedInterventionIds,
+        appState.inviteCode,
+      ),
     );
     context.push('/${RouteNames.journey}');
   }

--- a/app/lib/screens/study/onboarding/kickoff.dart
+++ b/app/lib/screens/study/onboarding/kickoff.dart
@@ -28,9 +28,10 @@ class _KickoffScreen extends State<KickoffScreen> {
       subject = await subject!.save();
       subject = await _fetchRemoteSubject(subject!.id);
       if (!context.mounted) return;
-      context.read<AppState>().activeSubject = subject;
-      context.read<AppState>().init(context);
-      await Cache.storeSubject(context.read<AppState>().activeSubject);
+      final state = context.read<AppState>();
+      state.updateActiveSubject(subject);
+      state.init(context);
+      await Cache.storeSubject(state.activeSubject);
       await storeActiveSubjectId(subject!.id);
       if (!context.mounted) return;
       setState(() => ready = true);

--- a/app/lib/screens/study/onboarding/study_overview.dart
+++ b/app/lib/screens/study/onboarding/study_overview.dart
@@ -35,20 +35,24 @@ class _StudyOverviewScreen extends State<StudyOverviewScreen> {
       return;
     }
     if (appState.preselectedInterventionIds != null) {
-      appState.activeSubject = StudySubject.fromStudy(
-        appState.selectedStudy!,
-        Supabase.instance.client.auth.currentUser!.id,
-        appState.preselectedInterventionIds!,
-        appState.inviteCode,
+      appState.updateActiveSubject(
+        StudySubject.fromStudy(
+          appState.selectedStudy!,
+          Supabase.instance.client.auth.currentUser!.id,
+          appState.preselectedInterventionIds!,
+          appState.inviteCode,
+        ),
       );
       context.push('/${RouteNames.journey}');
     } else if (study!.interventions.length <= 2) {
       // No need to select interventions if there are only 2 or less
-      appState.activeSubject = StudySubject.fromStudy(
-        appState.selectedStudy!,
-        Supabase.instance.client.auth.currentUser!.id,
-        study!.interventions.map((i) => i.id).toList(),
-        appState.inviteCode,
+      appState.updateActiveSubject(
+        StudySubject.fromStudy(
+          appState.selectedStudy!,
+          Supabase.instance.client.auth.currentUser!.id,
+          study!.interventions.map((i) => i.id).toList(),
+          appState.inviteCode,
+        ),
       );
       context.push('/${RouteNames.journey}');
     } else {

--- a/app/lib/util/cache.dart
+++ b/app/lib/util/cache.dart
@@ -10,6 +10,44 @@ import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 class Cache {
   static bool isSynchronizing = false;
 
+  @visibleForTesting
+  static Future<void> Function()? debugUploadBlobFilesOverride;
+
+  static bool isCompatibleCachedSubject({
+    required StudySubject localSubject,
+    required StudySubject remoteSubject,
+  }) {
+    return localSubject.id == remoteSubject.id &&
+        localSubject.studyId == remoteSubject.studyId &&
+        localSubject.userId == remoteSubject.userId;
+  }
+
+  static SubjectProgressSyncPlan buildProgressSyncPlan({
+    required StudySubject localSubject,
+    required StudySubject remoteSubject,
+  }) {
+    final remoteKeys = remoteSubject.progress
+        .map((progress) => _progressSyncKey(progress))
+        .toSet();
+    final mergedProgress = [...remoteSubject.progress];
+    final newProgress = <SubjectProgress>[];
+
+    for (final progress in localSubject.progress) {
+      final key = _progressSyncKey(progress);
+      if (remoteKeys.add(key)) {
+        newProgress.add(progress);
+        mergedProgress.add(progress);
+      }
+    }
+
+    return SubjectProgressSyncPlan(
+      newProgress: newProgress,
+      mergedProgress: mergedProgress,
+      saveProgress: (progress) => progress.save(),
+      saveSubject: (subject) => subject.save(onlyUpdate: true),
+    );
+  }
+
   static Future<void> storeSubject(StudySubject? subject) async {
     // debugPrint("Store subject in cache");
     if (subject == null) return;
@@ -86,13 +124,18 @@ class Cache {
   static Future<void> uploadBlobFiles() async {
     final blobStorageHandler = BlobStorageHandler();
     final futureBlobFiles = await TemporaryStorageHandler.getFutureBlobFiles();
-    for (final futureBlobFile in futureBlobFiles) {
-      await blobStorageHandler.uploadObservation(
-        futureBlobFile.futureBlobId,
-        File(futureBlobFile.localFilePath),
-      );
-      await File(futureBlobFile.localFilePath).delete();
-    }
+    await uploadPendingBlobFiles(
+      futureBlobFiles: futureBlobFiles,
+      uploadObservation: (futureBlobFile) async {
+        await blobStorageHandler.uploadObservation(
+          futureBlobFile.futureBlobId,
+          File(futureBlobFile.localFilePath),
+        );
+      },
+      deleteUploadedFile: (futureBlobFile) async {
+        await File(futureBlobFile.localFilePath).delete();
+      },
+    );
   }
 
   static Future<StudySubject> synchronize(StudySubject remoteSubject) async {
@@ -102,6 +145,15 @@ class Cache {
       return remoteSubject;
     }
     final localSubject = await loadSubject(backupSubject: remoteSubject);
+    if (!isCompatibleCachedSubject(
+      localSubject: localSubject,
+      remoteSubject: remoteSubject,
+    )) {
+      StudyULogger.warning(
+        'Skip cache synchronization because cached subject does not match remote subject',
+      );
+      return remoteSubject;
+    }
     // local and remote subject are equal, nothing to synchronize
     if (localSubject == remoteSubject) return remoteSubject;
     // remote subject belongs to a different study
@@ -114,61 +166,17 @@ class Cache {
     isSynchronizing = true;
 
     try {
-      await uploadBlobFiles();
-
-      // only minimal update
-      // Check if progress has changed
-      if (localSubject.progress.length != remoteSubject.progress.length) {
+      await (debugUploadBlobFilesOverride ?? uploadBlobFiles)();
+      final syncPlan = buildProgressSyncPlan(
+        localSubject: localSubject,
+        remoteSubject: remoteSubject,
+      );
+      if (syncPlan.hasChanges) {
         StudyULogger.info("Cache synchronization: Merging progress");
-        /*if (remoteSubject.progress.isNotEmpty) {
-        // sort remote progress list from oldest to newest
-        remoteSubject.progress.sort((a, b) =>
-            a.completedAt.compareTo(b.completedAt));
-        // merge all local progress older than the latest remote progress to remote subject and upload
-        newProgress = localSubject.progress.where((element) =>
-            element.completedAt.isAfter(remoteSubject.progress.last.completedAt)
-        ).toList();
-      } else {
-        newProgress = localSubject.progress;
-      }*/
-        // save new progress
-        final List<SubjectProgress> newProgress = [
-          ...localSubject.progress,
-          ...remoteSubject.progress,
-        ];
-        newProgress.removeWhere(
-          (element) =>
-              localSubject.progress.contains(element) &&
-              remoteSubject.progress.contains(element),
+        await applyProgressSyncPlan(
+          remoteSubject: remoteSubject,
+          syncPlan: syncPlan,
         );
-        for (final p in newProgress) {
-          await p.save();
-        }
-
-        // merge local and remote progress and remove duplicates
-        final List<SubjectProgress> finalProgress = [
-          ...localSubject.progress,
-          ...remoteSubject.progress,
-        ];
-        final duplicates = <DateTime?>{};
-        finalProgress.retainWhere(
-          (element) => duplicates.add(element.completedAt),
-        );
-        // replace remote progress with our merge
-        remoteSubject.progress = finalProgress;
-        await remoteSubject.save(onlyUpdate: true);
-      } else {
-        // Unable to determine what has changed
-        // We can either drop local or overwrite remote
-        // ... for now do nothing
-        if (!kDebugMode && localSubject.startedAt == remoteSubject.startedAt) {
-          StudyULogger.fatal(
-            "Cache synchronization found local changes that cannot be merged",
-          );
-          StudyULogger.error(
-            "localSubject: ${localSubject.toFullJson()} \nremoteSubject: ${remoteSubject.toFullJson()}",
-          );
-        }
       }
       appConnectionStatusController.setStatus(AppConnectionStatus.healthy);
     } catch (exception) {
@@ -182,15 +190,42 @@ class Cache {
     return remoteSubject;
   }
 
+  static String _progressSyncKey(SubjectProgress progress) =>
+      jsonEncode(progress.toJson());
+
+  static Future<void> uploadPendingBlobFiles({
+    required List<FutureBlobFile> futureBlobFiles,
+    required Future<void> Function(FutureBlobFile futureBlobFile)
+    uploadObservation,
+    required Future<void> Function(FutureBlobFile futureBlobFile)
+    deleteUploadedFile,
+  }) async {
+    for (final futureBlobFile in futureBlobFiles) {
+      await uploadObservation(futureBlobFile);
+      await deleteUploadedFile(futureBlobFile);
+    }
+  }
+
+  static Future<void> applyProgressSyncPlan({
+    required StudySubject remoteSubject,
+    required SubjectProgressSyncPlan syncPlan,
+  }) async {
+    for (final progress in syncPlan.newProgress) {
+      await syncPlan.saveProgress(progress);
+    }
+    remoteSubject.progress = syncPlan.mergedProgress;
+    await syncPlan.saveSubject(remoteSubject);
+  }
+
   static Future<String> getCachedUserData() async {
     final debugInfo = StringBuffer();
     debugInfo.writeln('=== Cached User Data Debug Info ===');
 
     try {
       // Check selected subject ID
-      if (await SecureStorage.containsKey('selected_study_object_id')) {
+      if (await SecureStorage.containsKey(selectedSubjectIdKey)) {
         final selectedSubjectId = await SecureStorage.read(
-          'selected_study_object_id',
+          selectedSubjectIdKey,
         );
         debugInfo.writeln('Selected Subject ID: $selectedSubjectId');
       } else {
@@ -198,8 +233,8 @@ class Cache {
       }
 
       // Check user email
-      if (await SecureStorage.containsKey('user_email')) {
-        final userEmail = await SecureStorage.read('user_email');
+      if (await SecureStorage.containsKey(userEmailKey)) {
+        final userEmail = await SecureStorage.read(userEmailKey);
         debugInfo.writeln('User Email: $userEmail');
       } else {
         debugInfo.writeln('User Email: NOT FOUND');
@@ -224,7 +259,7 @@ class Cache {
       }
 
       // Check user password (without revealing the actual password)
-      if (await SecureStorage.containsKey('user_password')) {
+      if (await SecureStorage.containsKey(userPasswordKey)) {
         debugInfo.writeln('User Password: EXISTS (hidden for security)');
       } else {
         debugInfo.writeln('User Password: NOT FOUND');
@@ -235,4 +270,20 @@ class Cache {
 
     return debugInfo.toString();
   }
+}
+
+class SubjectProgressSyncPlan {
+  final List<SubjectProgress> newProgress;
+  final List<SubjectProgress> mergedProgress;
+  final Future<SubjectProgress> Function(SubjectProgress progress) saveProgress;
+  final Future<StudySubject> Function(StudySubject subject) saveSubject;
+
+  const SubjectProgressSyncPlan({
+    required this.newProgress,
+    required this.mergedProgress,
+    required this.saveProgress,
+    required this.saveSubject,
+  });
+
+  bool get hasChanges => newProgress.isNotEmpty;
 }

--- a/app/lib/util/cache.dart
+++ b/app/lib/util/cache.dart
@@ -11,7 +11,8 @@ class Cache {
   static bool isSynchronizing = false;
 
   @visibleForTesting
-  static Future<void> Function()? debugUploadBlobFilesOverride;
+  static Future<void> Function(String studyId, String userId)?
+  debugUploadBlobFilesOverride;
 
   static bool isCompatibleCachedSubject({
     required StudySubject localSubject,
@@ -121,9 +122,12 @@ class Cache {
     SecureStorage.delete(cacheSubjectKey);
   }
 
-  static Future<void> uploadBlobFiles() async {
+  static Future<void> uploadBlobFiles(String studyId, String userId) async {
     final blobStorageHandler = BlobStorageHandler();
-    final futureBlobFiles = await TemporaryStorageHandler.getFutureBlobFiles();
+    final futureBlobFiles = await TemporaryStorageHandler.getFutureBlobFiles(
+      studyId: studyId,
+      userId: userId,
+    );
     await uploadPendingBlobFiles(
       futureBlobFiles: futureBlobFiles,
       uploadObservation: (futureBlobFile) async {
@@ -136,6 +140,22 @@ class Cache {
         await File(futureBlobFile.localFilePath).delete();
       },
     );
+  }
+
+  static Future<void> deletePendingBlobFilesForSubject(
+    StudySubject? subject,
+  ) async {
+    if (subject == null) return;
+    try {
+      await TemporaryStorageHandler.deleteFutureBlobFiles(
+        studyId: subject.studyId,
+        userId: subject.userId,
+      );
+    } catch (error) {
+      StudyULogger.warning(
+        'Could not delete pending blob files for subject ${subject.id}: $error',
+      );
+    }
   }
 
   static Future<StudySubject> synchronize(StudySubject remoteSubject) async {
@@ -166,7 +186,10 @@ class Cache {
     isSynchronizing = true;
 
     try {
-      await (debugUploadBlobFilesOverride ?? uploadBlobFiles)();
+      await (debugUploadBlobFilesOverride ?? uploadBlobFiles)(
+        remoteSubject.studyId,
+        remoteSubject.userId,
+      );
       final syncPlan = buildProgressSyncPlan(
         localSubject: localSubject,
         remoteSubject: remoteSubject,

--- a/app/lib/util/study_local_cleanup.dart
+++ b/app/lib/util/study_local_cleanup.dart
@@ -1,0 +1,31 @@
+import 'package:studyu_app/util/cache.dart';
+import 'package:studyu_app/util/fitbit_handler.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+
+Future<StudySubject?> resolveCachedSubjectForCleanup({
+  StudySubject? fallbackSubject,
+}) async {
+  try {
+    return await Cache.loadSubject(backupSubject: fallbackSubject);
+  } catch (_) {
+    return fallbackSubject;
+  }
+}
+
+Future<void> clearStudyLocalData({
+  StudySubject? fallbackSubject,
+  bool clearStoredParticipantCredentials = false,
+}) async {
+  final subject = await resolveCachedSubjectForCleanup(
+    fallbackSubject: fallbackSubject,
+  );
+  await Cache.deletePendingBlobFilesForSubject(subject);
+  if (subject != null) {
+    await FitbitHandler.deleteFitbitCredentials(subject.studyId);
+  }
+  await clearDeletedSubjectLocalState();
+  if (clearStoredParticipantCredentials) {
+    await clearParticipantCredentials();
+  }
+}

--- a/app/lib/util/study_subject_extension.dart
+++ b/app/lib/util/study_subject_extension.dart
@@ -48,7 +48,7 @@ extension StudySubjectExtension on StudySubject {
       }
       // Upload multimodal files
       if (!offline) {
-        await Cache.uploadBlobFiles();
+        await Cache.uploadBlobFiles(studyId, userId);
       }
     }
 

--- a/app/lib/util/temporary_storage_handler.dart
+++ b/app/lib/util/temporary_storage_handler.dart
@@ -1,6 +1,7 @@
 import 'dart:core';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:studyu_core/core.dart';
@@ -22,6 +23,7 @@ class TemporaryStorageHandler {
   }
 
   static Future<Directory?> _getMultimodalTempDirectory() async {
+    if (kIsWeb) return null;
     try {
       final tempAppData = await getTemporaryDirectory();
       final multimodalTempDirectory = Directory(
@@ -40,6 +42,11 @@ class TemporaryStorageHandler {
   }
 
   static Future<Directory> _getMultimodalUploadDirectory() async {
+    if (kIsWeb) {
+      throw UnsupportedError(
+        'Multimodal upload directory is not supported on web.',
+      );
+    }
     final appData = await getApplicationDocumentsDirectory();
     final multimodalUploadDirectory = Directory(
       "${appData.path}/multimodal-upload",
@@ -52,6 +59,7 @@ class TemporaryStorageHandler {
     String stagingFilePath,
     String blobId,
   ) async {
+    if (kIsWeb) return;
     final stagingFile = File(stagingFilePath);
     final uploadDirectory = await _getMultimodalUploadDirectory();
     final uploadFile = File(path.join(uploadDirectory.path, [blobId].join()));
@@ -59,6 +67,7 @@ class TemporaryStorageHandler {
   }
 
   static Future<List<FutureBlobFile>> getFutureBlobFiles() async {
+    if (kIsWeb) return [];
     final uploadDirectory = await _getMultimodalUploadDirectory();
     final files = await uploadDirectory.list().toList();
     final futureBlobFiles = files.map((file) {
@@ -69,6 +78,7 @@ class TemporaryStorageHandler {
   }
 
   Future<FutureBlobFile?> getStagingAudio() async {
+    if (kIsWeb) return null;
     final temporaryMultimodalDirectory = await _getMultimodalTempDirectory();
 
     if (temporaryMultimodalDirectory == null) {
@@ -93,6 +103,7 @@ class TemporaryStorageHandler {
   }
 
   Future<FutureBlobFile?> getStagingImage() async {
+    if (kIsWeb) return null;
     final temporaryMultimodalDirectory = await _getMultimodalTempDirectory();
 
     if (temporaryMultimodalDirectory == null) {
@@ -117,6 +128,7 @@ class TemporaryStorageHandler {
   }
 
   static Future<void> deleteAllStagingFiles() async {
+    if (kIsWeb) return;
     final temporaryMultimodalDirectory = await _getMultimodalTempDirectory();
 
     if (temporaryMultimodalDirectory == null) {

--- a/app/lib/util/temporary_storage_handler.dart
+++ b/app/lib/util/temporary_storage_handler.dart
@@ -10,6 +10,9 @@ class TemporaryStorageHandler {
   static const String _stagingBaseNamePrefix = 'staging_';
   static const String _audioFileType = ".m4a";
   static const String _imageFileType = ".jpg";
+  static final RegExp _futureBlobIdPattern = RegExp(
+    r'^user-id_(.+)_study-id_(.+)_(\d+)(\.[^.]+)$',
+  );
 
   final String _userId;
   final String _studyId;
@@ -66,15 +69,62 @@ class TemporaryStorageHandler {
     await stagingFile.rename(uploadFile.path);
   }
 
-  static Future<List<FutureBlobFile>> getFutureBlobFiles() async {
+  static bool _matchesScope(
+    FutureBlobFileScope? scope, {
+    String? studyId,
+    String? userId,
+  }) {
+    if (scope == null) {
+      return studyId == null && userId == null;
+    }
+    return (studyId == null || scope.studyId == studyId) &&
+        (userId == null || scope.userId == userId);
+  }
+
+  static FutureBlobFileScope? parseFutureBlobFileScope(String futureBlobId) {
+    final match = _futureBlobIdPattern.firstMatch(futureBlobId);
+    if (match == null) {
+      return null;
+    }
+    return FutureBlobFileScope(
+      userId: match.group(1)!,
+      studyId: match.group(2)!,
+    );
+  }
+
+  static Future<List<FutureBlobFile>> getFutureBlobFiles({
+    String? studyId,
+    String? userId,
+  }) async {
     if (kIsWeb) return [];
     final uploadDirectory = await _getMultimodalUploadDirectory();
     final files = await uploadDirectory.list().toList();
-    final futureBlobFiles = files.map((file) {
-      final fileName = path.basename(file.path);
-      return FutureBlobFile(file.path, fileName);
-    }).toList();
+    final futureBlobFiles = files
+        .map((file) {
+          final fileName = path.basename(file.path);
+          return FutureBlobFile(file.path, fileName);
+        })
+        .where(
+          (file) => _matchesScope(
+            parseFutureBlobFileScope(file.futureBlobId),
+            studyId: studyId,
+            userId: userId,
+          ),
+        )
+        .toList();
     return futureBlobFiles;
+  }
+
+  static Future<void> deleteFutureBlobFiles({
+    String? studyId,
+    String? userId,
+  }) async {
+    for (final file in await getFutureBlobFiles(
+      studyId: studyId,
+      userId: userId,
+    )) {
+      await File(file.localFilePath).delete();
+    }
   }
 
   Future<FutureBlobFile?> getStagingAudio() async {
@@ -148,4 +198,11 @@ class TemporaryStorageHandler {
       await file.delete();
     }
   }
+}
+
+class FutureBlobFileScope {
+  final String userId;
+  final String studyId;
+
+  const FutureBlobFileScope({required this.userId, required this.studyId});
 }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -71,9 +71,13 @@ dev_dependencies:
   # flutter_launcher_icons: ^0.14.4
   # Deprecated? icons_launcher may be an alternative.
   flutter_lints: ^6.0.0
+  flutter_secure_storage: ^10.3.1
+  flutter_secure_storage_platform_interface: ^2.0.1
   flutter_test:
     sdk: flutter
   lint: ^2.8.0
+  path_provider_platform_interface: ^2.1.2
+  plugin_platform_interface: ^2.1.8
 
 flutter:
   generate: true

--- a/app/test/app_error_screen_test.dart
+++ b/app/test/app_error_screen_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/l10n/app_localizations.dart';
+import 'package:studyu_app/screens/app_onboarding/app_error_screen.dart';
+
+Widget buildTestApp(Widget child) {
+  return MaterialApp(
+    supportedLocales: AppLocalizations.supportedLocales,
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    locale: const Locale('en'),
+    home: child,
+  );
+}
+
+void main() {
+  testWidgets('cache missing error screen renders recoverable copy', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildTestApp(
+        const AppErrorScreen(reason: AppErrorReason.cacheUnavailableMissing),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Cached study data not found'), findsOneWidget);
+    expect(
+      find.textContaining('could not find cached study data'),
+      findsOneWidget,
+    );
+    expect(find.text('Contact Support'), findsOneWidget);
+    expect(find.text('Leave study and delete all data'), findsOneWidget);
+  });
+
+  testWidgets('cache corrupt error screen renders recoverable copy', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildTestApp(
+        const AppErrorScreen(reason: AppErrorReason.cacheUnavailableCorrupt),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Cached study data could not be read'), findsOneWidget);
+    expect(find.textContaining('could not be restored safely'), findsOneWidget);
+    expect(find.text('Contact Support'), findsOneWidget);
+    expect(find.text('Leave study and delete all data'), findsOneWidget);
+  });
+}

--- a/app/test/app_state_test.dart
+++ b/app/test/app_state_test.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+
+import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/models/app_state.dart';
+import 'package:studyu_app/util/cache.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+
+const _studyId = 'study-id';
+const _userId = 'user-id';
+const _interventionId = 'intervention-a';
+const _taskId = 'task-a';
+const _periodId = 'period-a';
+
+StudySubject _buildSubject() {
+  final study = Study(_studyId, _userId)
+    ..schedule.includeBaseline = false
+    ..schedule.numberOfCycles = 1
+    ..schedule.phaseDuration = 7
+    ..interventions = [
+      Intervention(_interventionId, 'Intervention A')
+        ..tasks = [
+          CheckmarkTask.withId()
+            ..id = _taskId
+            ..title = 'Task A',
+        ],
+    ];
+
+  return StudySubject.fromStudy(
+    study,
+    _userId,
+    study.interventions.map((intervention) => intervention.id).toList(),
+    null,
+  )..startedAt = DateTime.utc(2026, 8, 10);
+}
+
+SubjectProgress _progress(String subjectId) {
+  return SubjectProgress(
+    subjectId: subjectId,
+    interventionId: _interventionId,
+    taskId: _taskId,
+    resultType: 'bool',
+    result: Result<bool>.app(type: 'bool', periodId: _periodId, result: true),
+  )..completedAt = DateTime.utc(2026, 8, 10, 8);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FlutterSecureStoragePlatform originalPlatform;
+  late Map<String, String> storageData;
+
+  setUp(() {
+    originalPlatform = FlutterSecureStoragePlatform.instance;
+    storageData = {};
+    FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
+      storageData,
+    );
+  });
+
+  tearDown(() {
+    FlutterSecureStoragePlatform.instance = originalPlatform;
+    appConnectionStatusController.reset();
+    Cache.debugUploadBlobFilesOverride = null;
+  });
+
+  test('clearActiveStudyState removes stale active-study state', () {
+    final appState = AppState();
+    final study = Study(_studyId, _userId);
+    final subject = StudySubject.fromStudy(study, _userId, const [], null);
+
+    appState
+      ..selectedStudy = study
+      ..selectedInterventions = []
+      ..activeSubject = subject
+      ..inviteCode = 'invite-code'
+      ..preselectedInterventionIds = ['intervention-a'];
+
+    appState.clearActiveStudyState();
+
+    expect(appState.selectedStudy, isNull);
+    expect(appState.selectedInterventions, isNull);
+    expect(appState.activeSubject, isNull);
+    expect(appState.inviteCode, isNull);
+    expect(appState.preselectedInterventionIds, isNull);
+    expect(appState.studyNotifications, isNull);
+  });
+
+  test(
+    'retryCachedSubjectSynchronization updates active subject from recovered remote subject',
+    () async {
+      final appState = AppState();
+      final cachedSubject = _buildSubject();
+      final remoteSubject = StudySubject.fromJson(cachedSubject.toFullJson())
+        ..progress = [_progress(cachedSubject.id)];
+      final staleSubject = StudySubject.fromJson(cachedSubject.toFullJson())
+        ..progress = [];
+
+      appState
+        ..activeSubject = staleSubject
+        ..selectedStudy = staleSubject.study
+        ..setConnectionStatus(AppConnectionStatus.backendUnavailable)
+        ..debugFetchRemoteSubjectForSync = (_) async => remoteSubject;
+
+      await appState.retryCachedSubjectSynchronization();
+
+      expect(appState.activeSubject?.progress, hasLength(1));
+      expect(appState.activeSubject?.progress.single.taskId, _taskId);
+      expect(appConnectionStatusController.status, AppConnectionStatus.healthy);
+    },
+  );
+
+  test(
+    'retryCachedSubjectSynchronization restores session before retrying after auth failure',
+    () async {
+      final appState = AppState();
+      final cachedSubject = _buildSubject();
+      final remoteSubject = StudySubject.fromJson(cachedSubject.toFullJson())
+        ..progress = [_progress(cachedSubject.id)];
+      var fetchCalls = 0;
+      var restoreCalls = 0;
+
+      appState
+        ..activeSubject = cachedSubject
+        ..selectedStudy = cachedSubject.study
+        ..setConnectionStatus(AppConnectionStatus.backendUnavailable)
+        ..debugFetchRemoteSubjectForSync = (_) async {
+          fetchCalls++;
+          if (fetchCalls == 1) {
+            throw Exception('AuthApiException(code: invalid_jwt)');
+          }
+          return remoteSubject;
+        }
+        ..debugRestoreParticipantSessionForSync = () async {
+          restoreCalls++;
+          return true;
+        };
+
+      await appState.retryCachedSubjectSynchronization();
+
+      expect(fetchCalls, 2);
+      expect(restoreCalls, 1);
+      expect(appState.activeSubject?.progress, hasLength(1));
+      expect(appConnectionStatusController.status, AppConnectionStatus.healthy);
+    },
+  );
+
+  test(
+    'scheduleActiveSubjectSyncRetryIfNeeded retries until healthy',
+    () async {
+      final appState = AppState();
+      final subject = _buildSubject();
+      var fetchCalls = 0;
+      final completer = Completer<void>();
+
+      appState
+        ..activeSubject = subject
+        ..selectedStudy = subject.study
+        ..debugActiveSubjectSyncRetryDelay = const Duration(milliseconds: 1)
+        ..debugFetchRemoteSubjectForSync = (_) async {
+          fetchCalls++;
+          if (!completer.isCompleted) {
+            completer.complete();
+          }
+          appConnectionStatusController.setStatus(AppConnectionStatus.healthy);
+          return subject;
+        }
+        ..setConnectionStatus(AppConnectionStatus.backendUnavailable);
+
+      appState.scheduleActiveSubjectSyncRetryIfNeeded();
+      await completer.future.timeout(const Duration(seconds: 1));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(fetchCalls, greaterThanOrEqualTo(1));
+      expect(appConnectionStatusController.status, AppConnectionStatus.healthy);
+    },
+  );
+}

--- a/app/test/app_state_test.dart
+++ b/app/test/app_state_test.dart
@@ -7,6 +7,7 @@ import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 const _studyId = 'study-id';
 const _userId = 'user-id';
@@ -144,6 +145,46 @@ void main() {
       expect(restoreCalls, 1);
       expect(appState.activeSubject?.progress, hasLength(1));
       expect(appConnectionStatusController.status, AppConnectionStatus.healthy);
+    },
+  );
+
+  test(
+    'retryCachedSubjectSynchronization ignores rejected restore credentials',
+    () async {
+      final appState = AppState();
+      final subject = _buildSubject();
+      var fetchCalls = 0;
+      var restoreCalls = 0;
+
+      appState
+        ..activeSubject = subject
+        ..selectedStudy = subject.study
+        ..setConnectionStatus(AppConnectionStatus.backendUnavailable)
+        ..debugFetchRemoteSubjectForSync = (_) {
+          fetchCalls++;
+          throw Exception('AuthApiException(code: invalid_jwt)');
+        }
+        ..debugRestoreParticipantSessionForSync = () {
+          restoreCalls++;
+          return Future<bool>.error(
+            const AuthApiException(
+              'Invalid login credentials',
+              code: 'invalid_credentials',
+            ),
+          );
+        };
+
+      await expectLater(
+        appState.retryCachedSubjectSynchronization(),
+        completes,
+      );
+
+      expect(fetchCalls, 1);
+      expect(restoreCalls, 1);
+      expect(
+        appConnectionStatusController.status,
+        AppConnectionStatus.backendUnavailable,
+      );
     },
   );
 

--- a/app/test/cache_synchronization_test.dart
+++ b/app/test/cache_synchronization_test.dart
@@ -1,0 +1,323 @@
+import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/util/cache.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+
+const _studyId = 'study-id';
+const _userId = 'user-id';
+const _interventionAId = 'intervention-a';
+const _interventionBId = 'intervention-b';
+const _taskAId = 'task-a';
+const _taskBId = 'task-b';
+const _periodAId = 'period-a';
+const _periodBId = 'period-b';
+
+StudySubject _buildSubject() {
+  final study = Study(_studyId, _userId)
+    ..schedule.includeBaseline = false
+    ..schedule.numberOfCycles = 1
+    ..schedule.phaseDuration = 7
+    ..interventions = [
+      Intervention(_interventionAId, 'Intervention A')
+        ..tasks = [
+          CheckmarkTask.withId()
+            ..id = _taskAId
+            ..title = 'Task A',
+        ],
+      Intervention(_interventionBId, 'Intervention B')
+        ..tasks = [
+          CheckmarkTask.withId()
+            ..id = _taskBId
+            ..title = 'Task B',
+        ],
+    ];
+
+  return StudySubject.fromStudy(
+    study,
+    _userId,
+    study.interventions.map((intervention) => intervention.id).toList(),
+    null,
+  )..startedAt = DateTime.utc(2026, 8, 10);
+}
+
+SubjectProgress _progress({
+  required String subjectId,
+  required String interventionId,
+  required String taskId,
+  required String periodId,
+  required DateTime completedAt,
+}) {
+  return SubjectProgress(
+    subjectId: subjectId,
+    interventionId: interventionId,
+    taskId: taskId,
+    resultType: 'bool',
+    result: Result<bool>.app(type: 'bool', periodId: periodId, result: true),
+  )..completedAt = completedAt;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FlutterSecureStoragePlatform originalPlatform;
+  late Map<String, String> storageData;
+
+  setUp(() {
+    originalPlatform = FlutterSecureStoragePlatform.instance;
+    storageData = {};
+    FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
+      storageData,
+    );
+  });
+
+  tearDown(() {
+    FlutterSecureStoragePlatform.instance = originalPlatform;
+    appConnectionStatusController.reset();
+    Cache.isSynchronizing = false;
+  });
+
+  group('Cache.buildProgressSyncPlan', () {
+    test('merges local progress even when local and remote lengths match', () {
+      final remoteSubject = _buildSubject();
+      final localSubject = StudySubject.fromJson(remoteSubject.toFullJson());
+
+      remoteSubject.progress = [
+        _progress(
+          subjectId: remoteSubject.id,
+          interventionId: _interventionAId,
+          taskId: _taskAId,
+          periodId: _periodAId,
+          completedAt: DateTime.utc(2026, 8, 10, 8),
+        ),
+      ];
+      localSubject.progress = [
+        _progress(
+          subjectId: localSubject.id,
+          interventionId: _interventionBId,
+          taskId: _taskBId,
+          periodId: _periodBId,
+          completedAt: DateTime.utc(2026, 8, 11, 8),
+        ),
+      ];
+
+      final plan = Cache.buildProgressSyncPlan(
+        localSubject: localSubject,
+        remoteSubject: remoteSubject,
+      );
+
+      expect(plan.hasChanges, isTrue);
+      expect(plan.newProgress, hasLength(1));
+      expect(plan.mergedProgress, hasLength(2));
+      expect(
+        plan.mergedProgress.map((progress) => progress.taskId),
+        containsAll([_taskAId, _taskBId]),
+      );
+    });
+
+    test('does not collapse separate tasks that share same timestamp', () {
+      final remoteSubject = _buildSubject();
+      final localSubject = StudySubject.fromJson(remoteSubject.toFullJson());
+      final sharedTimestamp = DateTime.utc(2026, 8, 10, 8);
+
+      remoteSubject.progress = [
+        _progress(
+          subjectId: remoteSubject.id,
+          interventionId: _interventionAId,
+          taskId: _taskAId,
+          periodId: _periodAId,
+          completedAt: sharedTimestamp,
+        ),
+      ];
+      localSubject.progress = [
+        _progress(
+          subjectId: localSubject.id,
+          interventionId: _interventionBId,
+          taskId: _taskBId,
+          periodId: _periodBId,
+          completedAt: sharedTimestamp,
+        ),
+      ];
+
+      final plan = Cache.buildProgressSyncPlan(
+        localSubject: localSubject,
+        remoteSubject: remoteSubject,
+      );
+
+      expect(plan.hasChanges, isTrue);
+      expect(plan.mergedProgress, hasLength(2));
+      expect(
+        plan.mergedProgress.map((progress) => progress.taskId),
+        containsAll([_taskAId, _taskBId]),
+      );
+    });
+
+    test('does not resubmit already synchronized progress', () {
+      final remoteSubject = _buildSubject();
+      final localSubject = StudySubject.fromJson(remoteSubject.toFullJson());
+      final sharedProgress = _progress(
+        subjectId: remoteSubject.id,
+        interventionId: _interventionAId,
+        taskId: _taskAId,
+        periodId: _periodAId,
+        completedAt: DateTime.utc(2026, 8, 10, 8),
+      );
+
+      remoteSubject.progress = [sharedProgress];
+      localSubject.progress = [
+        SubjectProgress.fromJson(sharedProgress.toJson()),
+      ];
+
+      final plan = Cache.buildProgressSyncPlan(
+        localSubject: localSubject,
+        remoteSubject: remoteSubject,
+      );
+
+      expect(plan.hasChanges, isFalse);
+      expect(plan.newProgress, isEmpty);
+      expect(plan.mergedProgress, hasLength(1));
+    });
+
+    test('treats mismatched cached subject identity as incompatible', () {
+      final remoteSubject = _buildSubject();
+      final localSubject = StudySubject.fromJson(remoteSubject.toFullJson())
+        ..id = 'different-subject-id';
+
+      expect(
+        Cache.isCompatibleCachedSubject(
+          localSubject: localSubject,
+          remoteSubject: remoteSubject,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('Cache partial retry behavior', () {
+    test(
+      'retry plan keeps only unsynced progress after partial save failure',
+      () async {
+        final remoteSubject = _buildSubject();
+        final localSubject = StudySubject.fromJson(remoteSubject.toFullJson());
+        final firstProgress = _progress(
+          subjectId: localSubject.id,
+          interventionId: _interventionAId,
+          taskId: _taskAId,
+          periodId: _periodAId,
+          completedAt: DateTime.utc(2026, 8, 10, 8),
+        );
+        final secondProgress = _progress(
+          subjectId: localSubject.id,
+          interventionId: _interventionBId,
+          taskId: _taskBId,
+          periodId: _periodBId,
+          completedAt: DateTime.utc(2026, 8, 11, 8),
+        );
+        localSubject.progress = [firstProgress, secondProgress];
+
+        final firstPlan = Cache.buildProgressSyncPlan(
+          localSubject: localSubject,
+          remoteSubject: remoteSubject,
+        );
+        final savedProgress = <SubjectProgress>[];
+
+        await expectLater(
+          () => Cache.applyProgressSyncPlan(
+            remoteSubject: remoteSubject,
+            syncPlan: SubjectProgressSyncPlan(
+              newProgress: firstPlan.newProgress,
+              mergedProgress: firstPlan.mergedProgress,
+              saveProgress: (progress) async {
+                savedProgress.add(progress);
+                if (savedProgress.length == 2) {
+                  throw Exception('simulated second progress upload failure');
+                }
+                return progress;
+              },
+              saveSubject: (subject) async => subject,
+            ),
+          ),
+          throwsException,
+        );
+
+        expect(savedProgress, hasLength(2));
+        remoteSubject.progress = [firstProgress];
+
+        final retryPlan = Cache.buildProgressSyncPlan(
+          localSubject: localSubject,
+          remoteSubject: remoteSubject,
+        );
+
+        expect(retryPlan.newProgress, hasLength(1));
+        expect(retryPlan.newProgress.single.taskId, _taskBId);
+      },
+    );
+
+    test('failed blob upload keeps remaining files queued for retry', () async {
+      final uploads = <String>[];
+      final deleted = <String>[];
+      final blobA = FutureBlobFile('/tmp/upload-a', 'blob-a');
+      final blobB = FutureBlobFile('/tmp/upload-b', 'blob-b');
+
+      await expectLater(
+        () => Cache.uploadPendingBlobFiles(
+          futureBlobFiles: [blobA, blobB],
+          uploadObservation: (futureBlobFile) async {
+            uploads.add(futureBlobFile.futureBlobId);
+            if (futureBlobFile.futureBlobId == blobB.futureBlobId) {
+              throw Exception('simulated second blob upload failure');
+            }
+          },
+          deleteUploadedFile: (futureBlobFile) async {
+            deleted.add(futureBlobFile.futureBlobId);
+          },
+        ),
+        throwsException,
+      );
+
+      expect(uploads, ['blob-a', 'blob-b']);
+      expect(
+        deleted,
+        ['blob-a'],
+        reason: 'Only successfully uploaded files should be removed from queue',
+      );
+    });
+
+    test(
+      'synchronize skips cached progress when cached subject belongs to different participant',
+      () async {
+        final remoteSubject = _buildSubject();
+        final cachedSubject = StudySubject.fromJson(remoteSubject.toFullJson())
+          ..id = 'different-subject-id'
+          ..progress = [
+            _progress(
+              subjectId: 'different-subject-id',
+              interventionId: _interventionBId,
+              taskId: _taskBId,
+              periodId: _periodBId,
+              completedAt: DateTime.utc(2026, 8, 11, 8),
+            ),
+          ];
+        final originalRemoteProgress = [
+          _progress(
+            subjectId: remoteSubject.id,
+            interventionId: _interventionAId,
+            taskId: _taskAId,
+            periodId: _periodAId,
+            completedAt: DateTime.utc(2026, 8, 10, 8),
+          ),
+        ];
+        remoteSubject.progress = [...originalRemoteProgress];
+
+        await Cache.storeSubject(cachedSubject);
+
+        final synchronized = await Cache.synchronize(remoteSubject);
+
+        expect(synchronized.progress, hasLength(1));
+        expect(synchronized.progress.single.taskId, _taskAId);
+        expect(synchronized.progress.single.subjectId, remoteSubject.id);
+      },
+    );
+  });
+}

--- a/app/test/deleted_subject_cleanup_test.dart
+++ b/app/test/deleted_subject_cleanup_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FlutterSecureStoragePlatform originalPlatform;
+  late Map<String, String> storageData;
+
+  setUp(() {
+    originalPlatform = FlutterSecureStoragePlatform.instance;
+    storageData = {};
+    FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
+      storageData,
+    );
+  });
+
+  tearDown(() {
+    FlutterSecureStoragePlatform.instance = originalPlatform;
+  });
+
+  test(
+    'clearDeletedSubjectLocalState removes only stale subject state',
+    () async {
+      await SecureStorage.write(selectedSubjectIdKey, 'subject-1');
+      await SecureStorage.write(cacheSubjectKey, 'cached-subject');
+      await SecureStorage.write(userEmailKey, 'participant@example.com');
+      await SecureStorage.write(userPasswordKey, 'password');
+
+      await clearDeletedSubjectLocalState();
+
+      expect(await SecureStorage.read(selectedSubjectIdKey), isNull);
+      expect(await SecureStorage.read(cacheSubjectKey), isNull);
+      expect(await SecureStorage.read(userEmailKey), 'participant@example.com');
+      expect(await SecureStorage.read(userPasswordKey), 'password');
+    },
+  );
+}

--- a/app/test/loading_screen_session_restore_test.dart
+++ b/app/test/loading_screen_session_restore_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/screens/app_onboarding/loading_screen.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+
+void main() {
+  tearDown(() {
+    appConnectionStatusController.reset();
+  });
+
+  test(
+    'tryRestoreParticipantSession skips network auth while connectivity is already degraded',
+    () async {
+      appConnectionStatusController.setStatus(
+        AppConnectionStatus.backendUnavailable,
+      );
+      var signInCalls = 0;
+
+      await tryRestoreParticipantSession(
+        isLoggedIn: () => false,
+        hasStoredCredentials: () async => true,
+        signIn: () async {
+          signInCalls++;
+        },
+      );
+
+      expect(signInCalls, 0);
+    },
+  );
+}

--- a/app/test/loading_screen_subject_recovery_test.dart
+++ b/app/test/loading_screen_subject_recovery_test.dart
@@ -1,8 +1,13 @@
+import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:studyu_app/screens/app_onboarding/loading_screen.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+import 'package:supabase/supabase.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   tearDown(() {
     appConnectionStatusController.reset();
   });
@@ -119,6 +124,59 @@ void main() {
       );
     },
   );
+
+  test('rejected startup credentials reach deleted-subject recovery', () async {
+    final originalStoragePlatform = FlutterSecureStoragePlatform.instance;
+    final storageData = <String, String>{};
+    FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
+      storageData,
+    );
+    var authenticationCalls = 0;
+    var loadCacheCalls = 0;
+
+    try {
+      await storeFakeUserEmailAndPassword(
+        'participant@example.com',
+        'password',
+      );
+
+      final rejectedCredentialsError = await tryRestoreParticipantSession(
+        isLoggedIn: () => false,
+        hasStoredCredentials: () async => true,
+        signIn: () {
+          authenticationCalls++;
+          return Future<void>.error(
+            const AuthApiException(
+              'Invalid login credentials',
+              code: 'invalid_credentials',
+            ),
+          );
+        },
+      );
+
+      expect(await SecureStorage.read(userEmailKey), isNull);
+      expect(await SecureStorage.read(userPasswordKey), isNull);
+
+      await expectLater(
+        () => restoreCachedValueForStartup<String>(
+          fetchRemote: () => Future<String?>.error(Exception('expired JWT')),
+          loadCached: () {
+            loadCacheCalls++;
+            return Future.value('cached-subject');
+          },
+          signIn: () => Future<bool>.error(rejectedCredentialsError!),
+          isDeletedRemoteError: (_) => false,
+        ),
+        throwsA(isA<SubjectDeletedException>()),
+      );
+
+      expect(authenticationCalls, 1);
+      expect(loadCacheCalls, 0);
+    } finally {
+      await clearParticipantCredentials();
+      FlutterSecureStoragePlatform.instance = originalStoragePlatform;
+    }
+  });
 
   test(
     'restoreCachedValueForStartup maps deleted remote subject without using cache',

--- a/app/test/loading_screen_subject_recovery_test.dart
+++ b/app/test/loading_screen_subject_recovery_test.dart
@@ -39,6 +39,70 @@ void main() {
   );
 
   test(
+    'restoreCachedValueForStartup returns cached value and skips sign-in while device is offline',
+    () async {
+      var signInCalls = 0;
+      var fetchCalls = 0;
+
+      final result = await restoreCachedValueForStartup<String>(
+        fetchRemote: () {
+          fetchCalls++;
+          return Future<String?>.error(
+            Exception('SocketException: Network is unreachable'),
+          );
+        },
+        loadCached: () => Future.value('cached-subject'),
+        signIn: () {
+          signInCalls++;
+          return Future.value(true);
+        },
+        isDeletedRemoteError: (_) => false,
+      );
+
+      expect(result, 'cached-subject');
+      expect(fetchCalls, 1);
+      expect(signInCalls, 0);
+      expect(
+        appConnectionStatusController.status,
+        AppConnectionStatus.deviceOffline,
+      );
+    },
+  );
+
+  test(
+    'restoreCachedValueForStartup uses cache immediately once backend is already marked unavailable',
+    () async {
+      var signInCalls = 0;
+      var fetchCalls = 0;
+
+      appConnectionStatusController.setStatus(
+        AppConnectionStatus.backendUnavailable,
+      );
+
+      final result = await restoreCachedValueForStartup<String>(
+        fetchRemote: () {
+          fetchCalls++;
+          return Future.value('remote-subject');
+        },
+        loadCached: () => Future.value('cached-subject'),
+        signIn: () {
+          signInCalls++;
+          return Future.value(true);
+        },
+        isDeletedRemoteError: (_) => false,
+      );
+
+      expect(result, 'cached-subject');
+      expect(fetchCalls, 0);
+      expect(signInCalls, 0);
+      expect(
+        appConnectionStatusController.status,
+        AppConnectionStatus.backendUnavailable,
+      );
+    },
+  );
+
+  test(
     'restoreCachedValueForStartup throws cache unavailable when backend is down and cache is missing',
     () async {
       await expectLater(

--- a/app/test/offline_task_persistence_test.dart
+++ b/app/test/offline_task_persistence_test.dart
@@ -210,4 +210,78 @@ void main() {
       );
     },
   );
+
+  test(
+    'future blob file helpers filter and delete only matching subject scope',
+    () async {
+      final primaryHandler = TemporaryStorageHandler(_studyId, _userId);
+      final otherHandler = TemporaryStorageHandler('study-b', 'user-b');
+
+      final primaryImage = await primaryHandler.getStagingImage();
+      final otherImage = await otherHandler.getStagingImage();
+      expect(primaryImage, isNotNull);
+      expect(otherImage, isNotNull);
+
+      await File(primaryImage!.localFilePath).create(recursive: true);
+      await File(primaryImage.localFilePath).writeAsString('primary');
+      await TemporaryStorageHandler.moveStagingFileToUploadDirectory(
+        primaryImage.localFilePath,
+        primaryImage.futureBlobId,
+      );
+
+      await File(otherImage!.localFilePath).create(recursive: true);
+      await File(otherImage.localFilePath).writeAsString('other');
+      await TemporaryStorageHandler.moveStagingFileToUploadDirectory(
+        otherImage.localFilePath,
+        otherImage.futureBlobId,
+      );
+
+      final scopedFiles = await TemporaryStorageHandler.getFutureBlobFiles(
+        studyId: _studyId,
+        userId: _userId,
+      );
+
+      expect(scopedFiles.map((file) => file.futureBlobId), [
+        primaryImage.futureBlobId,
+      ]);
+
+      await TemporaryStorageHandler.deleteFutureBlobFiles(
+        studyId: _studyId,
+        userId: _userId,
+      );
+
+      final remainingFiles = await TemporaryStorageHandler.getFutureBlobFiles();
+      expect(remainingFiles.map((file) => file.futureBlobId), [
+        otherImage.futureBlobId,
+      ]);
+    },
+  );
+
+  test(
+    'cache synchronization uploads only pending files for remote subject',
+    () async {
+      final remoteSubject = _buildSubject(
+        checkmarkTask: CheckmarkTask.withId(),
+        questionnaireTask: QuestionnaireTask.withId(),
+      );
+      final localSubject = StudySubject.fromJson(remoteSubject.toFullJson())
+        ..inviteCode = 'cached-invite';
+      await Cache.storeSubject(localSubject);
+
+      String? uploadedStudyId;
+      String? uploadedUserId;
+      Cache.debugUploadBlobFilesOverride = (studyId, userId) async {
+        uploadedStudyId = studyId;
+        uploadedUserId = userId;
+      };
+
+      final synchronized = await Cache.synchronize(remoteSubject);
+
+      expect(synchronized, same(remoteSubject));
+      expect(uploadedStudyId, remoteSubject.studyId);
+      expect(uploadedUserId, remoteSubject.userId);
+
+      Cache.debugUploadBlobFilesOverride = null;
+    },
+  );
 }

--- a/app/test/offline_task_persistence_test.dart
+++ b/app/test/offline_task_persistence_test.dart
@@ -1,0 +1,213 @@
+import 'dart:io';
+
+import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:studyu_app/util/cache.dart';
+import 'package:studyu_app/util/study_subject_extension.dart';
+import 'package:studyu_app/util/temporary_storage_handler.dart';
+import 'package:studyu_core/core.dart';
+
+const _studyId = 'study-id';
+const _userId = 'user-id';
+const _interventionId = 'intervention-a';
+const _interventionBId = 'intervention-b';
+const _checkmarkPeriodId = 'period-checkmark';
+const _questionnairePeriodId = 'period-questionnaire';
+const _questionId = 'question-upload';
+
+StudySubject _buildSubject({
+  required CheckmarkTask checkmarkTask,
+  required QuestionnaireTask questionnaireTask,
+}) {
+  final study = Study(_studyId, _userId)
+    ..title = 'Offline persistence study'
+    ..status = StudyStatus.running
+    ..schedule.includeBaseline = false
+    ..schedule.numberOfCycles = 1
+    ..schedule.phaseDuration = 7
+    ..interventions = [
+      Intervention(_interventionId, 'Intervention A'),
+      Intervention(_interventionBId, 'Intervention B'),
+    ]
+    ..observations = [questionnaireTask];
+
+  study.interventions.first.tasks = [checkmarkTask];
+
+  return StudySubject.fromStudy(
+    study,
+    _userId,
+    study.interventions.map((intervention) => intervention.id).toList(),
+    null,
+  )..startedAt = DateTime.now().subtract(const Duration(days: 1));
+}
+
+class _FakePathProviderPlatform extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  _FakePathProviderPlatform({
+    required this.temporaryPath,
+    required this.applicationDocumentsPath,
+  });
+
+  final String temporaryPath;
+  final String applicationDocumentsPath;
+
+  @override
+  Future<String?> getTemporaryPath() async => temporaryPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async =>
+      applicationDocumentsPath;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Map<String, String> secureStorageData;
+  late FlutterSecureStoragePlatform secureStoragePlatform;
+  late PathProviderPlatform pathProviderPlatform;
+  late Directory tempDirectory;
+  late Directory documentsDirectory;
+
+  setUp(() async {
+    secureStorageData = {};
+    secureStoragePlatform = FlutterSecureStoragePlatform.instance;
+    FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
+      secureStorageData,
+    );
+
+    pathProviderPlatform = PathProviderPlatform.instance;
+    final root = await Directory.systemTemp.createTemp(
+      'studyu-offline-task-test-',
+    );
+    tempDirectory = Directory('${root.path}/temp')..createSync(recursive: true);
+    documentsDirectory = Directory('${root.path}/documents')
+      ..createSync(recursive: true);
+    PathProviderPlatform.instance = _FakePathProviderPlatform(
+      temporaryPath: tempDirectory.path,
+      applicationDocumentsPath: documentsDirectory.path,
+    );
+  });
+
+  tearDown(() async {
+    FlutterSecureStoragePlatform.instance = secureStoragePlatform;
+    PathProviderPlatform.instance = pathProviderPlatform;
+    if (documentsDirectory.parent.existsSync()) {
+      await documentsDirectory.parent.delete(recursive: true);
+    }
+  });
+
+  test(
+    'offline checkmark completion persists subject progress across cache reload',
+    () async {
+      final checkmarkTask = CheckmarkTask.withId()
+        ..title = 'Rate your day'
+        ..schedule.completionPeriods = [
+          CompletionPeriod(
+            id: _checkmarkPeriodId,
+            unlockTime: StudyUTimeOfDay(hour: 8),
+            lockTime: StudyUTimeOfDay(hour: 20),
+          ),
+        ];
+      final questionnaireTask = QuestionnaireTask.withId()
+        ..title = 'Upload task'
+        ..schedule.completionPeriods = [
+          CompletionPeriod(
+            id: _questionnairePeriodId,
+            unlockTime: StudyUTimeOfDay(hour: 8),
+            lockTime: StudyUTimeOfDay(hour: 20),
+          ),
+        ];
+
+      final subject = _buildSubject(
+        checkmarkTask: checkmarkTask,
+        questionnaireTask: questionnaireTask,
+      );
+
+      await subject.addResult<bool>(
+        taskId: checkmarkTask.id,
+        periodId: _checkmarkPeriodId,
+        result: true,
+        offline: true,
+      );
+      await Cache.storeSubject(subject);
+
+      final restored = await Cache.loadSubject();
+
+      expect(restored.progress, hasLength(1));
+      expect(restored.progress.single.completedAt, isNotNull);
+      expect(
+        restored.completedTaskForDay(checkmarkTask.id, DateTime.now()),
+        isTrue,
+      );
+    },
+  );
+
+  test(
+    'offline questionnaire media result survives cache reload and keeps pending upload file',
+    () async {
+      final checkmarkTask = CheckmarkTask.withId()
+        ..title = 'Rate your day'
+        ..schedule.completionPeriods = [
+          CompletionPeriod(
+            id: _checkmarkPeriodId,
+            unlockTime: StudyUTimeOfDay(hour: 8),
+            lockTime: StudyUTimeOfDay(hour: 20),
+          ),
+        ];
+      final questionnaireTask = QuestionnaireTask.withId()
+        ..title = 'Upload task'
+        ..schedule.completionPeriods = [
+          CompletionPeriod(
+            id: _questionnairePeriodId,
+            unlockTime: StudyUTimeOfDay(hour: 8),
+            lockTime: StudyUTimeOfDay(hour: 20),
+          ),
+        ];
+
+      final subject = _buildSubject(
+        checkmarkTask: checkmarkTask,
+        questionnaireTask: questionnaireTask,
+      );
+
+      final stagingFile = await TemporaryStorageHandler(
+        _studyId,
+        _userId,
+      ).getStagingImage();
+      expect(stagingFile, isNotNull);
+      await File(stagingFile!.localFilePath).create(recursive: true);
+      await File(stagingFile.localFilePath).writeAsString('image-bytes');
+
+      final questionnaireState = QuestionnaireState();
+      questionnaireState.answers[_questionId] = Answer<FutureBlobFile>(
+        _questionId,
+        DateTime.now(),
+      )..response = stagingFile;
+
+      await subject.addResult<QuestionnaireState>(
+        taskId: questionnaireTask.id,
+        periodId: _questionnairePeriodId,
+        result: questionnaireState,
+        offline: true,
+      );
+      await Cache.storeSubject(subject);
+
+      final restored = await Cache.loadSubject();
+      final restoredQuestionnaire =
+          restored.progress.single.result.result as QuestionnaireState;
+      final restoredAnswer =
+          restoredQuestionnaire.answers[_questionId]! as Answer<String>;
+      final pendingUploads = await TemporaryStorageHandler.getFutureBlobFiles();
+
+      expect(restored.progress, hasLength(1));
+      expect(restoredAnswer.response, stagingFile.futureBlobId);
+      expect(
+        pendingUploads.map((file) => file.futureBlobId),
+        contains(stagingFile.futureBlobId),
+      );
+    },
+  );
+}

--- a/app/test/study_local_cleanup_test.dart
+++ b/app/test/study_local_cleanup_test.dart
@@ -1,0 +1,156 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:studyu_app/util/study_local_cleanup.dart';
+import 'package:studyu_app/util/temporary_storage_handler.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+
+class _FakePathProviderPlatform extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  _FakePathProviderPlatform({
+    required this.temporaryPath,
+    required this.applicationDocumentsPath,
+  });
+
+  final String temporaryPath;
+  final String applicationDocumentsPath;
+
+  @override
+  Future<String?> getTemporaryPath() async => temporaryPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async =>
+      applicationDocumentsPath;
+}
+
+StudySubject _buildSubject({
+  String studyId = 'study-id',
+  String userId = 'user-id',
+}) {
+  final study = Study(studyId, 'owner-id');
+  return StudySubject.fromStudy(study, userId, const [], null);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FlutterSecureStoragePlatform originalStoragePlatform;
+  late PathProviderPlatform originalPathProviderPlatform;
+  late Directory tempDirectory;
+  late Directory documentsDirectory;
+
+  setUp(() async {
+    originalStoragePlatform = FlutterSecureStoragePlatform.instance;
+    FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
+      {},
+    );
+
+    originalPathProviderPlatform = PathProviderPlatform.instance;
+    final root = await Directory.systemTemp.createTemp(
+      'studyu-study-local-cleanup-test-',
+    );
+    tempDirectory = Directory('${root.path}/temp')..createSync(recursive: true);
+    documentsDirectory = Directory('${root.path}/documents')
+      ..createSync(recursive: true);
+    PathProviderPlatform.instance = _FakePathProviderPlatform(
+      temporaryPath: tempDirectory.path,
+      applicationDocumentsPath: documentsDirectory.path,
+    );
+  });
+
+  tearDown(() async {
+    FlutterSecureStoragePlatform.instance = originalStoragePlatform;
+    PathProviderPlatform.instance = originalPathProviderPlatform;
+    if (documentsDirectory.parent.existsSync()) {
+      await documentsDirectory.parent.delete(recursive: true);
+    }
+  });
+
+  test(
+    'clearStudyLocalData removes removed-study cache and scoped uploads but keeps participant credentials by default',
+    () async {
+      final subject = _buildSubject();
+      final otherSubject = _buildSubject(
+        studyId: 'other-study',
+        userId: 'other-user',
+      );
+      await SecureStorage.write(selectedSubjectIdKey, subject.id);
+      await SecureStorage.write(
+        cacheSubjectKey,
+        jsonEncode(subject.toFullJson()),
+      );
+      await storeFakeUserEmailAndPassword(
+        'participant@$fakeStudyUEmailDomain',
+        'password',
+      );
+
+      final subjectUpload = await TemporaryStorageHandler(
+        subject.studyId,
+        subject.userId,
+      ).getStagingImage();
+      final otherUpload = await TemporaryStorageHandler(
+        otherSubject.studyId,
+        otherSubject.userId,
+      ).getStagingImage();
+      expect(subjectUpload, isNotNull);
+      expect(otherUpload, isNotNull);
+
+      await File(subjectUpload!.localFilePath).create(recursive: true);
+      await File(subjectUpload.localFilePath).writeAsString('subject');
+      await TemporaryStorageHandler.moveStagingFileToUploadDirectory(
+        subjectUpload.localFilePath,
+        subjectUpload.futureBlobId,
+      );
+
+      await File(otherUpload!.localFilePath).create(recursive: true);
+      await File(otherUpload.localFilePath).writeAsString('other');
+      await TemporaryStorageHandler.moveStagingFileToUploadDirectory(
+        otherUpload.localFilePath,
+        otherUpload.futureBlobId,
+      );
+
+      await clearStudyLocalData(fallbackSubject: subject);
+
+      expect(await SecureStorage.read(selectedSubjectIdKey), isNull);
+      expect(await SecureStorage.read(cacheSubjectKey), isNull);
+      expect(await getFakeUserEmail(), isNotNull);
+      expect(await getFakeUserPassword(), isNotNull);
+      expect(
+        (await TemporaryStorageHandler.getFutureBlobFiles()).map(
+          (file) => file.futureBlobId,
+        ),
+        [otherUpload.futureBlobId],
+      );
+    },
+  );
+
+  test(
+    'clearStudyLocalData can also clear stored participant credentials for full reset flows',
+    () async {
+      final subject = _buildSubject();
+      await SecureStorage.write(
+        cacheSubjectKey,
+        jsonEncode(subject.toFullJson()),
+      );
+      await storeFakeUserEmailAndPassword(
+        'participant@$fakeStudyUEmailDomain',
+        'password',
+      );
+
+      await clearStudyLocalData(
+        fallbackSubject: subject,
+        clearStoredParticipantCredentials: true,
+      );
+
+      expect(await getFakeUserEmail(), isNull);
+      expect(await getFakeUserPassword(), isNull);
+    },
+  );
+}

--- a/core/test/model/study_subject/study_subject_cache_test.dart
+++ b/core/test/model/study_subject/study_subject_cache_test.dart
@@ -1,0 +1,138 @@
+import 'package:studyu_core/core.dart';
+import 'package:test/test.dart';
+
+const _studyId = 'study-id';
+const _userId = 'user-id';
+const _interventionAId = 'intervention-a';
+const _interventionBId = 'intervention-b';
+const _checkmarkPeriodId = 'period-checkmark';
+const _observationPeriodId = 'period-observation';
+
+StudySubject _buildSubject() {
+  final checkmarkTask = CheckmarkTask.withId()
+    ..title = 'Rate your day'
+    ..schedule.completionPeriods = [
+      CompletionPeriod(
+        id: _checkmarkPeriodId,
+        unlockTime: StudyUTimeOfDay(hour: 8),
+        lockTime: StudyUTimeOfDay(hour: 20),
+      ),
+    ];
+
+  final observationTask = QuestionnaireTask.withId()
+    ..title = 'Mood survey'
+    ..schedule.completionPeriods = [
+      CompletionPeriod(
+        id: _observationPeriodId,
+        unlockTime: StudyUTimeOfDay(hour: 9),
+        lockTime: StudyUTimeOfDay(hour: 21),
+      ),
+    ];
+
+  final study = Study(_studyId, _userId)
+    ..title = 'Cached study'
+    ..status = StudyStatus.running
+    ..schedule = StudySchedule(sequenceCustom: 'AB')
+    ..interventions = [
+      Intervention(_interventionAId, 'Intervention A')..tasks = [checkmarkTask],
+      Intervention(_interventionBId, 'Intervention B'),
+    ]
+    ..observations = [observationTask];
+
+  study.schedule
+    ..includeBaseline = true
+    ..numberOfCycles = 1
+    ..phaseDuration = 2;
+
+  final subject = StudySubject.fromStudy(
+    study,
+    _userId,
+    study.interventions.map((intervention) => intervention.id).toList(),
+    null,
+  )..startedAt = DateTime.utc(2026, 8);
+
+  subject.progress = [
+    SubjectProgress(
+      subjectId: subject.id,
+      interventionId: _interventionAId,
+      taskId: checkmarkTask.id,
+      resultType: 'bool',
+      result: Result<bool>.app(
+        type: 'bool',
+        periodId: _checkmarkPeriodId,
+        result: true,
+      ),
+    )..completedAt = DateTime.utc(2026, 8, 3, 10),
+  ];
+
+  return subject;
+}
+
+void main() {
+  group('StudySubject cache roundtrip', () {
+    test(
+      'preserves cached configuration, schedule, task state, and progress',
+      () {
+        final subject = _buildSubject();
+        final activeDate = subject.startedAt!.add(
+          Duration(days: subject.study.schedule.phaseDuration),
+        );
+
+        final restored = StudySubject.fromJson(subject.toFullJson());
+
+        expect(restored.study.title, subject.study.title);
+        expect(restored.study.status, StudyStatus.running);
+        expect(restored.study.schedule.includeBaseline, isTrue);
+        expect(
+          restored.study.schedule.phaseDuration,
+          subject.study.schedule.phaseDuration,
+        );
+        expect(
+          restored.study.schedule.numberOfCycles,
+          subject.study.schedule.numberOfCycles,
+        );
+        expect(
+          restored.selectedInterventionIds,
+          subject.selectedInterventionIds,
+        );
+        expect(
+          restored.getInterventionForDate(activeDate)?.id,
+          _interventionAId,
+        );
+
+        final scheduledTaskIds = restored
+            .scheduleFor(activeDate)
+            .map((taskInstance) => taskInstance.task.id)
+            .toList();
+        expect(
+          scheduledTaskIds,
+          unorderedEquals([
+            restored.study.interventions.first.tasks.single.id,
+            restored.study.observations.single.id,
+          ]),
+        );
+
+        expect(restored.progress, hasLength(1));
+        expect(
+          restored.progress.single.completedAt,
+          DateTime.utc(2026, 8, 3, 10),
+        );
+        expect(
+          restored.completedTaskForDay(
+            restored.study.interventions.first.tasks.single.id,
+            activeDate,
+          ),
+          isTrue,
+        );
+        expect(
+          restored.completedTaskForDay(
+            restored.study.observations.single.id,
+            activeDate,
+          ),
+          isFalse,
+        );
+        expect(restored.allTasksCompletedFor(activeDate), isFalse);
+      },
+    );
+  });
+}

--- a/flutter_common/lib/src/utils/user.dart
+++ b/flutter_common/lib/src/utils/user.dart
@@ -175,10 +175,14 @@ Future<void> deleteActiveStudyReference() async {
   await SecureStorage.delete(selectedSubjectIdKey);
 }
 
-Future<void> deleteLocalData() async {
-  await clearParticipantCredentials();
+Future<void> clearDeletedSubjectLocalState() async {
   await SecureStorage.delete(selectedSubjectIdKey);
   await SecureStorage.delete(cacheSubjectKey);
+}
+
+Future<void> deleteLocalData() async {
+  await clearParticipantCredentials();
+  await clearDeletedSubjectLocalState();
 }
 
 void previewSubjectIdKey() {

--- a/flutter_common/lib/src/utils/user.dart
+++ b/flutter_common/lib/src/utils/user.dart
@@ -63,22 +63,24 @@ Future<bool> isParticipantSessionValid() async {
 Future<bool> signInParticipant() async {
   final hasEmail = await SecureStorage.containsKey(userEmailKey);
   final hasPassword = await SecureStorage.containsKey(userPasswordKey);
-  if (hasEmail && hasPassword) {
-    try {
-      final fakeEmail = await getFakeUserEmail();
-      final fakePassword = await getFakeUserPassword();
-      final authResponse = await Supabase.instance.client.auth
-          .signInWithPassword(email: fakeEmail, password: fakePassword!);
-      return authResponse.session != null;
-    } on AuthApiException catch (error, stacktrace) {
-      if (error.code == 'invalid_credentials') {
-        await clearParticipantCredentials();
-        return false;
-      }
-      SupabaseQuery.catchSupabaseException(error, stacktrace);
-    } catch (error, stacktrace) {
-      SupabaseQuery.catchSupabaseException(error, stacktrace);
+  if (!hasEmail || !hasPassword) return false;
+
+  try {
+    final fakeEmail = await getFakeUserEmail();
+    final fakePassword = await getFakeUserPassword();
+    final authResponse = await Supabase.instance.client.auth.signInWithPassword(
+      email: fakeEmail,
+      password: fakePassword!,
+    );
+    return authResponse.session != null;
+  } on AuthApiException catch (error, stacktrace) {
+    if (error.code == 'invalid_credentials') {
+      await clearParticipantCredentials();
+      rethrow;
     }
+    SupabaseQuery.catchSupabaseException(error, stacktrace);
+  } catch (error, stacktrace) {
+    SupabaseQuery.catchSupabaseException(error, stacktrace);
   }
   return false;
 }
@@ -112,6 +114,8 @@ Future<bool> ensureParticipantSignedIn({
 
   try {
     if (await (signIn ?? signInParticipant)()) return true;
+  } on AuthApiException catch (error) {
+    if (error.code != 'invalid_credentials') rethrow;
   } catch (error) {
     final status = connectionStatusFromError(error);
     if (status != null) {
@@ -135,7 +139,11 @@ Future<bool> ensureParticipantSignedIn({
 
 // Using a fake user email to enable anonymous users, while working with row-level security on postgres
 Future<bool> anonymousSignUp() async {
-  if (await signInParticipant()) return true;
+  try {
+    if (await signInParticipant()) return true;
+  } on AuthApiException catch (error) {
+    if (error.code != 'invalid_credentials') rethrow;
+  }
   final fakeUserEmail = '${const Uuid().v4()}@$fakeStudyUEmailDomain';
   final fakeUserPassword = const Uuid().v4();
   try {

--- a/flutter_common/pubspec.yaml
+++ b/flutter_common/pubspec.yaml
@@ -25,8 +25,10 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^6.0.0
+  flutter_secure_storage_platform_interface: ^2.0.1
   flutter_test:
     sdk: flutter
+  http: ^1.6.0
 
 flutter:
   generate: true

--- a/flutter_common/test/connection_status_test.dart
+++ b/flutter_common/test/connection_status_test.dart
@@ -38,4 +38,25 @@ void main() {
 
     expect(calls, [AppConnectionStatus.backendUnavailable]);
   });
+
+  test('connectionStatusFromError maps explicit offline transport errors', () {
+    expect(
+      connectionStatusFromError(
+        Exception('SocketException: Network is unreachable'),
+      ),
+      AppConnectionStatus.deviceOffline,
+    );
+  });
+
+  test(
+    'connectionStatusFromError keeps generic fetch failures as backend unavailable',
+    () {
+      expect(
+        connectionStatusFromError(
+          Exception('ClientException: Failed to fetch'),
+        ),
+        AppConnectionStatus.backendUnavailable,
+      );
+    },
+  );
 }

--- a/flutter_common/test/init_test.dart
+++ b/flutter_common/test/init_test.dart
@@ -1,10 +1,131 @@
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:studyu_flutter_common/src/utils/connection_status.dart';
+import 'package:studyu_flutter_common/src/utils/storage.dart';
 import 'package:studyu_flutter_common/src/utils/user.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class _TestAsyncStorage extends GotrueAsyncStorage {
+  const _TestAsyncStorage();
+
+  @override
+  Future<String?> getItem({required String key}) async => null;
+
+  @override
+  Future<void> removeItem({required String key}) async {}
+
+  @override
+  Future<void> setItem({required String key, required String value}) async {}
+}
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FlutterSecureStoragePlatform originalStoragePlatform;
+  var signInRequests = 0;
+  var signUpRequests = 0;
+
+  setUpAll(() async {
+    final authClient = MockClient((request) async {
+      if (request.url.path.endsWith('/token')) {
+        signInRequests++;
+        return http.Response(
+          jsonEncode({
+            'code': 'invalid_credentials',
+            'message': 'Invalid login credentials',
+          }),
+          400,
+          headers: {'x-supabase-api-version': '2024-01-01'},
+        );
+      }
+      if (request.url.path.endsWith('/signup')) {
+        signUpRequests++;
+        return http.Response(
+          jsonEncode({
+            'access_token': 'header.payload.signature',
+            'expires_in': 3600,
+            'refresh_token': 'refresh-token',
+            'token_type': 'bearer',
+            'user': {'id': '00000000-0000-0000-0000-000000000001'},
+          }),
+          200,
+        );
+      }
+      return http.Response('', 404);
+    });
+
+    await Supabase.initialize(
+      url: 'https://example.supabase.co',
+      publishableKey: 'test-key',
+      httpClient: authClient,
+      authOptions: const FlutterAuthClientOptions(
+        authFlowType: AuthFlowType.implicit,
+        autoRefreshToken: false,
+        detectSessionInUri: false,
+        localStorage: EmptyLocalStorage(),
+        pkceAsyncStorage: _TestAsyncStorage(),
+      ),
+    );
+  });
+
+  setUp(() {
+    originalStoragePlatform = FlutterSecureStoragePlatform.instance;
+    FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
+      {},
+    );
+    signInRequests = 0;
+    signUpRequests = 0;
+  });
+
   tearDown(() {
+    FlutterSecureStoragePlatform.instance = originalStoragePlatform;
     appConnectionStatusController.reset();
+  });
+
+  tearDownAll(() async {
+    await Supabase.instance.dispose();
+  });
+
+  test('signInParticipant deletes rejected credentials and rethrows', () async {
+    await storeFakeUserEmailAndPassword('old@example.com', 'old-password');
+
+    await expectLater(
+      signInParticipant(),
+      throwsA(
+        isA<AuthApiException>().having(
+          (error) => error.code,
+          'code',
+          'invalid_credentials',
+        ),
+      ),
+    );
+
+    expect(signInRequests, 1);
+    expect(await SecureStorage.read(userEmailKey), isNull);
+    expect(await SecureStorage.read(userPasswordKey), isNull);
+  });
+
+  test('anonymousSignUp replaces rejected participant credentials', () async {
+    await storeFakeUserEmailAndPassword('old@example.com', 'old-password');
+
+    final success = await anonymousSignUp();
+
+    expect(success, isTrue);
+    expect(signInRequests, 1);
+    expect(signUpRequests, 1);
+    expect(
+      await SecureStorage.read(userEmailKey),
+      allOf(isNotNull, isNot('old@example.com')),
+    );
+    expect(
+      await SecureStorage.read(userPasswordKey),
+      allOf(isNotNull, isNot('old-password')),
+    );
   });
 
   test('ensureParticipantSignedIn returns true for existing session', () async {
@@ -91,6 +212,30 @@ void main() {
       final success = await ensureParticipantSignedIn(
         isSignedIn: () => false,
         signIn: () async => false,
+        signUp: () async {
+          signUpCalls++;
+          return true;
+        },
+      );
+
+      expect(success, isTrue);
+      expect(signUpCalls, 1);
+    },
+  );
+
+  test(
+    'ensureParticipantSignedIn replaces rejected participant credentials',
+    () async {
+      var signUpCalls = 0;
+
+      final success = await ensureParticipantSignedIn(
+        isSignedIn: () => false,
+        signIn: () => Future<bool>.error(
+          const AuthApiException(
+            'Invalid login credentials',
+            code: 'invalid_credentials',
+          ),
+        ),
         signUp: () async {
           signUpCalls++;
           return true;


### PR DESCRIPTION
## Description

Related Jira issue: [STUDYU-95](https://studyu.atlassian.net/browse/STUDYU-95)

Split from #906 and stacked on the degraded-startup foundation.

**Stack 2 of 3** · Previous: #934 · Next: #936

Cached startup recovery could merge data from the wrong participant, lose pending progress, or retain a subject that had been removed remotely. Protected synchronization could also run before participant authentication was restored, and transport/auth failures could clear credentials that should survive an outage.

This PR adds safe cache recovery and cleanup:

- restores participant authentication before protected subject synchronization;
- validates cached subject identity before merging progress;
- preserves pending progress and media uploads across failed synchronization;
- retries cache synchronization without anonymous protected requests;
- detects remotely deleted subjects and removes their local study data;
- centralizes subject cleanup for switching, opt-out, and recovery flows;
- preserves credentials and auth errors during transport/backend failures.

This is Stack 2 of 3. Base: `fix/pr906-degraded-startup`. Stack 3 targets this branch.

## Visuals

<!-- Required: attach a screenshot or recording of cached startup/recovery when the backend is unavailable or a study was removed. -->

## Testing Steps

1. Join a study and establish cached participant state.
2. Stop the backend, reload, and verify the cached subject is restored.
3. Restore the backend and verify synchronization authenticates before protected fetches.
4. Remove the subject remotely and verify local study data is cleaned up on recovery.
5. Automated verification completed:
   - focused app tests: `app_error_screen_test.dart`, `app_state_test.dart`, `cache_synchronization_test.dart`, `deleted_subject_cleanup_test.dart`, `loading_screen_session_restore_test.dart`, `loading_screen_subject_recovery_test.dart`, `offline_task_persistence_test.dart`, `study_local_cleanup_test.dart`
   - `cd core && rtk fvm dart test test/model/study_subject/study_subject_cache_test.dart`
   - `cd flutter_common && rtk fvm flutter test test/connection_status_test.dart test/init_test.dart`
   - `rtk scripts/pre-commit-check`

### PR Checklist
- [x] Formatting passes via `scripts/pre-commit-check`
- [x] Dart and Flutter analyzers pass via `scripts/pre-commit-check`
- [ ] Screenshot or video attached
- [x] Description links related work (#906)


[STUDYU-95]: https://studyu.atlassian.net/browse/STUDYU-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ