### PR TITLE
STUDYU-108: fix: configure pr agent api settings

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -31,9 +31,8 @@ jobs:
         uses: the-pr-agent/pr-agent@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Model is served through OpenRouter; the key is a secret and the
-          # model name is a repository variable (e.g. "openrouter/anthropic/claude-sonnet-4").
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENAI__API_BASE: ${{ secrets.OPENROUTER_API_BASE }}
+          OPENAI__KEY: ${{ secrets.OPENROUTER_API_KEY }}
           config.model: ${{ vars.OPENROUTER_MODEL }}
           config.fallback_models: '["${{ vars.OPENROUTER_MODEL }}"]'
           config.custom_model_max_tokens: "1050000"


### PR DESCRIPTION
## Jira ticket
https://studyu.atlassian.net/browse/STUDYU-108

## Description

Configure PR-Agent to use OpenRouter through the documented OpenAI-compatible settings.

- Read the OpenAI-compatible API base URL from `OPENROUTER_API_BASE`.
- Read the OpenAI-compatible API key from `OPENROUTER_API_KEY`.

## Testing Steps

1. Set `OPENROUTER_API_BASE` to `https://openrouter.ai/api/v1`.
2. Run a pull request workflow.
3. Confirm PR-Agent sends requests to the configured base URL.

## PR Checklist
- [ ] I tested the changes and affected user flows.
- [x] I reviewed the full diff and checked for unintended changes.
- [x] Screenshot or video attached, or this item removed for non-visual changes