### PR TITLE
STUDYU-106: chore(db): log supabase port conflicts

### DIFF
--- a/.github/workflows/supabase-test.yml
+++ b/.github/workflows/supabase-test.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           version: latest
 
+      - name: Diagnose Supabase port
+        run: |
+          sudo lsof -nP -iTCP:54322 -sTCP:LISTEN || true
+          docker ps --format 'table {{.Names}}\t{{.Ports}}'
+
       - name: Start Supabase database
         run: |
           supabase db start


### PR DESCRIPTION
## Description

Adds diagnostics before the Supabase test database starts so intermittent port `54322` conflicts identify the listening process and any Docker container publishing the port.

- Jira: [STUDYU-106](https://studyu.atlassian.net/browse/STUDYU-106)
- Failed run: https://github.com/hpi-studyu/studyu/actions/runs/33014131338/job/98327808134
- Successful rerun: https://github.com/hpi-studyu/studyu/actions/runs/33014131338/job/98465314724

## Visuals

Not applicable. This change only affects CI logs.

## Testing Steps

1. Trigger the `Test Supabase` workflow.
2. Confirm the `Diagnose Supabase port` step logs the port owner when present without failing when the port is free.
3. Confirm the existing Supabase database tests still run unchanged.

### PR Checklist

- [x] `scripts/pre-commit-check` passes
- [x] Screenshot or video not required for this non-visual change
- [x] Description links the related Jira issue


[STUDYU-106]: https://studyu.atlassian.net/browse/STUDYU-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ