### PR TITLE
STUDYU-95: fix(app): persist and sync tasks offline

### DIFF
--- a/app/lib/models/app_state.dart
+++ b/app/lib/models/app_state.dart
@@ -29,7 +29,9 @@ class AppState with ChangeNotifier {
   late final VoidCallback _connectionStatusListener;
   AppConnectionStatus _connectionStatus = appConnectionStatusController.status;
   Timer? _activeSubjectSyncRetryTimer;
-  bool _activeSubjectSyncInFlight = false;
+  Future<void>? _activeSubjectSyncFuture;
+  bool _activeSubjectSyncStopped = false;
+  bool _activeSubjectSyncPending = false;
   StreamSubscription<StudySubject>? _activeSubjectCacheSubscription;
   StudySubject? _activeSubjectCacheSource;
 
@@ -42,6 +44,9 @@ class AppState with ChangeNotifier {
 
   @visibleForTesting
   Future<bool> Function()? debugRestoreParticipantSessionForSync;
+
+  @visibleForTesting
+  bool Function()? debugHasParticipantSessionForSync;
 
   bool get hasPendingDeepLink =>
       pendingDeepLinkStudyId != null || pendingDeepLinkInviteCode != null;
@@ -88,10 +93,15 @@ class AppState with ChangeNotifier {
     _activeSubjectCacheSubscription = currentSubject.onSave.listen((
       StudySubject subject,
     ) async {
+      if (_activeSubjectSyncStopped ||
+          !identical(_activeSubjectCacheSource, currentSubject)) {
+        return;
+      }
       activeSubject = subject;
       if (selectedStudy == null || selectedStudy?.id == subject.study.id) {
         selectedStudy = subject.study;
       }
+      _syncActiveSubjectCache();
       await Cache.storeSubject(subject);
       scheduleActiveSubjectSyncRetryIfNeeded();
       notifyListeners();
@@ -103,7 +113,11 @@ class AppState with ChangeNotifier {
     bool notifyListenersNow = true,
     bool updateSelectedStudy = true,
   }) {
+    final hadActiveSubject = activeSubject != null;
     activeSubject = subject;
+    if (!hadActiveSubject && subject != null) {
+      _activeSubjectSyncStopped = false;
+    }
     if (updateSelectedStudy) {
       selectedStudy = subject?.study;
     }
@@ -139,6 +153,8 @@ class AppState with ChangeNotifier {
   }
 
   void clearActiveStudyState() {
+    _activeSubjectSyncStopped = true;
+    _activeSubjectSyncPending = false;
     _cancelActiveSubjectSyncRetry();
     _activeSubjectCacheSubscription?.cancel();
     _activeSubjectCacheSubscription = null;
@@ -155,17 +171,21 @@ class AppState with ChangeNotifier {
   void _applyConnectionStatus(AppConnectionStatus status) {
     if (_connectionStatus == status) return;
     _connectionStatus = status;
-    if (status == AppConnectionStatus.healthy) {
-      _cancelActiveSubjectSyncRetry();
-    } else {
-      scheduleActiveSubjectSyncRetryIfNeeded();
-    }
+    scheduleActiveSubjectSyncRetryIfNeeded();
     notifyListeners();
   }
 
+  void markActiveSubjectSynchronizationPending() {
+    if (_activeSubjectSyncStopped) return;
+    _activeSubjectSyncPending = true;
+    scheduleActiveSubjectSyncRetryIfNeeded();
+  }
+
   void scheduleActiveSubjectSyncRetryIfNeeded() {
-    if (_connectionStatus == AppConnectionStatus.healthy ||
-        activeSubject == null) {
+    if (_activeSubjectSyncStopped ||
+        activeSubject == null ||
+        (_connectionStatus == AppConnectionStatus.healthy &&
+            !_activeSubjectSyncPending)) {
       _cancelActiveSubjectSyncRetry();
       return;
     }
@@ -180,15 +200,44 @@ class AppState with ChangeNotifier {
     _activeSubjectSyncRetryTimer = null;
   }
 
-  Future<void> retryCachedSubjectSynchronization() async {
-    if (_activeSubjectSyncInFlight) return;
+  Future<void> retryCachedSubjectSynchronization() {
+    if (_activeSubjectSyncStopped) return Future.value();
+    final activeSynchronization = _activeSubjectSyncFuture;
+    if (activeSynchronization != null) return activeSynchronization;
+
+    late final Future<void> synchronization;
+    synchronization = _retryCachedSubjectSynchronization().whenComplete(() {
+      if (identical(_activeSubjectSyncFuture, synchronization)) {
+        _activeSubjectSyncFuture = null;
+      }
+    });
+    _activeSubjectSyncFuture = synchronization;
+    return synchronization;
+  }
+
+  Future<void> _retryCachedSubjectSynchronization() async {
     final currentSubject = activeSubject;
     if (currentSubject == null) {
       _cancelActiveSubjectSyncRetry();
       return;
     }
-    _activeSubjectSyncInFlight = true;
     try {
+      final hasParticipantSession =
+          (debugHasParticipantSessionForSync ?? isUserLoggedIn)();
+      if (!hasParticipantSession) {
+        final bool didRestoreSession;
+        try {
+          didRestoreSession =
+              await (debugRestoreParticipantSessionForSync ??
+                  _restoreParticipantSessionForSync)();
+        } on AuthApiException catch (error) {
+          if (error.code == 'invalid_credentials') return;
+          rethrow;
+        }
+        if (!didRestoreSession || activeSubject?.id != currentSubject.id) {
+          return;
+        }
+      }
       await _synchronizeCachedSubject(currentSubject);
     } catch (error) {
       final status = connectionStatusFromError(error);
@@ -219,8 +268,37 @@ class AppState with ChangeNotifier {
           appConnectionStatusController.setStatus(recoveryStatus);
         }
       }
+    }
+  }
+
+  Future<void> stopAndAwaitActiveSubjectSynchronization() async {
+    _activeSubjectSyncStopped = true;
+    _activeSubjectSyncPending = false;
+    _cancelActiveSubjectSyncRetry();
+    try {
+      await _activeSubjectSyncFuture;
+    } catch (error) {
+      StudyULogger.warning(
+        'Active subject synchronization stopped with an error: $error',
+      );
     } finally {
-      _activeSubjectSyncInFlight = false;
+      _activeSubjectSyncPending = false;
+    }
+  }
+
+  Future<void> resumeActiveSubjectSynchronization() async {
+    final currentSubject = activeSubject;
+    if (currentSubject == null) return;
+    _activeSubjectSyncStopped = false;
+    _activeSubjectSyncPending = true;
+    try {
+      await Cache.storeSubject(currentSubject);
+    } catch (error) {
+      StudyULogger.warning(
+        'Could not restore active subject cache after failed deletion: $error',
+      );
+    } finally {
+      scheduleActiveSubjectSyncRetryIfNeeded();
     }
   }
 
@@ -231,13 +309,25 @@ class AppState with ChangeNotifier {
     if (remoteSubject == null || activeSubject?.id != currentSubject.id) {
       return;
     }
-    final synchronizedSubject = await Cache.synchronize(remoteSubject);
-    if (activeSubject?.id != currentSubject.id) return;
-    appConnectionStatusController.setStatus(AppConnectionStatus.healthy);
-    updateActiveSubject(synchronizedSubject);
-    if (appConnectionStatusController.status == AppConnectionStatus.healthy) {
-      _cancelActiveSubjectSyncRetry();
+    final synchronization = await Cache.synchronize(remoteSubject);
+    final latestActiveSubject = activeSubject;
+    if (!synchronization.succeeded ||
+        latestActiveSubject?.id != currentSubject.id) {
+      markActiveSubjectSynchronizationPending();
+      if (synchronization.error != null) throw synchronization.error!;
+      return;
     }
+    if (!Cache.containsAllProgress(
+      subject: synchronization.subject,
+      progressSource: latestActiveSubject!,
+    )) {
+      markActiveSubjectSynchronizationPending();
+      return;
+    }
+    _activeSubjectSyncPending = false;
+    appConnectionStatusController.setStatus(AppConnectionStatus.healthy);
+    updateActiveSubject(synchronization.subject);
+    _cancelActiveSubjectSyncRetry();
   }
 
   Future<bool> _restoreParticipantSessionForSync() async {
@@ -254,6 +344,7 @@ class AppState with ChangeNotifier {
 
   @override
   void dispose() {
+    _activeSubjectSyncStopped = true;
     _cancelActiveSubjectSyncRetry();
     _activeSubjectCacheSubscription?.cancel();
     _activeSubjectCacheSource = null;

--- a/app/lib/screens/app_onboarding/app_error_screen.dart
+++ b/app/lib/screens/app_onboarding/app_error_screen.dart
@@ -10,7 +10,6 @@ import 'package:studyu_app/util/schedule_notifications.dart';
 import 'package:studyu_app/util/study_local_cleanup.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_core/env.dart';
-import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 enum AppErrorReason {
@@ -326,7 +325,9 @@ class _AppErrorScreenState extends State<AppErrorScreen> {
         StudyULogger.info("Deleted subject local state cleared");
       } else {
         StudyULogger.info("Deleting all secure storage data");
-        await SecureStorage.deleteAll();
+        await appState.stopAndAwaitActiveSubjectSynchronization();
+        appState.clearActiveStudyState();
+        await clearAllLocalData();
         StudyULogger.info("Secure storage data deleted");
       }
 

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -532,13 +532,17 @@ class _LoadingScreenState extends State<LoadingScreen> {
     }
     if (!mounted) return;
     if (subject != null) {
-      subject = await Cache.synchronize(subject);
+      final synchronization = await Cache.synchronize(subject);
+      subject = synchronization.subject;
       if (!mounted) return;
       if (!isStudyAvailableForTesting(subject.study)) {
         context.go('/${RouteNames.studyUnavailable}');
         return;
       }
       state.updateActiveSubject(subject);
+      if (!synchronization.succeeded) {
+        state.markActiveSubjectSynchronizationPending();
+      }
       state.init(context);
       context.go('/${RouteNames.dashboard}');
     } else {

--- a/app/lib/screens/app_onboarding/study_switch_dialogs.dart
+++ b/app/lib/screens/app_onboarding/study_switch_dialogs.dart
@@ -170,15 +170,21 @@ class StudySwitchDialogs {
         ) ??
         false;
 
-    if (!confirmed) {
+    if (!confirmed || !context.mounted) {
       return false;
     }
 
-    await currentSubject.softDelete();
-    await clearStudyLocalData(fallbackSubject: currentSubject);
-    if (context.mounted) {
-      context.read<AppState>().clearActiveStudyState();
-    }
+    final appState = context.read<AppState>();
+    await deleteStudySubjectAndClearLocalData(
+      subject: currentSubject,
+      deleteRemoteSubject: () async {
+        await currentSubject.softDelete();
+      },
+      onRemoteDeleted: appState.clearActiveStudyState,
+      stopActiveSynchronization:
+          appState.stopAndAwaitActiveSubjectSynchronization,
+      resumeActiveSynchronization: appState.resumeActiveSubjectSynchronization,
+    );
     if (context.mounted) {
       await cancelNotifications(context);
     }
@@ -212,18 +218,22 @@ class StudySwitchDialogs {
         ) ??
         false;
 
-    if (!confirmed) {
+    if (!confirmed || !context.mounted) {
       return false;
     }
 
-    await currentSubject.delete();
-    await clearStudyLocalData(
-      fallbackSubject: currentSubject,
+    final appState = context.read<AppState>();
+    await deleteStudySubjectAndClearLocalData(
+      subject: currentSubject,
       clearStoredParticipantCredentials: true,
+      deleteRemoteSubject: () async {
+        await currentSubject.delete();
+      },
+      onRemoteDeleted: appState.clearActiveStudyState,
+      stopActiveSynchronization:
+          appState.stopAndAwaitActiveSubjectSynchronization,
+      resumeActiveSynchronization: appState.resumeActiveSubjectSynchronization,
     );
-    if (context.mounted) {
-      context.read<AppState>().clearActiveStudyState();
-    }
     if (context.mounted) {
       await cancelNotifications(context);
     }

--- a/app/lib/screens/study/dashboard/settings.dart
+++ b/app/lib/screens/study/dashboard/settings.dart
@@ -200,8 +200,19 @@ class OptOutAlertDialog extends StatelessWidget {
           label: Text(AppLocalizations.of(context)!.opt_out),
           style: ElevatedButton.styleFrom(backgroundColor: Colors.orange[800]),
           onPressed: () async {
+            final appState = context.read<AppState>();
             try {
-              await subject!.softDelete();
+              await deleteStudySubjectAndClearLocalData(
+                subject: subject!,
+                deleteRemoteSubject: () async {
+                  await subject!.softDelete();
+                },
+                onRemoteDeleted: appState.clearActiveStudyState,
+                stopActiveSynchronization:
+                    appState.stopAndAwaitActiveSubjectSynchronization,
+                resumeActiveSynchronization:
+                    appState.resumeActiveSubjectSynchronization,
+              );
             } catch (error) {
               final status = connectionStatusFromError(error);
               if (status != null) {
@@ -217,10 +228,6 @@ class OptOutAlertDialog extends StatelessWidget {
                 return;
               }
               rethrow;
-            }
-            await clearStudyLocalData(fallbackSubject: subject);
-            if (context.mounted) {
-              context.read<AppState>().clearActiveStudyState();
             }
             if (context.mounted) await cancelNotifications(context);
             if (context.mounted) {
@@ -248,24 +255,37 @@ class DeleteAlertDialog extends StatelessWidget {
         label: Text(AppLocalizations.of(context)!.delete_data),
         style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
         onPressed: () async {
+          final appState = context.read<AppState>();
           try {
-            await subject!.delete();
-          } on PostgrestException catch (e) {
-            if (e.code != 'PGRST116') {
-              // Unexpected DB error — don't clear local data
-              if (context.mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  _buildStatusSnackBar(
+            await deleteStudySubjectAndClearLocalData(
+              subject: subject!,
+              clearStoredParticipantCredentials: true,
+              deleteRemoteSubject: () async {
+                try {
+                  await subject!.delete();
+                } on PostgrestException catch (error) {
+                  if (error.code != 'PGRST116') rethrow;
+                }
+              },
+              onRemoteDeleted: appState.clearActiveStudyState,
+              stopActiveSynchronization:
+                  appState.stopAndAwaitActiveSubjectSynchronization,
+              resumeActiveSynchronization:
+                  appState.resumeActiveSubjectSynchronization,
+            );
+          } on PostgrestException catch (error) {
+            // Unexpected DB error — don't clear local data
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                _buildStatusSnackBar(
+                  context,
+                  AppLocalizations.of(
                     context,
-                    AppLocalizations.of(
-                      context,
-                    )!.error_occurred_with_message(e.message),
-                  ),
-                );
-              }
-              return;
+                  )!.error_occurred_with_message(error.message),
+                ),
+              );
             }
-            // PGRST116: subject already deleted from DB — proceed with local cleanup
+            return;
           } catch (error) {
             final status = connectionStatusFromError(error);
             if (status != null) {
@@ -281,14 +301,6 @@ class DeleteAlertDialog extends StatelessWidget {
               return;
             }
             rethrow;
-          }
-          // Reached when delete succeeded or subject was already gone from DB
-          await clearStudyLocalData(
-            fallbackSubject: subject,
-            clearStoredParticipantCredentials: true,
-          );
-          if (context.mounted) {
-            context.read<AppState>().clearActiveStudyState();
           }
           if (context.mounted) await cancelNotifications(context);
           if (context.mounted) {

--- a/app/lib/screens/study/tasks/intervention/checkmark_task_widget.dart
+++ b/app/lib/screens/study/tasks/intervention/checkmark_task_widget.dart
@@ -19,6 +19,7 @@ class CheckmarkTaskWidget extends StatefulWidget {
 class _CheckmarkTaskWidgetState extends State<CheckmarkTaskWidget> {
   DateTime? _lastClickTime;
   bool _isLoading = false;
+  bool _isPendingCacheWrite = false;
 
   @override
   Widget build(BuildContext context) {
@@ -29,36 +30,36 @@ class _CheckmarkTaskWidgetState extends State<CheckmarkTaskWidget> {
           const TextStyle(color: Colors.white),
         ),
       ),
-      onPressed: () async {
-        if (isRedundantClick(_lastClickTime)) return;
-        setState(() {
-          _isLoading = true;
-          _lastClickTime = DateTime.now();
-        });
-        await handleTaskCompletion(context, (StudySubject? subject) async {
-          try {
-            await subject!.addResult<bool>(
-              taskId: widget.task!.id,
-              periodId: widget.completionPeriod!.id,
-              result: true,
-            );
-          } catch (e) {
-            print('Saving results to cache due to error: $e');
-            await subject!.addResult<bool>(
-              taskId: widget.task!.id,
-              periodId: widget.completionPeriod!.id,
-              result: true,
-              offline: true,
-            );
-            rethrow;
-          }
-        });
-        setState(() {
-          _isLoading = false;
-        });
-        if (!context.mounted) return;
-        context.pop(true);
-      },
+      onPressed: _isLoading || _isPendingCacheWrite
+          ? null
+          : () async {
+              if (isRedundantClick(_lastClickTime)) return;
+              setState(() {
+                _isLoading = true;
+                _lastClickTime = DateTime.now();
+              });
+              final completed = await handleTaskCompletion(
+                context,
+                (StudySubject? subject) async {
+                  await subject!.addResult<bool>(
+                    taskId: widget.task!.id,
+                    periodId: widget.completionPeriod!.id,
+                    result: true,
+                  );
+                },
+                onCacheRetrySucceeded: () {
+                  if (context.mounted) context.pop(true);
+                },
+              );
+              if (!context.mounted) return;
+              setState(() {
+                _isLoading = false;
+                _isPendingCacheWrite = !completed;
+              });
+              if (completed) {
+                context.pop(true);
+              }
+            },
       icon: _isLoading
           ? const CircularProgressIndicator(color: Colors.white)
           : const Icon(Icons.check),

--- a/app/lib/screens/study/tasks/observation/questionnaire_task_widget.dart
+++ b/app/lib/screens/study/tasks/observation/questionnaire_task_widget.dart
@@ -26,6 +26,7 @@ class QuestionnaireTaskWidget extends StatefulWidget {
 class _QuestionnaireTaskWidgetState extends State<QuestionnaireTaskWidget> {
   DateTime? _lastClickTime;
   bool _isLoading = false;
+  bool _isPendingCacheWrite = false;
   final GlobalKey<FormState> formKey = GlobalKey<FormState>();
   final GlobalKey<QuestionnaireWidgetState> questionnaireKey =
       GlobalKey<QuestionnaireWidgetState>();
@@ -34,25 +35,26 @@ class _QuestionnaireTaskWidgetState extends State<QuestionnaireTaskWidget> {
     T response,
     BuildContext context,
   ) async {
-    await handleTaskCompletion(context, (StudySubject? subject) async {
-      try {
+    final completed = await handleTaskCompletion(
+      context,
+      (StudySubject? subject) async {
         await subject!.addResult<T>(
           taskId: widget.task.id,
           periodId: widget.completionPeriod.id,
           result: response,
         );
-      } catch (e) {
-        print('Saving results to cache due to error: $e');
-        await subject!.addResult<T>(
-          taskId: widget.task.id,
-          periodId: widget.completionPeriod.id,
-          result: response,
-          offline: true,
-        );
-        rethrow;
-      }
-    });
+      },
+      onCacheRetrySucceeded: () {
+        if (context.mounted) context.pop(true);
+      },
+    );
     if (!context.mounted) return;
+    if (!completed) {
+      setState(() {
+        _isPendingCacheWrite = true;
+      });
+      return;
+    }
     context.pop(true);
   }
 
@@ -102,7 +104,7 @@ class _QuestionnaireTaskWidgetState extends State<QuestionnaireTaskWidget> {
         taskId: widget.task.id,
         header: widget.task.header,
         footer: widget.task.footer,
-        isSubmitting: _isLoading,
+        isSubmitting: _isLoading || _isPendingCacheWrite,
         onComplete: _handleCompletion,
       ),
     );

--- a/app/lib/screens/study/tasks/task_screen.dart
+++ b/app/lib/screens/study/tasks/task_screen.dart
@@ -76,48 +76,79 @@ class _TaskScreenState extends State<TaskScreen> {
   }
 }
 
-Future<void> handleTaskCompletion(
+Future<bool> handleTaskCompletion(
   BuildContext context,
-  Function(StudySubject?) completionCallback,
-) async {
+  Future<void> Function(StudySubject?) completionCallback, {
+  required VoidCallback onCacheRetrySucceeded,
+}) async {
   final state = context.read<AppState>();
   final activeSubject = state.activeSubject;
-  try {
-    if (state.trackParticipantProgress) {
-      await completionCallback(activeSubject);
-      state.setConnectionStatus(AppConnectionStatus.healthy);
-    } else {
+  final wasConnectionDegraded =
+      state.connectionStatus != AppConnectionStatus.healthy;
+  var cacheWriteSucceeded = false;
+  var cacheRetryInFlight = false;
+
+  Future<bool> storeInCache() async {
+    try {
+      await Cache.storeSubject(activeSubject);
+      state.markActiveSubjectSynchronizationPending();
+      cacheWriteSucceeded = true;
+      debugPrint("Store subject in cache");
+      return true;
+    } catch (cacheError) {
+      debugPrint("Could not cache results: $cacheError");
+      if (!context.mounted) return false;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(
-            AppLocalizations.of(context)!.preview_mode_results_not_saved,
+          content: Text(AppLocalizations.of(context)!.could_not_save_results),
+          duration: const Duration(seconds: 10),
+          persist: true,
+          action: SnackBarAction(
+            label: 'Retry',
+            onPressed: () async {
+              if (cacheRetryInFlight || cacheWriteSucceeded) return;
+              cacheRetryInFlight = true;
+              try {
+                if (await storeInCache() && context.mounted) {
+                  onCacheRetrySucceeded();
+                }
+              } finally {
+                cacheRetryInFlight = false;
+              }
+            },
           ),
-          duration: const Duration(seconds: 3),
         ),
       );
+      return false;
     }
+  }
+
+  if (!state.trackParticipantProgress) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          AppLocalizations.of(context)!.preview_mode_results_not_saved,
+        ),
+        duration: const Duration(seconds: 3),
+      ),
+    );
+    return true;
+  }
+
+  try {
+    await completionCallback(activeSubject);
   } catch (exception) {
     final status = connectionStatusFromError(exception);
     if (status != null) {
       state.setConnectionStatus(status);
     }
     debugPrint("Could not save results: $exception");
-    try {
-      await Cache.storeSubject(activeSubject);
-      debugPrint("Store subject in cache");
-    } catch (cacheError) {
-      debugPrint("Could not cache results: $cacheError");
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context)!.could_not_save_results),
-          duration: const Duration(seconds: 10),
-          action: SnackBarAction(
-            label: 'Retry',
-            onPressed: () => handleTaskCompletion(context, completionCallback),
-          ),
-        ),
-      );
-    }
+    return storeInCache();
   }
+
+  if (wasConnectionDegraded) {
+    return storeInCache();
+  }
+  state.setConnectionStatus(AppConnectionStatus.healthy);
+  return true;
 }

--- a/app/lib/util/cache.dart
+++ b/app/lib/util/cache.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
@@ -7,12 +8,54 @@ import 'package:studyu_app/util/temporary_storage_handler.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
+typedef CacheSynchronizationResult = ({
+  StudySubject subject,
+  bool succeeded,
+  Object? error,
+});
+
+typedef _CachedSubjectSnapshot = ({StudySubject? subject, int revision});
+
+class _CacheSynchronizationCancelled implements Exception {
+  const _CacheSynchronizationCancelled();
+}
+
 class Cache {
   static bool isSynchronizing = false;
+  static int _subjectRevision = 0;
+  static final Queue<Future<void> Function()> _subjectOperationQueue = Queue();
+  static bool _subjectOperationRunning = false;
+  static int _synchronizationBlockCount = 0;
+  static int _synchronizationGeneration = 0;
+  static Completer<void>? _activeSynchronization;
+  static final Set<Completer<void>> _activeSubjectRemoteMutations = {};
 
   @visibleForTesting
   static Future<void> Function(String studyId, String userId)?
   debugUploadBlobFilesOverride;
+
+  @visibleForTesting
+  static Future<SubjectProgress> Function(SubjectProgress progress)?
+  debugSaveProgressOverride;
+
+  @visibleForTesting
+  static Future<StudySubject> Function(StudySubject subject)?
+  debugSaveSubjectOverride;
+
+  @visibleForTesting
+  static Future<void> Function()? debugAfterSubjectSnapshotLoaded;
+
+  @visibleForTesting
+  static void debugResetSubjectWrites() {
+    _subjectRevision = 0;
+    _subjectOperationQueue.clear();
+    _subjectOperationRunning = false;
+    _synchronizationBlockCount = 0;
+    _synchronizationGeneration = 0;
+    _activeSynchronization = null;
+    _activeSubjectRemoteMutations.clear();
+    debugAfterSubjectSnapshotLoaded = null;
+  }
 
   static bool isCompatibleCachedSubject({
     required StudySubject localSubject,
@@ -44,16 +87,144 @@ class Cache {
     return SubjectProgressSyncPlan(
       newProgress: newProgress,
       mergedProgress: mergedProgress,
-      saveProgress: (progress) => progress.save(),
-      saveSubject: (subject) => subject.save(onlyUpdate: true),
+      saveProgress: debugSaveProgressOverride ?? (progress) => progress.save(),
+      saveSubject:
+          debugSaveSubjectOverride ??
+          (subject) => subject.save(onlyUpdate: true),
+    );
+  }
+
+  static Future<T> _queueSubjectWrite<T>(Future<T> Function() write) {
+    final result = Completer<T>();
+    _subjectOperationQueue.add(() async {
+      try {
+        result.complete(await write());
+      } catch (error, stackTrace) {
+        result.completeError(error, stackTrace);
+      }
+    });
+    _runNextSubjectOperation();
+    return result.future;
+  }
+
+  static void _runNextSubjectOperation() {
+    if (_subjectOperationRunning || _subjectOperationQueue.isEmpty) return;
+    _subjectOperationRunning = true;
+    final operation = _subjectOperationQueue.removeFirst();
+    unawaited(
+      operation().whenComplete(() {
+        _subjectOperationRunning = false;
+        _runNextSubjectOperation();
+      }),
+    );
+  }
+
+  static Future<void> _writeSubject(StudySubject subject) {
+    return SecureStorage.write(
+      cacheSubjectKey,
+      jsonEncode(subject.toFullJson()),
     );
   }
 
   static Future<void> storeSubject(StudySubject? subject) async {
     // debugPrint("Store subject in cache");
-    if (subject == null) return;
-    SecureStorage.write(cacheSubjectKey, jsonEncode(subject.toFullJson()));
-    assert(subject == (await loadSubject()));
+    if (subject == null || _synchronizationBlockCount > 0) return;
+    final synchronizationGeneration = _synchronizationGeneration;
+    await _queueSubjectWrite(() async {
+      if (_synchronizationBlockCount > 0 ||
+          synchronizationGeneration != _synchronizationGeneration) {
+        return;
+      }
+      await _writeSubject(subject);
+      _subjectRevision++;
+    });
+  }
+
+  static Future<bool> _storeSubjectIfRevisionUnchanged(
+    StudySubject subject,
+    int expectedRevision,
+  ) {
+    return _queueSubjectWrite(() async {
+      if (_synchronizationBlockCount > 0 ||
+          _subjectRevision != expectedRevision) {
+        return false;
+      }
+      await _writeSubject(subject);
+      _subjectRevision++;
+      return true;
+    });
+  }
+
+  static Future<T> runWithSubjectSynchronizationBlocked<T>(
+    Future<T> Function() action,
+  ) async {
+    _synchronizationBlockCount++;
+    _synchronizationGeneration++;
+    final activeOperations = <Future<void>>[
+      if (_activeSynchronization case final synchronization?)
+        synchronization.future,
+      ..._activeSubjectRemoteMutations.map((mutation) => mutation.future),
+    ];
+    try {
+      await Future.wait(activeOperations);
+      return await action();
+    } finally {
+      _synchronizationBlockCount--;
+    }
+  }
+
+  static Future<T> runSubjectRemoteMutation<T>(
+    Future<T> Function() mutation,
+  ) async {
+    if (_synchronizationBlockCount > 0) {
+      throw const _CacheSynchronizationCancelled();
+    }
+    final activeMutation = Completer<void>();
+    _activeSubjectRemoteMutations.add(activeMutation);
+    try {
+      if (_synchronizationBlockCount > 0) {
+        throw const _CacheSynchronizationCancelled();
+      }
+      return await mutation();
+    } finally {
+      _activeSubjectRemoteMutations.remove(activeMutation);
+      activeMutation.complete();
+    }
+  }
+
+  static void _ensureSynchronizationAllowed(int generation) {
+    if (_synchronizationBlockCount > 0 ||
+        generation != _synchronizationGeneration) {
+      throw const _CacheSynchronizationCancelled();
+    }
+  }
+
+  static Future<_CachedSubjectSnapshot> _loadSubjectSnapshot({
+    StudySubject? backupSubject,
+  }) {
+    return _queueSubjectWrite(() async {
+      final subject = await SecureStorage.containsKey(cacheSubjectKey)
+          ? await loadSubject(backupSubject: backupSubject)
+          : null;
+      return (subject: subject, revision: _subjectRevision);
+    });
+  }
+
+  static Future<CacheSynchronizationResult>
+  _successfulSynchronizationIfRevisionUnchanged({
+    required StudySubject subject,
+    required StudySubject backupSubject,
+    required int expectedRevision,
+  }) {
+    return _queueSubjectWrite(() async {
+      if (_subjectRevision == expectedRevision) {
+        return (subject: subject, succeeded: true, error: null);
+      }
+      final latest = await SecureStorage.containsKey(cacheSubjectKey)
+          ? await loadSubject(backupSubject: backupSubject)
+          : null;
+      return (subject: latest ?? subject, succeeded: false, error: null);
+    });
   }
 
   static Future<StudySubject> loadSubject({StudySubject? backupSubject}) async {
@@ -119,10 +290,23 @@ class Cache {
 
   static Future<void> delete() async {
     StudyULogger.warning("Delete cache");
-    SecureStorage.delete(cacheSubjectKey);
+    await _queueSubjectWrite(() async {
+      await SecureStorage.delete(cacheSubjectKey);
+      _subjectRevision++;
+    });
   }
 
-  static Future<void> uploadBlobFiles(String studyId, String userId) async {
+  static Future<void> uploadBlobFiles(
+    String studyId,
+    String userId, {
+    FutureOr<void> Function()? beforeRemoteMutation,
+  }) async {
+    await beforeRemoteMutation?.call();
+    final uploadOverride = debugUploadBlobFilesOverride;
+    if (uploadOverride != null) {
+      await uploadOverride(studyId, userId);
+      return;
+    }
     final blobStorageHandler = BlobStorageHandler();
     final futureBlobFiles = await TemporaryStorageHandler.getFutureBlobFiles(
       studyId: studyId,
@@ -130,6 +314,7 @@ class Cache {
     );
     await uploadPendingBlobFiles(
       futureBlobFiles: futureBlobFiles,
+      beforeRemoteMutation: beforeRemoteMutation,
       uploadObservation: (futureBlobFile) async {
         await blobStorageHandler.uploadObservation(
           futureBlobFile.futureBlobId,
@@ -158,38 +343,77 @@ class Cache {
     }
   }
 
-  static Future<StudySubject> synchronize(StudySubject remoteSubject) async {
-    if (isSynchronizing) return remoteSubject;
-    // No local subject found
-    if (!(await SecureStorage.containsKey(cacheSubjectKey))) {
-      return remoteSubject;
-    }
-    final localSubject = await loadSubject(backupSubject: remoteSubject);
-    if (!isCompatibleCachedSubject(
-      localSubject: localSubject,
-      remoteSubject: remoteSubject,
-    )) {
-      StudyULogger.warning(
-        'Skip cache synchronization because cached subject does not match remote subject',
+  static Future<CacheSynchronizationResult> synchronize(
+    StudySubject remoteSubject,
+  ) async {
+    if (_synchronizationBlockCount > 0 || isSynchronizing) {
+      final snapshot = await _loadSubjectSnapshot(backupSubject: remoteSubject);
+      return (
+        subject: snapshot.subject ?? remoteSubject,
+        succeeded: false,
+        error: null,
       );
-      return remoteSubject;
-    }
-    // local and remote subject are equal, nothing to synchronize
-    if (localSubject == remoteSubject) return remoteSubject;
-    // remote subject belongs to a different study
-    if (!kDebugMode &&
-        remoteSubject.startedAt!.isAfter(localSubject.startedAt!)) {
-      return remoteSubject;
     }
 
-    debugPrint("Synchronize subject with cache");
     isSynchronizing = true;
+    final synchronizationGeneration = _synchronizationGeneration;
+    final synchronization = Completer<void>();
+    _activeSynchronization = synchronization;
+    StudySubject? localSubject;
 
     try {
-      await (debugUploadBlobFilesOverride ?? uploadBlobFiles)(
+      final snapshot = await _loadSubjectSnapshot(backupSubject: remoteSubject);
+      await debugAfterSubjectSnapshotLoaded?.call();
+      _ensureSynchronizationAllowed(synchronizationGeneration);
+      localSubject = snapshot.subject;
+      if (localSubject == null) {
+        return await _successfulSynchronizationIfRevisionUnchanged(
+          subject: remoteSubject,
+          backupSubject: remoteSubject,
+          expectedRevision: snapshot.revision,
+        );
+      }
+      if (!isCompatibleCachedSubject(
+        localSubject: localSubject,
+        remoteSubject: remoteSubject,
+      )) {
+        StudyULogger.warning(
+          'Skip cache synchronization because cached subject does not match remote subject',
+        );
+        return await _successfulSynchronizationIfRevisionUnchanged(
+          subject: remoteSubject,
+          backupSubject: remoteSubject,
+          expectedRevision: snapshot.revision,
+        );
+      }
+      // local and remote subject are equal, nothing to synchronize
+      if (localSubject == remoteSubject) {
+        return await _successfulSynchronizationIfRevisionUnchanged(
+          subject: remoteSubject,
+          backupSubject: remoteSubject,
+          expectedRevision: snapshot.revision,
+        );
+      }
+      // remote subject belongs to a different study
+      if (!kDebugMode &&
+          remoteSubject.startedAt!.isAfter(localSubject.startedAt!)) {
+        return await _successfulSynchronizationIfRevisionUnchanged(
+          subject: remoteSubject,
+          backupSubject: remoteSubject,
+          expectedRevision: snapshot.revision,
+        );
+      }
+
+      debugPrint("Synchronize subject with cache");
+      _ensureSynchronizationAllowed(synchronizationGeneration);
+      await uploadBlobFiles(
         remoteSubject.studyId,
         remoteSubject.userId,
+        beforeRemoteMutation: () {
+          _ensureSynchronizationAllowed(synchronizationGeneration);
+        },
       );
+      _ensureSynchronizationAllowed(synchronizationGeneration);
       final syncPlan = buildProgressSyncPlan(
         localSubject: localSubject,
         remoteSubject: remoteSubject,
@@ -199,18 +423,62 @@ class Cache {
         await applyProgressSyncPlan(
           remoteSubject: remoteSubject,
           syncPlan: syncPlan,
+          beforeRemoteMutation: () {
+            _ensureSynchronizationAllowed(synchronizationGeneration);
+          },
+        );
+      }
+      _ensureSynchronizationAllowed(synchronizationGeneration);
+      final stored = await _storeSubjectIfRevisionUnchanged(
+        remoteSubject,
+        snapshot.revision,
+      );
+      if (!stored) {
+        final latestSubject = await _loadSubjectSnapshot(
+          backupSubject: remoteSubject,
+        );
+        return (
+          subject: latestSubject.subject ?? localSubject,
+          succeeded: false,
+          error: null,
         );
       }
       appConnectionStatusController.setStatus(AppConnectionStatus.healthy);
+      return (subject: remoteSubject, succeeded: true, error: null);
+    } on _CacheSynchronizationCancelled {
+      return (
+        subject: localSubject ?? remoteSubject,
+        succeeded: false,
+        error: null,
+      );
     } catch (exception) {
       final status = connectionStatusFromError(exception);
       if (status != null) {
         appConnectionStatusController.setStatus(status);
       }
       StudyULogger.warning(exception);
+      return (
+        subject: localSubject ?? remoteSubject,
+        succeeded: false,
+        error: exception,
+      );
+    } finally {
+      isSynchronizing = false;
+      if (identical(_activeSynchronization, synchronization)) {
+        _activeSynchronization = null;
+      }
+      synchronization.complete();
     }
-    isSynchronizing = false;
-    return remoteSubject;
+  }
+
+  static bool containsAllProgress({
+    required StudySubject subject,
+    required StudySubject progressSource,
+  }) {
+    final subjectProgress = subject.progress.map(_progressSyncKey).toSet();
+    return progressSource.progress.every(
+      (progress) => subjectProgress.contains(_progressSyncKey(progress)),
+    );
   }
 
   static String _progressSyncKey(SubjectProgress progress) =>
@@ -222,8 +490,10 @@ class Cache {
     uploadObservation,
     required Future<void> Function(FutureBlobFile futureBlobFile)
     deleteUploadedFile,
+    FutureOr<void> Function()? beforeRemoteMutation,
   }) async {
     for (final futureBlobFile in futureBlobFiles) {
+      await beforeRemoteMutation?.call();
       await uploadObservation(futureBlobFile);
       await deleteUploadedFile(futureBlobFile);
     }
@@ -232,11 +502,14 @@ class Cache {
   static Future<void> applyProgressSyncPlan({
     required StudySubject remoteSubject,
     required SubjectProgressSyncPlan syncPlan,
+    FutureOr<void> Function()? beforeRemoteMutation,
   }) async {
     for (final progress in syncPlan.newProgress) {
+      await beforeRemoteMutation?.call();
       await syncPlan.saveProgress(progress);
     }
     remoteSubject.progress = syncPlan.mergedProgress;
+    await beforeRemoteMutation?.call();
     await syncPlan.saveSubject(remoteSubject);
   }
 

--- a/app/lib/util/debug_screen.dart
+++ b/app/lib/util/debug_screen.dart
@@ -10,6 +10,7 @@ import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/util/notifications.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';
+import 'package:studyu_app/util/study_local_cleanup.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -84,9 +85,12 @@ class DebugScreen {
 
   static Future<void> resetApp(BuildContext context) async {
     try {
+      final appState = context.read<AppState>();
+      await appState.stopAndAwaitActiveSubjectSynchronization();
+      appState.clearActiveStudyState();
+      await clearAllLocalData();
       await _deleteCacheDir();
       await _deleteAppDir();
-      await SecureStorage.deleteAll();
       if (context.mounted) {
         context.pop();
         context.pop();

--- a/app/lib/util/study_local_cleanup.dart
+++ b/app/lib/util/study_local_cleanup.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 Future<StudySubject?> resolveCachedSubjectForCleanup({
   StudySubject? fallbackSubject,
@@ -13,7 +17,7 @@ Future<StudySubject?> resolveCachedSubjectForCleanup({
   }
 }
 
-Future<void> clearStudyLocalData({
+Future<void> _clearStudyLocalData({
   StudySubject? fallbackSubject,
   bool clearStoredParticipantCredentials = false,
 }) async {
@@ -24,8 +28,81 @@ Future<void> clearStudyLocalData({
   if (subject != null) {
     await FitbitHandler.deleteFitbitCredentials(subject.studyId);
   }
-  await clearDeletedSubjectLocalState();
+  await deleteActiveStudyReference();
+  await Cache.delete();
   if (clearStoredParticipantCredentials) {
     await clearParticipantCredentials();
   }
+}
+
+Future<void> clearStudyLocalData({
+  StudySubject? fallbackSubject,
+  bool clearStoredParticipantCredentials = false,
+}) {
+  return Cache.runWithSubjectSynchronizationBlocked(
+    () => _clearStudyLocalData(
+      fallbackSubject: fallbackSubject,
+      clearStoredParticipantCredentials: clearStoredParticipantCredentials,
+    ),
+  );
+}
+
+Future<void> deleteStudySubjectAndClearLocalData({
+  required StudySubject subject,
+  required Future<void> Function() deleteRemoteSubject,
+  required FutureOr<void> Function() onRemoteDeleted,
+  required Future<void> Function() stopActiveSynchronization,
+  required FutureOr<void> Function() resumeActiveSynchronization,
+  bool clearStoredParticipantCredentials = false,
+}) async {
+  await stopActiveSynchronization();
+  var remoteDeleted = false;
+  try {
+    await Cache.runWithSubjectSynchronizationBlocked(() async {
+      await deleteRemoteSubject();
+      remoteDeleted = true;
+      await onRemoteDeleted();
+      await _clearStudyLocalData(
+        fallbackSubject: subject,
+        clearStoredParticipantCredentials: clearStoredParticipantCredentials,
+      );
+    });
+  } catch (_) {
+    if (!remoteDeleted) await resumeActiveSynchronization();
+    rethrow;
+  }
+}
+
+Future<void> _clearParticipantSessionForReset({
+  Future<void> Function()? clearSession,
+  void Function()? stopAutoRefresh,
+}) async {
+  try {
+    (stopAutoRefresh ?? Supabase.instance.client.auth.stopAutoRefresh)();
+  } catch (error) {
+    StudyULogger.warning(
+      'Could not stop participant auth refresh during reset: $error',
+    );
+  }
+  try {
+    await (clearSession ?? clearParticipantSession)();
+  } catch (error) {
+    StudyULogger.warning(
+      'Could not clear participant session during reset: $error',
+    );
+  }
+}
+
+Future<void> clearAllLocalData({
+  @visibleForTesting Future<void> Function()? clearSession,
+  @visibleForTesting void Function()? stopAutoRefresh,
+}) {
+  return Cache.runWithSubjectSynchronizationBlocked(() async {
+    await _clearParticipantSessionForReset(
+      clearSession: clearSession,
+      stopAutoRefresh: stopAutoRefresh,
+    );
+    await Cache.delete();
+    await SecureStorage.deleteAll();
+  });
 }

--- a/app/lib/util/study_subject_extension.dart
+++ b/app/lib/util/study_subject_extension.dart
@@ -2,6 +2,40 @@ import 'package:flutter/foundation.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/temporary_storage_handler.dart';
 import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart'
+    as flutter_common;
+
+@visibleForTesting
+Future<SubjectProgress> Function(SubjectProgress progress)?
+debugSaveResultProgressOverride;
+
+@visibleForTesting
+Future<StudySubject> Function(StudySubject subject)?
+debugSaveResultSubjectOverride;
+
+@visibleForTesting
+Future<void> saveResultProgress({
+  required StudySubject subject,
+  required SubjectProgress progressEntry,
+  required Future<SubjectProgress> Function(SubjectProgress progress)
+  saveProgress,
+  required Future<void> Function() saveSubject,
+}) async {
+  progressEntry.completedAt ??= DateTime.now().toUtc();
+  SubjectProgress savedProgress;
+  try {
+    savedProgress = await saveProgress(progressEntry);
+  } catch (_) {
+    if (!subject.progress.contains(progressEntry)) {
+      subject.progress.add(progressEntry);
+    }
+    rethrow;
+  }
+  if (!subject.progress.contains(savedProgress)) {
+    subject.progress.add(savedProgress);
+  }
+  await saveSubject();
+}
 
 extension StudySubjectExtension on StudySubject {
   Future<void> addResult<T>({
@@ -24,48 +58,70 @@ extension StudySubjectExtension on StudySubject {
       print('Unsupported question type: $T');
     }
 
-    // Skip multimodal file handling for web
-    if (!kIsWeb) {
-      // Move multimodal files to upload directory
-      if (resultObject.result is QuestionnaireState) {
-        final questionnaireState = resultObject.result as QuestionnaireState;
-        for (final answerEntry in questionnaireState.answers.entries.toList()) {
-          final answer = answerEntry.value;
-          if (answer.response is FutureBlobFile) {
-            final futureBlobFile = answer.response as FutureBlobFile;
-            await TemporaryStorageHandler.moveStagingFileToUploadDirectory(
-              futureBlobFile.localFilePath,
-              futureBlobFile.futureBlobId,
-            );
-
-            // Replaces Answer<FutureBlobFile> with Answer<String>
-            questionnaireState.answers[answerEntry.key] = Answer<String>(
-              answer.question,
-              answer.timestamp,
-            )..response = futureBlobFile.futureBlobId;
-          }
-        }
-      }
-      // Upload multimodal files
-      if (!offline) {
-        await Cache.uploadBlobFiles(studyId, userId);
-      }
-    }
-
-    SubjectProgress p = SubjectProgress(
+    final saveOffline = offline || flutter_common.hasDegradedConnectionStatus();
+    final initialProgressCount = progress.length;
+    final progressEntry = SubjectProgress(
       subjectId: id,
       interventionId: getInterventionForDate(DateTime.now())!.id,
       taskId: taskId,
       result: resultObject,
       resultType: resultObject.type,
     );
-    if (offline) {
-      p.completedAt = DateTime.now().toUtc();
-      progress.add(p);
-    } else {
-      p = await p.save();
-      progress.add(p);
-      await save(onlyUpdate: true);
+
+    Future<void> moveQuestionnaireFiles() async {
+      if (kIsWeb || resultObject.result is! QuestionnaireState) return;
+      final questionnaireState = resultObject.result as QuestionnaireState;
+      for (final answerEntry in questionnaireState.answers.entries.toList()) {
+        final answer = answerEntry.value;
+        if (answer.response is! FutureBlobFile) continue;
+        final futureBlobFile = answer.response as FutureBlobFile;
+        await TemporaryStorageHandler.moveStagingFileToUploadDirectory(
+          futureBlobFile.localFilePath,
+          futureBlobFile.futureBlobId,
+        );
+
+        // Replaces Answer<FutureBlobFile> with Answer<String>
+        questionnaireState.answers[answerEntry.key] = Answer<String>(
+          answer.question,
+          answer.timestamp,
+        )..response = futureBlobFile.futureBlobId;
+      }
+    }
+
+    try {
+      if (saveOffline) {
+        await moveQuestionnaireFiles();
+        progressEntry.completedAt = DateTime.now().toUtc();
+        progress.add(progressEntry);
+      } else {
+        await Cache.runSubjectRemoteMutation(() async {
+          await moveQuestionnaireFiles();
+          if (!kIsWeb) {
+            await Cache.uploadBlobFiles(studyId, userId);
+          }
+          await saveResultProgress(
+            subject: this,
+            progressEntry: progressEntry,
+            saveProgress:
+                debugSaveResultProgressOverride ??
+                (progress) => progress.save(),
+            saveSubject: () async {
+              final saveSubjectOverride = debugSaveResultSubjectOverride;
+              if (saveSubjectOverride != null) {
+                await saveSubjectOverride(this);
+              } else {
+                await save(onlyUpdate: true);
+              }
+            },
+          );
+        });
+      }
+    } catch (_) {
+      if (!saveOffline && progress.length == initialProgressCount) {
+        progressEntry.completedAt ??= DateTime.now().toUtc();
+        progress.add(progressEntry);
+      }
+      rethrow;
     }
   }
 }

--- a/app/lib/util/temporary_storage_handler.dart
+++ b/app/lib/util/temporary_storage_handler.dart
@@ -7,6 +7,10 @@ import 'package:path_provider/path_provider.dart';
 import 'package:studyu_core/core.dart';
 
 class TemporaryStorageHandler {
+  @visibleForTesting
+  static Future<void> Function(String stagingFilePath, String blobId)?
+  debugMoveStagingFileToUploadDirectory;
+
   static const String _stagingBaseNamePrefix = 'staging_';
   static const String _audioFileType = ".m4a";
   static const String _imageFileType = ".jpg";
@@ -63,6 +67,11 @@ class TemporaryStorageHandler {
     String blobId,
   ) async {
     if (kIsWeb) return;
+    final moveOverride = debugMoveStagingFileToUploadDirectory;
+    if (moveOverride != null) {
+      await moveOverride(stagingFilePath, blobId);
+      return;
+    }
     final stagingFile = File(stagingFilePath);
     final uploadDirectory = await _getMultimodalUploadDirectory();
     final uploadFile = File(path.join(uploadDirectory.path, [blobId].join()));

--- a/app/test/app_state_test.dart
+++ b/app/test/app_state_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
 import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
@@ -37,14 +38,44 @@ StudySubject _buildSubject() {
   )..startedAt = DateTime.utc(2026, 8, 10);
 }
 
-SubjectProgress _progress(String subjectId) {
+SubjectProgress _progress(String subjectId, {DateTime? completedAt}) {
   return SubjectProgress(
     subjectId: subjectId,
     interventionId: _interventionId,
     taskId: _taskId,
     resultType: 'bool',
     result: Result<bool>.app(type: 'bool', periodId: _periodId, result: true),
-  )..completedAt = DateTime.utc(2026, 8, 10, 8);
+  )..completedAt = completedAt ?? DateTime.utc(2026, 8, 10, 8);
+}
+
+class _SaveEmittingStudySubject extends StudySubject {
+  _SaveEmittingStudySubject(StudySubject subject)
+    : super(subject.id, subject.studyId, subject.userId, [
+        ...subject.selectedInterventionIds,
+      ]) {
+    study = subject.study;
+    progress = [...subject.progress];
+    startedAt = subject.startedAt;
+    inviteCode = subject.inviteCode;
+    isDeleted = subject.isDeleted;
+  }
+
+  final _saveController = StreamController<StudySubject>();
+
+  @override
+  Stream<StudySubject> get onSave => _saveController.stream;
+
+  void emitSave(StudySubject subject) => _saveController.add(subject);
+
+  Future<void> close() => _saveController.close();
+
+  @override
+  bool operator ==(Object other) =>
+      other is StudySubject &&
+      jsonEncode(toFullJson()) == jsonEncode(other.toFullJson());
+
+  @override
+  int get hashCode => jsonEncode(toFullJson()).hashCode;
 }
 
 void main() {
@@ -54,6 +85,7 @@ void main() {
   late Map<String, String> storageData;
 
   setUp(() {
+    Cache.debugResetSubjectWrites();
     originalPlatform = FlutterSecureStoragePlatform.instance;
     storageData = {};
     FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
@@ -65,6 +97,8 @@ void main() {
     FlutterSecureStoragePlatform.instance = originalPlatform;
     appConnectionStatusController.reset();
     Cache.debugUploadBlobFilesOverride = null;
+    Cache.debugSaveProgressOverride = null;
+    Cache.debugSaveSubjectOverride = null;
   });
 
   test('clearActiveStudyState removes stale active-study state', () {
@@ -90,6 +124,61 @@ void main() {
   });
 
   test(
+    'cache subscription ignores saves after active state teardown',
+    () async {
+      final appState = AppState();
+      final subject = _SaveEmittingStudySubject(_buildSubject());
+
+      appState.updateActiveSubject(subject);
+      appState.clearActiveStudyState();
+      subject.emitSave(_buildSubject());
+      await Future<void>.delayed(Duration.zero);
+
+      expect(appState.activeSubject, isNull);
+
+      appState.dispose();
+      await subject.close();
+    },
+  );
+
+  test('cache subscription follows replacement subject saves', () async {
+    final appState = AppState();
+    final firstSubject = _SaveEmittingStudySubject(_buildSubject());
+    final secondSubject = _SaveEmittingStudySubject(
+      StudySubject.fromJson(firstSubject.toFullJson())
+        ..progress = [_progress(firstSubject.id)],
+    );
+    final thirdSubject = _SaveEmittingStudySubject(
+      StudySubject.fromJson(secondSubject.toFullJson())
+        ..progress = [
+          ...secondSubject.progress,
+          _progress(
+            secondSubject.id,
+            completedAt: DateTime.utc(2026, 8, 10, 9),
+          ),
+        ],
+    );
+
+    appState.updateActiveSubject(firstSubject);
+    firstSubject.emitSave(secondSubject);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(appState.activeSubject, same(secondSubject));
+    expect((await Cache.loadSubject()).progress, hasLength(1));
+
+    secondSubject.emitSave(thirdSubject);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(appState.activeSubject, same(thirdSubject));
+    expect((await Cache.loadSubject()).progress, hasLength(2));
+
+    appState.dispose();
+    await firstSubject.close();
+    await secondSubject.close();
+    await thirdSubject.close();
+  });
+
+  test(
     'retryCachedSubjectSynchronization updates active subject from recovered remote subject',
     () async {
       final appState = AppState();
@@ -103,6 +192,9 @@ void main() {
         ..activeSubject = staleSubject
         ..selectedStudy = staleSubject.study
         ..setConnectionStatus(AppConnectionStatus.backendUnavailable)
+        ..debugHasParticipantSessionForSync = () {
+          return true;
+        }
         ..debugFetchRemoteSubjectForSync = (_) async => remoteSubject;
 
       await appState.retryCachedSubjectSynchronization();
@@ -110,6 +202,104 @@ void main() {
       expect(appState.activeSubject?.progress, hasLength(1));
       expect(appState.activeSubject?.progress.single.taskId, _taskId);
       expect(appConnectionStatusController.status, AppConnectionStatus.healthy);
+    },
+  );
+
+  test(
+    'in-flight local completion is retained and reconciled on retry',
+    () async {
+      final appState = AppState();
+      final currentSubject = _buildSubject();
+      final remoteSubject = StudySubject.fromJson(currentSubject.toFullJson())
+        ..progress = [
+          _progress(
+            currentSubject.id,
+            completedAt: DateTime.utc(2026, 8, 10, 7),
+          ),
+        ];
+      await Cache.storeSubject(currentSubject);
+      Cache.debugUploadBlobFilesOverride = (_, _) async {};
+      Cache.debugSaveProgressOverride = (progress) async => progress;
+      Cache.debugSaveSubjectOverride = (subject) async => subject;
+      final snapshotLoaded = Completer<void>();
+      final releaseSynchronization = Completer<void>();
+      Cache.debugAfterSubjectSnapshotLoaded = () async {
+        snapshotLoaded.complete();
+        await releaseSynchronization.future;
+      };
+
+      appState
+        ..activeSubject = currentSubject
+        ..selectedStudy = currentSubject.study
+        ..debugActiveSubjectSyncRetryDelay = const Duration(hours: 1)
+        ..debugHasParticipantSessionForSync = () {
+          return true;
+        }
+        ..debugFetchRemoteSubjectForSync = (_) async => remoteSubject;
+
+      final firstSynchronization = appState.retryCachedSubjectSynchronization();
+      await snapshotLoaded.future;
+      currentSubject.progress.add(
+        _progress(currentSubject.id, completedAt: DateTime.utc(2026, 8, 10, 9)),
+      );
+      releaseSynchronization.complete();
+      await firstSynchronization;
+
+      expect(appState.activeSubject, same(currentSubject));
+      expect(appState.activeSubject?.progress, hasLength(1));
+
+      await Cache.storeSubject(currentSubject);
+      Cache.debugAfterSubjectSnapshotLoaded = null;
+      await appState.retryCachedSubjectSynchronization();
+
+      expect(appState.activeSubject?.progress, hasLength(2));
+      expect(
+        appState.activeSubject?.progress.map(
+          (progress) => progress.completedAt,
+        ),
+        containsAll([
+          DateTime.utc(2026, 8, 10, 7),
+          DateTime.utc(2026, 8, 10, 9),
+        ]),
+      );
+
+      appState.dispose();
+    },
+  );
+
+  test(
+    'failed cached synchronization preserves active progress and degraded status',
+    () async {
+      final appState = AppState();
+      final cachedSubject = _buildSubject();
+      cachedSubject.progress = [_progress(cachedSubject.id)];
+      final remoteSubject = StudySubject.fromJson(cachedSubject.toFullJson())
+        ..progress = [];
+      await Cache.storeSubject(cachedSubject);
+      Cache.debugUploadBlobFilesOverride = (_, _) =>
+          Future<void>.error(Exception('failed to fetch'));
+
+      appState
+        ..activeSubject = cachedSubject
+        ..selectedStudy = cachedSubject.study
+        ..debugHasParticipantSessionForSync = () {
+          return true;
+        }
+        ..debugFetchRemoteSubjectForSync = (_) async {
+          return remoteSubject;
+        }
+        ..setConnectionStatus(AppConnectionStatus.backendUnavailable);
+
+      await appState.retryCachedSubjectSynchronization();
+
+      expect(appState.activeSubject, same(cachedSubject));
+      expect(appState.activeSubject?.progress, hasLength(1));
+      expect(
+        appConnectionStatusController.status,
+        AppConnectionStatus.backendUnavailable,
+      );
+
+      appState.dispose();
     },
   );
 
@@ -127,6 +317,9 @@ void main() {
         ..activeSubject = cachedSubject
         ..selectedStudy = cachedSubject.study
         ..setConnectionStatus(AppConnectionStatus.backendUnavailable)
+        ..debugHasParticipantSessionForSync = () {
+          return true;
+        }
         ..debugFetchRemoteSubjectForSync = (_) async {
           fetchCalls++;
           if (fetchCalls == 1) {
@@ -149,6 +342,50 @@ void main() {
   );
 
   test(
+    'sessionless recovery authenticates before the first protected fetch',
+    () async {
+      final appState = AppState();
+      final cachedSubject = _buildSubject();
+      final remoteSubject = StudySubject.fromJson(cachedSubject.toFullJson())
+        ..progress = [_progress(cachedSubject.id)];
+      final events = <String>[];
+      var authenticated = false;
+      var anonymousProtectedFetches = 0;
+
+      appState
+        ..activeSubject = cachedSubject
+        ..selectedStudy = cachedSubject.study
+        ..setConnectionStatus(AppConnectionStatus.backendUnavailable)
+        ..debugHasParticipantSessionForSync = () {
+          return false;
+        }
+        ..debugRestoreParticipantSessionForSync = () async {
+          events.add('authenticate');
+          authenticated = true;
+          return true;
+        }
+        ..debugFetchRemoteSubjectForSync = (_) async {
+          events.add('fetch');
+          if (!authenticated) {
+            anonymousProtectedFetches++;
+            throw const PostgrestException(
+              message: 'permission denied for table study_subject',
+              code: '42501',
+            );
+          }
+          return remoteSubject;
+        };
+
+      await appState.retryCachedSubjectSynchronization();
+
+      expect(events, ['authenticate', 'fetch']);
+      expect(anonymousProtectedFetches, 0);
+      expect(appState.activeSubject?.progress, hasLength(1));
+      expect(appConnectionStatusController.status, AppConnectionStatus.healthy);
+    },
+  );
+
+  test(
     'retryCachedSubjectSynchronization ignores rejected restore credentials',
     () async {
       final appState = AppState();
@@ -160,6 +397,9 @@ void main() {
         ..activeSubject = subject
         ..selectedStudy = subject.study
         ..setConnectionStatus(AppConnectionStatus.backendUnavailable)
+        ..debugHasParticipantSessionForSync = () {
+          return true;
+        }
         ..debugFetchRemoteSubjectForSync = (_) {
           fetchCalls++;
           throw Exception('AuthApiException(code: invalid_jwt)');
@@ -188,6 +428,61 @@ void main() {
     },
   );
 
+  test('marked synchronization retries while status remains healthy', () async {
+    final appState = AppState();
+    final cachedSubject = _buildSubject()..inviteCode = 'cached';
+    cachedSubject.progress = [_progress(cachedSubject.id)];
+    final remoteSubject = StudySubject.fromJson(cachedSubject.toFullJson())
+      ..inviteCode = 'remote'
+      ..progress = [];
+    await Cache.storeSubject(cachedSubject);
+    Cache.debugUploadBlobFilesOverride = (_, _) =>
+        Future<void>.error(Exception('unclassified synchronization failure'));
+
+    final startupSynchronization = await Cache.synchronize(remoteSubject);
+
+    expect(startupSynchronization.succeeded, isFalse);
+    expect(appConnectionStatusController.status, AppConnectionStatus.healthy);
+
+    var fetchCalls = 0;
+    var restoreCalls = 0;
+    Cache.debugUploadBlobFilesOverride = (_, _) async {};
+    Cache.debugSaveProgressOverride = (progress) async => progress;
+    Cache.debugSaveSubjectOverride = (subject) async => subject;
+    appState
+      ..updateActiveSubject(startupSynchronization.subject)
+      ..debugActiveSubjectSyncRetryDelay = const Duration(milliseconds: 1)
+      ..debugHasParticipantSessionForSync = () {
+        return true;
+      }
+      ..debugFetchRemoteSubjectForSync = (_) async {
+        fetchCalls++;
+        if (fetchCalls == 1) {
+          throw Exception('AuthApiException(code: invalid_jwt)');
+        }
+        return remoteSubject;
+      }
+      ..debugRestoreParticipantSessionForSync = () async {
+        restoreCalls++;
+        return true;
+      }
+      ..markActiveSubjectSynchronizationPending();
+
+    final deadline = DateTime.now().add(const Duration(seconds: 1));
+    while (appState.activeSubject?.inviteCode != 'remote' &&
+        DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+
+    expect(fetchCalls, greaterThanOrEqualTo(2));
+    expect(restoreCalls, 1);
+    expect(appState.activeSubject?.inviteCode, 'remote');
+    expect(appState.activeSubject?.progress, hasLength(1));
+    expect(appConnectionStatusController.status, AppConnectionStatus.healthy);
+
+    appState.dispose();
+  });
+
   test(
     'scheduleActiveSubjectSyncRetryIfNeeded retries until healthy',
     () async {
@@ -200,6 +495,9 @@ void main() {
         ..activeSubject = subject
         ..selectedStudy = subject.study
         ..debugActiveSubjectSyncRetryDelay = const Duration(milliseconds: 1)
+        ..debugHasParticipantSessionForSync = () {
+          return true;
+        }
         ..debugFetchRemoteSubjectForSync = (_) async {
           fetchCalls++;
           if (!completer.isCompleted) {

--- a/app/test/cache_synchronization_test.dart
+++ b/app/test/cache_synchronization_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
 import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -58,6 +60,29 @@ SubjectProgress _progress({
   )..completedAt = completedAt;
 }
 
+class _FirstWriteBlockedSecureStoragePlatform
+    extends TestFlutterSecureStoragePlatform {
+  _FirstWriteBlockedSecureStoragePlatform(super.data);
+
+  final firstWriteStarted = Completer<void>();
+  final releaseFirstWrite = Completer<void>();
+  int writeCount = 0;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) async {
+    writeCount++;
+    if (writeCount == 1) {
+      firstWriteStarted.complete();
+      await releaseFirstWrite.future;
+    }
+    await super.write(key: key, value: value, options: options);
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -65,6 +90,7 @@ void main() {
   late Map<String, String> storageData;
 
   setUp(() {
+    Cache.debugResetSubjectWrites();
     originalPlatform = FlutterSecureStoragePlatform.instance;
     storageData = {};
     FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
@@ -76,6 +102,9 @@ void main() {
     FlutterSecureStoragePlatform.instance = originalPlatform;
     appConnectionStatusController.reset();
     Cache.isSynchronizing = false;
+    Cache.debugUploadBlobFilesOverride = null;
+    Cache.debugSaveProgressOverride = null;
+    Cache.debugSaveSubjectOverride = null;
   });
 
   group('Cache.buildProgressSyncPlan', () {
@@ -312,11 +341,275 @@ void main() {
 
         await Cache.storeSubject(cachedSubject);
 
-        final synchronized = await Cache.synchronize(remoteSubject);
+        final synchronization = await Cache.synchronize(remoteSubject);
 
-        expect(synchronized.progress, hasLength(1));
-        expect(synchronized.progress.single.taskId, _taskAId);
-        expect(synchronized.progress.single.subjectId, remoteSubject.id);
+        expect(synchronization.succeeded, isTrue);
+        expect(synchronization.subject.progress, hasLength(1));
+        expect(synchronization.subject.progress.single.taskId, _taskAId);
+        expect(
+          synchronization.subject.progress.single.subjectId,
+          remoteSubject.id,
+        );
+      },
+    );
+
+    test(
+      'queued cache write invalidates a snapshot taken after the active write',
+      () async {
+        final remoteSubject = _buildSubject()..inviteCode = 'remote';
+        final firstSubject = StudySubject.fromJson(remoteSubject.toFullJson())
+          ..inviteCode = 'first';
+        final queuedSubject = StudySubject.fromJson(remoteSubject.toFullJson())
+          ..inviteCode = 'queued'
+          ..progress = [
+            _progress(
+              subjectId: remoteSubject.id,
+              interventionId: _interventionBId,
+              taskId: _taskBId,
+              periodId: _periodBId,
+              completedAt: DateTime.utc(2026, 8, 11, 8),
+            ),
+          ];
+        final blockedStorage = _FirstWriteBlockedSecureStoragePlatform(
+          storageData,
+        );
+        FlutterSecureStoragePlatform.instance = blockedStorage;
+        final snapshotLoaded = Completer<void>();
+        final releaseSynchronization = Completer<void>();
+        Cache.debugAfterSubjectSnapshotLoaded = () async {
+          snapshotLoaded.complete();
+          await releaseSynchronization.future;
+        };
+        Cache.debugUploadBlobFilesOverride = (_, _) async {};
+        Cache.debugSaveProgressOverride = (progress) async => progress;
+        Cache.debugSaveSubjectOverride = (subject) async => subject;
+
+        final firstWrite = Cache.storeSubject(firstSubject);
+        await blockedStorage.firstWriteStarted.future;
+        final synchronizationFuture = Cache.synchronize(remoteSubject);
+        final queuedWrite = Cache.storeSubject(queuedSubject);
+
+        blockedStorage.releaseFirstWrite.complete();
+        await snapshotLoaded.future;
+        await queuedWrite;
+        releaseSynchronization.complete();
+        final synchronization = await synchronizationFuture;
+        await firstWrite;
+
+        expect(synchronization.succeeded, isFalse);
+        expect(synchronization.subject.inviteCode, 'queued');
+        expect(synchronization.subject.progress, hasLength(1));
+        final restored = await Cache.loadSubject();
+        expect(restored.inviteCode, 'queued');
+        expect(restored.progress, hasLength(1));
+      },
+    );
+
+    test(
+      'concurrent first cache write makes missing-cache synchronization retry',
+      () async {
+        final remoteSubject = _buildSubject();
+        final latestSubject = StudySubject.fromJson(remoteSubject.toFullJson())
+          ..progress = [
+            _progress(
+              subjectId: remoteSubject.id,
+              interventionId: _interventionBId,
+              taskId: _taskBId,
+              periodId: _periodBId,
+              completedAt: DateTime.utc(2026, 8, 11, 8),
+            ),
+          ];
+        final snapshotLoaded = Completer<void>();
+        final releaseSynchronization = Completer<void>();
+        Cache.debugAfterSubjectSnapshotLoaded = () async {
+          snapshotLoaded.complete();
+          await releaseSynchronization.future;
+        };
+
+        final synchronizationFuture = Cache.synchronize(remoteSubject);
+        await snapshotLoaded.future;
+        await Cache.storeSubject(latestSubject);
+        releaseSynchronization.complete();
+        final synchronization = await synchronizationFuture;
+
+        expect(synchronization.succeeded, isFalse);
+        expect(synchronization.subject.progress, hasLength(1));
+        expect(synchronization.subject.progress.single.taskId, _taskBId);
+        expect((await Cache.loadSubject()).progress.single.taskId, _taskBId);
+      },
+    );
+
+    test(
+      'concurrent cache write makes equal-subject synchronization retry',
+      () async {
+        final remoteSubject = _buildSubject();
+        await Cache.storeSubject(
+          StudySubject.fromJson(remoteSubject.toFullJson()),
+        );
+        final latestSubject = StudySubject.fromJson(remoteSubject.toFullJson())
+          ..progress = [
+            _progress(
+              subjectId: remoteSubject.id,
+              interventionId: _interventionBId,
+              taskId: _taskBId,
+              periodId: _periodBId,
+              completedAt: DateTime.utc(2026, 8, 11, 8),
+            ),
+          ];
+        final snapshotLoaded = Completer<void>();
+        final releaseSynchronization = Completer<void>();
+        Cache.debugAfterSubjectSnapshotLoaded = () async {
+          snapshotLoaded.complete();
+          await releaseSynchronization.future;
+        };
+
+        final synchronizationFuture = Cache.synchronize(remoteSubject);
+        await snapshotLoaded.future;
+        await Cache.storeSubject(latestSubject);
+        releaseSynchronization.complete();
+        final synchronization = await synchronizationFuture;
+
+        expect(synchronization.succeeded, isFalse);
+        expect(synchronization.subject.progress, hasLength(1));
+        expect(synchronization.subject.progress.single.taskId, _taskBId);
+        expect((await Cache.loadSubject()).progress.single.taskId, _taskBId);
+      },
+    );
+
+    test(
+      'concurrent cache change is preserved and leaves synchronization pending',
+      () async {
+        final remoteSubject = _buildSubject();
+        final cachedSubject = StudySubject.fromJson(remoteSubject.toFullJson())
+          ..inviteCode = 'cached-before-sync';
+        final latestSubject = StudySubject.fromJson(cachedSubject.toFullJson())
+          ..progress = [
+            _progress(
+              subjectId: cachedSubject.id,
+              interventionId: _interventionBId,
+              taskId: _taskBId,
+              periodId: _periodBId,
+              completedAt: DateTime.utc(2026, 8, 11, 8),
+            ),
+          ];
+        final synchronizationStarted = Completer<void>();
+        final releaseSynchronization = Completer<void>();
+        await Cache.storeSubject(cachedSubject);
+        Cache.debugUploadBlobFilesOverride = (_, _) async {
+          synchronizationStarted.complete();
+          await releaseSynchronization.future;
+        };
+
+        final synchronizationFuture = Cache.synchronize(remoteSubject);
+        await synchronizationStarted.future;
+        await Cache.storeSubject(latestSubject);
+        releaseSynchronization.complete();
+        final synchronization = await synchronizationFuture;
+
+        expect(synchronization.succeeded, isFalse);
+        expect(synchronization.error, isNull);
+        expect(synchronization.subject.progress, hasLength(1));
+        expect(synchronization.subject.progress.single.taskId, _taskBId);
+        final restored = await Cache.loadSubject();
+        expect(restored.progress, hasLength(1));
+        expect(restored.progress.single.taskId, _taskBId);
+      },
+    );
+
+    test(
+      'cache deletion invalidates an in-flight synchronization snapshot',
+      () async {
+        final remoteSubject = _buildSubject()..inviteCode = 'remote';
+        final cachedSubject = StudySubject.fromJson(remoteSubject.toFullJson())
+          ..inviteCode = 'cached';
+        await Cache.storeSubject(cachedSubject);
+        final synchronizationStarted = Completer<void>();
+        final releaseSynchronization = Completer<void>();
+        Cache.debugUploadBlobFilesOverride = (_, _) async {
+          synchronizationStarted.complete();
+          await releaseSynchronization.future;
+        };
+        Cache.debugSaveSubjectOverride = (subject) async => subject;
+
+        final synchronizationFuture = Cache.synchronize(remoteSubject);
+        await synchronizationStarted.future;
+        await Cache.delete();
+        releaseSynchronization.complete();
+        final synchronization = await synchronizationFuture;
+
+        expect(synchronization.succeeded, isFalse);
+        expect(await SecureStorage.containsKey(cacheSubjectKey), isFalse);
+      },
+    );
+
+    test('successful progress merge is persisted to the cache', () async {
+      final remoteSubject = _buildSubject();
+      remoteSubject.progress = [
+        _progress(
+          subjectId: remoteSubject.id,
+          interventionId: _interventionAId,
+          taskId: _taskAId,
+          periodId: _periodAId,
+          completedAt: DateTime.utc(2026, 8, 10, 8),
+        ),
+      ];
+      final cachedSubject = StudySubject.fromJson(remoteSubject.toFullJson())
+        ..progress = [
+          _progress(
+            subjectId: remoteSubject.id,
+            interventionId: _interventionBId,
+            taskId: _taskBId,
+            periodId: _periodBId,
+            completedAt: DateTime.utc(2026, 8, 11, 8),
+          ),
+        ];
+      await Cache.storeSubject(cachedSubject);
+      Cache.debugUploadBlobFilesOverride = (_, _) async {};
+      Cache.debugSaveProgressOverride = (progress) async => progress;
+      Cache.debugSaveSubjectOverride = (subject) async => subject;
+
+      final synchronization = await Cache.synchronize(remoteSubject);
+      final restored = await Cache.loadSubject();
+
+      expect(synchronization.succeeded, isTrue);
+      expect(restored.progress, hasLength(2));
+      expect(
+        restored.progress.map((progress) => progress.taskId),
+        containsAll([_taskAId, _taskBId]),
+      );
+    });
+
+    test(
+      'failed synchronization preserves cached progress and degraded status',
+      () async {
+        final remoteSubject = _buildSubject();
+        final cachedSubject = StudySubject.fromJson(remoteSubject.toFullJson())
+          ..progress = [
+            _progress(
+              subjectId: remoteSubject.id,
+              interventionId: _interventionAId,
+              taskId: _taskAId,
+              periodId: _periodAId,
+              completedAt: DateTime.utc(2026, 8, 10, 8),
+            ),
+          ];
+        await Cache.storeSubject(cachedSubject);
+        appConnectionStatusController.setStatus(
+          AppConnectionStatus.backendUnavailable,
+        );
+        Cache.debugUploadBlobFilesOverride = (_, _) =>
+            Future<void>.error(Exception('failed to fetch'));
+
+        final synchronization = await Cache.synchronize(remoteSubject);
+
+        expect(synchronization.succeeded, isFalse);
+        expect(synchronization.subject.progress, hasLength(1));
+        expect(synchronization.subject.progress.single.taskId, _taskAId);
+        expect(
+          appConnectionStatusController.status,
+          AppConnectionStatus.backendUnavailable,
+        );
+        expect((await Cache.loadSubject()).progress, hasLength(1));
       },
     );
   });

--- a/app/test/offline_task_persistence_test.dart
+++ b/app/test/offline_task_persistence_test.dart
@@ -1,14 +1,22 @@
+import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
 import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:provider/provider.dart';
+import 'package:studyu_app/l10n/app_localizations.dart';
+import 'package:studyu_app/models/app_state.dart';
+import 'package:studyu_app/screens/study/tasks/intervention/checkmark_task_widget.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/study_subject_extension.dart';
 import 'package:studyu_app/util/temporary_storage_handler.dart';
 import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 const _studyId = 'study-id';
 const _userId = 'user-id';
@@ -44,6 +52,42 @@ StudySubject _buildSubject({
   )..startedAt = DateTime.now().subtract(const Duration(days: 1));
 }
 
+class _SwitchableWriteSecureStoragePlatform
+    extends TestFlutterSecureStoragePlatform {
+  _SwitchableWriteSecureStoragePlatform(super.data);
+
+  bool failWrites = true;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) {
+    if (failWrites) {
+      return Future<void>.error(Exception('cache write failed'));
+    }
+    return super.write(key: key, value: value, options: options);
+  }
+}
+
+class _DelayedWriteSecureStoragePlatform
+    extends TestFlutterSecureStoragePlatform {
+  _DelayedWriteSecureStoragePlatform(super.data);
+
+  final writeGate = Completer<void>();
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) async {
+    await writeGate.future;
+    await super.write(key: key, value: value, options: options);
+  }
+}
+
 class _FakePathProviderPlatform extends Fake
     with MockPlatformInterfaceMixin
     implements PathProviderPlatform {
@@ -73,6 +117,7 @@ void main() {
   late Directory documentsDirectory;
 
   setUp(() async {
+    Cache.debugResetSubjectWrites();
     secureStorageData = {};
     secureStoragePlatform = FlutterSecureStoragePlatform.instance;
     FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
@@ -95,9 +140,279 @@ void main() {
   tearDown(() async {
     FlutterSecureStoragePlatform.instance = secureStoragePlatform;
     PathProviderPlatform.instance = pathProviderPlatform;
+    appConnectionStatusController.reset();
+    Cache.debugUploadBlobFilesOverride = null;
+    Cache.debugSaveProgressOverride = null;
+    Cache.debugSaveSubjectOverride = null;
     if (documentsDirectory.parent.existsSync()) {
       await documentsDirectory.parent.delete(recursive: true);
     }
+  });
+
+  test(
+    'storeSubject waits for durable progress persistence before completing',
+    () async {
+      final completionPeriod = CompletionPeriod(
+        id: _checkmarkPeriodId,
+        unlockTime: StudyUTimeOfDay(hour: 8),
+        lockTime: StudyUTimeOfDay(hour: 20),
+      );
+      final checkmarkTask = CheckmarkTask.withId()
+        ..title = 'Rate your day'
+        ..schedule.completionPeriods = [completionPeriod];
+      final questionnaireTask = QuestionnaireTask.withId()
+        ..title = 'Upload task';
+      final subject = _buildSubject(
+        checkmarkTask: checkmarkTask,
+        questionnaireTask: questionnaireTask,
+      );
+      await subject.addResult<bool>(
+        taskId: checkmarkTask.id,
+        periodId: completionPeriod.id,
+        result: true,
+        offline: true,
+      );
+      final delayedStorage = _DelayedWriteSecureStoragePlatform(
+        secureStorageData,
+      );
+      FlutterSecureStoragePlatform.instance = delayedStorage;
+      var storeCompleted = false;
+
+      final storeFuture = Cache.storeSubject(subject).whenComplete(() {
+        storeCompleted = true;
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      expect(storeCompleted, isFalse);
+      expect(secureStorageData, isNot(contains(cacheSubjectKey)));
+
+      delayedStorage.writeGate.complete();
+      await storeFuture;
+
+      final restored = await Cache.loadSubject();
+      expect(storeCompleted, isTrue);
+      expect(restored.progress, hasLength(1));
+      expect(
+        restored.completedTaskInstanceForDay(
+          checkmarkTask.id,
+          completionPeriod,
+          DateTime.now(),
+        ),
+        isTrue,
+      );
+    },
+  );
+
+  test(
+    'degraded connection stores task progress without remote save',
+    () async {
+      final checkmarkTask = CheckmarkTask.withId()
+        ..title = 'Rate your day'
+        ..schedule.completionPeriods = [
+          CompletionPeriod(
+            id: _checkmarkPeriodId,
+            unlockTime: StudyUTimeOfDay(hour: 8),
+            lockTime: StudyUTimeOfDay(hour: 20),
+          ),
+        ];
+      final questionnaireTask = QuestionnaireTask.withId();
+      final subject = _buildSubject(
+        checkmarkTask: checkmarkTask,
+        questionnaireTask: questionnaireTask,
+      );
+
+      appConnectionStatusController.setStatus(
+        AppConnectionStatus.backendUnavailable,
+      );
+      try {
+        await subject.addResult<bool>(
+          taskId: checkmarkTask.id,
+          periodId: _checkmarkPeriodId,
+          result: true,
+        );
+        await Cache.storeSubject(subject);
+
+        final restored = await Cache.loadSubject();
+        expect(restored.progress, hasLength(1));
+        expect(restored.progress.single.completedAt, isNotNull);
+      } finally {
+        appConnectionStatusController.setStatus(AppConnectionStatus.healthy);
+      }
+    },
+  );
+
+  test(
+    'ambiguous remote save preserves one completion with its original key',
+    () async {
+      final subject = _buildSubject(
+        checkmarkTask: CheckmarkTask.withId(),
+        questionnaireTask: QuestionnaireTask.withId(),
+      );
+      final pendingProgress = SubjectProgress(
+        subjectId: subject.id,
+        interventionId: _interventionId,
+        taskId: subject.study.interventions.first.tasks.first.id,
+        resultType: 'bool',
+        result: Result<bool>.app(
+          type: 'bool',
+          periodId: _checkmarkPeriodId,
+          result: true,
+        ),
+      );
+      DateTime? attemptedKey;
+
+      await expectLater(
+        () => saveResultProgress(
+          subject: subject,
+          progressEntry: pendingProgress,
+          saveProgress: (progress) {
+            attemptedKey = progress.completedAt;
+            return Future<SubjectProgress>.error(
+              Exception('response lost after commit'),
+            );
+          },
+          saveSubject: () async {},
+        ),
+        throwsException,
+      );
+
+      expect(attemptedKey, isNotNull);
+      expect(subject.progress, hasLength(1));
+      expect(subject.progress.single, same(pendingProgress));
+      expect(subject.progress.single.completedAt, attemptedKey);
+    },
+  );
+
+  testWidgets('cache retry finishes the existing completion exactly once', (
+    tester,
+  ) async {
+    final completionPeriod = CompletionPeriod(
+      id: _checkmarkPeriodId,
+      unlockTime: StudyUTimeOfDay(hour: 8),
+      lockTime: StudyUTimeOfDay(hour: 20),
+    );
+    final checkmarkTask = CheckmarkTask.withId()
+      ..title = 'Rate your day'
+      ..schedule.completionPeriods = [completionPeriod];
+    final subject = _buildSubject(
+      checkmarkTask: checkmarkTask,
+      questionnaireTask: QuestionnaireTask.withId(),
+    );
+    final remoteSubject = StudySubject.fromJson(subject.toFullJson());
+    var synchronizationAttempts = 0;
+    final appState = AppState()
+      ..debugActiveSubjectSyncRetryDelay = const Duration(hours: 1)
+      ..debugHasParticipantSessionForSync = () {
+        return true;
+      }
+      ..debugFetchRemoteSubjectForSync = (_) async {
+        synchronizationAttempts++;
+        return remoteSubject;
+      }
+      ..updateActiveSubject(subject);
+    final switchableStorage = _SwitchableWriteSecureStoragePlatform(
+      secureStorageData,
+    );
+    bool? routeResult;
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, _) => Scaffold(
+            body: ElevatedButton(
+              onPressed: () async {
+                routeResult = await context.push<bool>('/task');
+              },
+              child: const SizedBox(),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/task',
+          builder: (_, _) => Scaffold(
+            body: CheckmarkTaskWidget(
+              task: checkmarkTask,
+              completionPeriod: completionPeriod,
+            ),
+          ),
+        ),
+      ],
+    );
+    appConnectionStatusController.setStatus(
+      AppConnectionStatus.backendUnavailable,
+    );
+    FlutterSecureStoragePlatform.instance = switchableStorage;
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: appState,
+        child: MaterialApp.router(
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          locale: const Locale('en'),
+          routerConfig: router,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pump();
+    for (
+      var attempt = 0;
+      attempt < 100 &&
+          find.byType(CircularProgressIndicator).evaluate().isNotEmpty;
+      attempt++
+    ) {
+      await tester.pump(const Duration(milliseconds: 20));
+    }
+
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.byType(CheckmarkTaskWidget), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(
+      tester.widget<ElevatedButton>(find.byType(ElevatedButton)).onPressed,
+      isNull,
+    );
+    expect(subject.progress, hasLength(1));
+
+    await tester.pump(const Duration(seconds: 11));
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.byType(SnackBarAction), findsOneWidget);
+    expect(
+      tester.widget<ElevatedButton>(find.byType(ElevatedButton)).onPressed,
+      isNull,
+    );
+    expect(subject.progress, hasLength(1));
+
+    switchableStorage.failWrites = false;
+    appState.debugActiveSubjectSyncRetryDelay = const Duration(milliseconds: 1);
+    appConnectionStatusController.setStatus(AppConnectionStatus.healthy);
+    Cache.debugUploadBlobFilesOverride = (_, _) async {};
+    Cache.debugSaveProgressOverride = (progress) async => progress;
+    Cache.debugSaveSubjectOverride = (subject) async => subject;
+    await tester.ensureVisible(find.byType(SnackBarAction));
+    await tester.tap(find.byType(SnackBarAction));
+    for (
+      var attempt = 0;
+      attempt < 100 &&
+          (find.byType(CheckmarkTaskWidget).evaluate().isNotEmpty ||
+              synchronizationAttempts == 0);
+      attempt++
+    ) {
+      await tester.pump(const Duration(milliseconds: 20));
+    }
+
+    expect(find.byType(CheckmarkTaskWidget), findsNothing);
+    expect(routeResult, isTrue);
+    expect(subject.progress, hasLength(1));
+    expect(synchronizationAttempts, greaterThanOrEqualTo(1));
+    expect(appState.activeSubject?.progress, hasLength(1));
+    expect((await Cache.loadSubject()).progress, hasLength(1));
+
+    appState.dispose();
   });
 
   test(
@@ -275,13 +590,13 @@ void main() {
         uploadedUserId = userId;
       };
 
-      final synchronized = await Cache.synchronize(remoteSubject);
+      final synchronization = await Cache.synchronize(remoteSubject);
 
-      expect(synchronized, same(remoteSubject));
+      expect(synchronization.succeeded, isTrue);
+      expect(synchronization.subject, same(remoteSubject));
       expect(uploadedStudyId, remoteSubject.studyId);
       expect(uploadedUserId, remoteSubject.userId);
-
-      Cache.debugUploadBlobFilesOverride = null;
+      expect((await Cache.loadSubject()).inviteCode, remoteSubject.inviteCode);
     },
   );
 }

--- a/app/test/study_local_cleanup_test.dart
+++ b/app/test/study_local_cleanup_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -6,10 +7,64 @@ import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:studyu_app/models/app_state.dart';
+import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/study_local_cleanup.dart';
+import 'package:studyu_app/util/study_subject_extension.dart';
 import 'package:studyu_app/util/temporary_storage_handler.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+
+class _BlockedWriteSecureStoragePlatform
+    extends TestFlutterSecureStoragePlatform {
+  _BlockedWriteSecureStoragePlatform(super.data);
+
+  final firstWriteStarted = Completer<void>();
+  final releaseFirstWrite = Completer<void>();
+  int writeCount = 0;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) async {
+    writeCount++;
+    if (writeCount == 1) {
+      firstWriteStarted.complete();
+      await releaseFirstWrite.future;
+    }
+    await super.write(key: key, value: value, options: options);
+  }
+}
+
+class _FailingDeleteSecureStoragePlatform
+    extends TestFlutterSecureStoragePlatform {
+  _FailingDeleteSecureStoragePlatform(super.data);
+
+  @override
+  Future<void> delete({
+    required String key,
+    required Map<String, String> options,
+  }) {
+    if (key == selectedSubjectIdKey) {
+      return Future<void>.error(Exception('local cleanup failed'));
+    }
+    return super.delete(key: key, options: options);
+  }
+}
+
+class _FailingWriteSecureStoragePlatform
+    extends TestFlutterSecureStoragePlatform {
+  _FailingWriteSecureStoragePlatform(super.data);
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) => Future<void>.error(Exception('cache recovery write failed'));
+}
 
 class _FakePathProviderPlatform extends Fake
     with MockPlatformInterfaceMixin
@@ -34,8 +89,20 @@ StudySubject _buildSubject({
   String studyId = 'study-id',
   String userId = 'user-id',
 }) {
-  final study = Study(studyId, 'owner-id');
-  return StudySubject.fromStudy(study, userId, const [], null);
+  final study = Study(studyId, 'owner-id')
+    ..schedule.includeBaseline = false
+    ..schedule.numberOfCycles = 1
+    ..schedule.phaseDuration = 7
+    ..interventions = [
+      Intervention('intervention-id', 'Intervention'),
+      Intervention('other-intervention-id', 'Other intervention'),
+    ];
+  return StudySubject.fromStudy(
+    study,
+    userId,
+    study.interventions.map((intervention) => intervention.id).toList(),
+    null,
+  )..startedAt = DateTime.now().subtract(const Duration(days: 1));
 }
 
 void main() {
@@ -43,13 +110,16 @@ void main() {
 
   late FlutterSecureStoragePlatform originalStoragePlatform;
   late PathProviderPlatform originalPathProviderPlatform;
+  late Map<String, String> storageData;
   late Directory tempDirectory;
   late Directory documentsDirectory;
 
   setUp(() async {
+    Cache.debugResetSubjectWrites();
     originalStoragePlatform = FlutterSecureStoragePlatform.instance;
+    storageData = {};
     FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
-      {},
+      storageData,
     );
 
     originalPathProviderPlatform = PathProviderPlatform.instance;
@@ -68,6 +138,14 @@ void main() {
   tearDown(() async {
     FlutterSecureStoragePlatform.instance = originalStoragePlatform;
     PathProviderPlatform.instance = originalPathProviderPlatform;
+    Cache.isSynchronizing = false;
+    Cache.debugUploadBlobFilesOverride = null;
+    Cache.debugSaveProgressOverride = null;
+    Cache.debugSaveSubjectOverride = null;
+    TemporaryStorageHandler.debugMoveStagingFileToUploadDirectory = null;
+    debugSaveResultProgressOverride = null;
+    debugSaveResultSubjectOverride = null;
+    appConnectionStatusController.reset();
     if (documentsDirectory.parent.existsSync()) {
       await documentsDirectory.parent.delete(recursive: true);
     }
@@ -151,6 +229,391 @@ void main() {
 
       expect(await getFakeUserEmail(), isNull);
       expect(await getFakeUserPassword(), isNull);
+    },
+  );
+
+  test(
+    'subject deletion cancels blocked synchronization before remote progress writes',
+    () async {
+      final remoteSubject = _buildSubject();
+      final cachedSubject = StudySubject.fromJson(remoteSubject.toFullJson())
+        ..progress = [
+          SubjectProgress(
+            subjectId: remoteSubject.id,
+            interventionId: 'intervention-id',
+            taskId: 'task-id',
+            resultType: 'bool',
+            result: Result<bool>.app(
+              type: 'bool',
+              periodId: 'period-id',
+              result: true,
+            ),
+          )..completedAt = DateTime.utc(2026, 8, 21, 8),
+        ];
+      await Cache.storeSubject(cachedSubject);
+      final synchronizationStarted = Completer<void>();
+      final releaseSynchronization = Completer<void>();
+      final releaseRemoteDeletion = Completer<void>();
+      var uploadAttempts = 0;
+      var savedProgressCount = 0;
+      var savedSubjectCount = 0;
+      var remoteDeletionStarted = false;
+      Cache.debugUploadBlobFilesOverride = (_, _) async {
+        uploadAttempts++;
+        synchronizationStarted.complete();
+        await releaseSynchronization.future;
+      };
+      Cache.debugSaveProgressOverride = (progress) async {
+        savedProgressCount++;
+        return progress;
+      };
+      Cache.debugSaveSubjectOverride = (subject) async {
+        savedSubjectCount++;
+        return subject;
+      };
+
+      final synchronizationFuture = Cache.synchronize(remoteSubject);
+      await synchronizationStarted.future;
+      final deletionFuture = deleteStudySubjectAndClearLocalData(
+        subject: cachedSubject,
+        deleteRemoteSubject: () async {
+          remoteDeletionStarted = true;
+          await releaseRemoteDeletion.future;
+        },
+        onRemoteDeleted: () {},
+        stopActiveSynchronization: () async {},
+        resumeActiveSynchronization: () {},
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(remoteDeletionStarted, isFalse);
+
+      releaseSynchronization.complete();
+      final synchronization = await synchronizationFuture;
+      while (!remoteDeletionStarted) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      final blockedSynchronization = await Cache.synchronize(remoteSubject);
+
+      expect(synchronization.succeeded, isFalse);
+      expect(blockedSynchronization.succeeded, isFalse);
+      expect(uploadAttempts, 1);
+      expect(savedProgressCount, 0);
+      expect(savedSubjectCount, 0);
+
+      releaseRemoteDeletion.complete();
+      await deletionFuture;
+
+      expect(await SecureStorage.containsKey(cacheSubjectKey), isFalse);
+    },
+  );
+
+  test(
+    'subject deletion waits for addResult before staging file movement',
+    () async {
+      final subject = _buildSubject();
+      final questionnaireState = QuestionnaireState();
+      questionnaireState.answers['question-id'] = Answer<FutureBlobFile>(
+        'question-id',
+        DateTime.now(),
+      )..response = FutureBlobFile('/tmp/staging.jpg', 'future-blob.jpg');
+      final moveStarted = Completer<void>();
+      final releaseMove = Completer<void>();
+      var remoteDeletionStarted = false;
+      var uploadCount = 0;
+      var progressSaveCount = 0;
+      var subjectSaveCount = 0;
+      var mutationAfterDeletion = false;
+      TemporaryStorageHandler.debugMoveStagingFileToUploadDirectory =
+          (stagingFilePath, blobId) async {
+            expect(stagingFilePath, '/tmp/staging.jpg');
+            expect(blobId, 'future-blob.jpg');
+            moveStarted.complete();
+            await releaseMove.future;
+          };
+      Cache.debugUploadBlobFilesOverride = (_, _) async {
+        mutationAfterDeletion |= remoteDeletionStarted;
+        uploadCount++;
+      };
+      debugSaveResultProgressOverride = (progress) async {
+        mutationAfterDeletion |= remoteDeletionStarted;
+        progressSaveCount++;
+        return progress;
+      };
+      debugSaveResultSubjectOverride = (savedSubject) async {
+        mutationAfterDeletion |= remoteDeletionStarted;
+        subjectSaveCount++;
+        return savedSubject;
+      };
+
+      final resultMutation = subject.addResult<QuestionnaireState>(
+        taskId: 'task-id',
+        periodId: 'period-id',
+        result: questionnaireState,
+      );
+      await moveStarted.future;
+
+      final deletion = deleteStudySubjectAndClearLocalData(
+        subject: subject,
+        deleteRemoteSubject: () async {
+          remoteDeletionStarted = true;
+          subject.isDeleted = true;
+        },
+        onRemoteDeleted: () {},
+        stopActiveSynchronization: () async {},
+        resumeActiveSynchronization: () {},
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(remoteDeletionStarted, isFalse);
+
+      releaseMove.complete();
+      await resultMutation;
+      await deletion;
+
+      expect(remoteDeletionStarted, isTrue);
+      expect(mutationAfterDeletion, isFalse);
+      expect(uploadCount, 1);
+      expect(progressSaveCount, 1);
+      expect(subjectSaveCount, 1);
+      expect(subject.isDeleted, isTrue);
+    },
+  );
+
+  test(
+    'subject deletion waits for active authentication restoration',
+    () async {
+      final subject = _buildSubject();
+      final appState = AppState()..updateActiveSubject(subject);
+      final restorationStarted = Completer<void>();
+      final releaseRestoration = Completer<void>();
+      var remoteDeletionStarted = false;
+      appState
+        ..debugHasParticipantSessionForSync = () {
+          return false;
+        }
+        ..debugRestoreParticipantSessionForSync = () async {
+          restorationStarted.complete();
+          await releaseRestoration.future;
+          return false;
+        };
+
+      final retry = appState.retryCachedSubjectSynchronization();
+      await restorationStarted.future;
+      final deletion = deleteStudySubjectAndClearLocalData(
+        subject: subject,
+        deleteRemoteSubject: () async {
+          remoteDeletionStarted = true;
+        },
+        onRemoteDeleted: appState.clearActiveStudyState,
+        stopActiveSynchronization:
+            appState.stopAndAwaitActiveSubjectSynchronization,
+        resumeActiveSynchronization:
+            appState.resumeActiveSubjectSynchronization,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(remoteDeletionStarted, isFalse);
+
+      releaseRestoration.complete();
+      await Future.wait([retry, deletion]);
+
+      expect(remoteDeletionStarted, isTrue);
+      expect(appState.activeSubject, isNull);
+      appState.dispose();
+    },
+  );
+
+  test(
+    'failed deletion preserves its error and automatically resumes synchronization when cache recovery fails',
+    () async {
+      final subject = _buildSubject();
+      final remoteDeletionError = Exception('remote deletion failed');
+      final appState = AppState()
+        ..debugActiveSubjectSyncRetryDelay = const Duration(milliseconds: 1)
+        ..updateActiveSubject(subject);
+      var fetchCalls = 0;
+      appState
+        ..debugHasParticipantSessionForSync = () {
+          return true;
+        }
+        ..debugFetchRemoteSubjectForSync = (_) async {
+          fetchCalls++;
+          return subject;
+        };
+      FlutterSecureStoragePlatform.instance =
+          _FailingWriteSecureStoragePlatform(storageData);
+
+      await expectLater(
+        deleteStudySubjectAndClearLocalData(
+          subject: subject,
+          deleteRemoteSubject: () => Future<void>.error(remoteDeletionError),
+          onRemoteDeleted: appState.clearActiveStudyState,
+          stopActiveSynchronization:
+              appState.stopAndAwaitActiveSubjectSynchronization,
+          resumeActiveSynchronization:
+              appState.resumeActiveSubjectSynchronization,
+        ),
+        throwsA(same(remoteDeletionError)),
+      );
+
+      final deadline = DateTime.now().add(const Duration(seconds: 1));
+      while (fetchCalls == 0 && DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+
+      expect(appState.activeSubject, same(subject));
+      expect(fetchCalls, greaterThanOrEqualTo(1));
+      appState.dispose();
+    },
+  );
+
+  test(
+    'full reset clears restored session and stops later refresh persistence',
+    () async {
+      final subject = _buildSubject();
+      final appState = AppState()..updateActiveSubject(subject);
+      final restorationStarted = Completer<void>();
+      final releaseRestoration = Completer<void>();
+      final sessionStorage = SupabaseStorage();
+      var sessionActive = true;
+      var autoRefreshActive = true;
+      var resetCompleted = false;
+      appState
+        ..debugHasParticipantSessionForSync = () {
+          return false;
+        }
+        ..debugRestoreParticipantSessionForSync = () async {
+          restorationStarted.complete();
+          await releaseRestoration.future;
+          await sessionStorage.persistSession('restored-session');
+          return false;
+        };
+
+      final retry = appState.retryCachedSubjectSynchronization();
+      await restorationStarted.future;
+      final reset = () async {
+        await appState.stopAndAwaitActiveSubjectSynchronization();
+        appState.clearActiveStudyState();
+        await clearAllLocalData(
+          stopAutoRefresh: () {
+            autoRefreshActive = false;
+          },
+          clearSession: () async {
+            sessionActive = false;
+          },
+        );
+        resetCompleted = true;
+      }();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(resetCompleted, isFalse);
+
+      releaseRestoration.complete();
+      await Future.wait([retry, reset]);
+      if (sessionActive && autoRefreshActive) {
+        await sessionStorage.persistSession('refreshed-session');
+      }
+
+      expect(resetCompleted, isTrue);
+      expect(sessionActive, isFalse);
+      expect(autoRefreshActive, isFalse);
+      expect(storageData, isEmpty);
+      appState.dispose();
+    },
+  );
+
+  test('full reset continues when session shutdown is unavailable', () async {
+    await SupabaseStorage().persistSession('live-session');
+    var stopRefreshCalls = 0;
+    var clearSessionCalls = 0;
+
+    await clearAllLocalData(
+      stopAutoRefresh: () {
+        stopRefreshCalls++;
+        throw StateError('Supabase is not initialized');
+      },
+      clearSession: () {
+        clearSessionCalls++;
+        return Future<void>.error(Exception('backend unavailable'));
+      },
+    );
+
+    expect(stopRefreshCalls, 1);
+    expect(clearSessionCalls, 1);
+    expect(storageData, isEmpty);
+  });
+
+  test(
+    'remote deletion tears down active state before local cleanup failure',
+    () async {
+      final subject = _buildSubject();
+      final appState = AppState()
+        ..updateActiveSubject(subject)
+        ..debugActiveSubjectSyncRetryDelay = const Duration(milliseconds: 1);
+      var fetchCalls = 0;
+      var remoteDeleted = false;
+      appState
+        ..debugHasParticipantSessionForSync = () {
+          return true;
+        }
+        ..debugFetchRemoteSubjectForSync = (_) async {
+          fetchCalls++;
+          return subject;
+        };
+      FlutterSecureStoragePlatform.instance =
+          _FailingDeleteSecureStoragePlatform(storageData);
+      await SecureStorage.write(selectedSubjectIdKey, subject.id);
+
+      await expectLater(
+        deleteStudySubjectAndClearLocalData(
+          subject: subject,
+          deleteRemoteSubject: () async {
+            remoteDeleted = true;
+          },
+          onRemoteDeleted: appState.clearActiveStudyState,
+          stopActiveSynchronization:
+              appState.stopAndAwaitActiveSubjectSynchronization,
+          resumeActiveSynchronization:
+              appState.resumeActiveSubjectSynchronization,
+        ),
+        throwsException,
+      );
+
+      expect(remoteDeleted, isTrue);
+      expect(appState.activeSubject, isNull);
+
+      appConnectionStatusController.setStatus(
+        AppConnectionStatus.backendUnavailable,
+      );
+      appState.scheduleActiveSubjectSyncRetryIfNeeded();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(fetchCalls, 0);
+      appState.dispose();
+    },
+  );
+
+  test(
+    'full reset drains queued writes and rejects late cache writes',
+    () async {
+      final firstSubject = _buildSubject();
+      final queuedSubject = _buildSubject(studyId: 'queued-study');
+      final lateSubject = _buildSubject(studyId: 'late-study');
+      final blockedStorage = _BlockedWriteSecureStoragePlatform(storageData);
+      FlutterSecureStoragePlatform.instance = blockedStorage;
+
+      final firstWrite = Cache.storeSubject(firstSubject);
+      await blockedStorage.firstWriteStarted.future;
+      final queuedWrite = Cache.storeSubject(queuedSubject);
+      final reset = clearAllLocalData();
+      final lateWrite = Cache.storeSubject(lateSubject);
+
+      blockedStorage.releaseFirstWrite.complete();
+      await Future.wait([firstWrite, queuedWrite, lateWrite, reset]);
+
+      expect(await SecureStorage.containsKey(cacheSubjectKey), isFalse);
+      expect(storageData, isEmpty);
     },
   );
 }


### PR DESCRIPTION
## Description

Related Jira issue: [STUDYU-95](https://studyu.atlassian.net/browse/STUDYU-95)

Split from #906 and stacked on cache recovery.

**Stack 3 of 3** · Previous: #935

Completing a task while the backend was unavailable could leave the UI loading indefinitely. Progress could be lost, duplicated, overwritten by synchronization, or restored after participant cleanup. Full reset and opt-out flows also had races with task saves, authentication recovery, and secure-storage persistence.

This PR makes offline completion durable and synchronization safe:

- completes tasks locally while degraded and persists progress before leaving the task screen;
- keeps a persistent cache Retry without rerunning or duplicating task completion;
- assigns stable completion identity for idempotent remote retry;
- serializes cache reads, writes, revisions, and deletion against synchronization;
- preserves concurrent local progress and retries failed merges safely;
- coordinates task mutations, authentication recovery, opt-out, study switching, and full reset through destructive-operation barriers;
- prevents stale subject/session data from being resurrected after cleanup;
- resumes automatic synchronization after failed deletion even if best-effort cache recovery fails.

This is Stack 3 of 3. Base: `fix/pr906-cache-recovery`.

## Visuals

<!-- Required: attach a recording of completing a task while offline, returning to the dashboard, and synchronizing after reconnecting. -->

## Testing Steps

1. Open a participant task while online, then make the backend unavailable.
2. Complete the task and verify the screen returns promptly instead of loading indefinitely.
3. Reload while offline and verify completion remains visible from cache.
4. Restore the backend and verify progress synchronizes exactly once.
5. Exercise opt-out/full reset while synchronization or authentication recovery is active and verify cleared data is not restored.
6. Automated verification completed:
   - `cd app && rtk fvm flutter test test/app_state_test.dart test/cache_synchronization_test.dart test/offline_task_persistence_test.dart test/study_local_cleanup_test.dart`
   - `rtk scripts/pre-commit-check`
   - `git diff --check`

### PR Checklist
- [x] Formatting passes via `scripts/pre-commit-check`
- [x] Dart and Flutter analyzers pass via `scripts/pre-commit-check`
- [ ] Screenshot or video attached
- [x] Description links related work (#906)


[STUDYU-95]: https://studyu.atlassian.net/browse/STUDYU-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ