### PR TITLE
STUDYU-95: fix(app): preserve offline study progress

### DIFF
--- a/app/lib/models/app_state.dart
+++ b/app/lib/models/app_state.dart
@@ -221,6 +221,22 @@ class AppState with ChangeNotifier {
       _cancelActiveSubjectSyncRetry();
       return;
     }
+    await _attemptCachedSubjectSynchronization(currentSubject);
+  }
+
+  Future<bool> synchronizeActiveSubjectBeforeDestructiveAction() async {
+    final currentSubject = activeSubject;
+    if (currentSubject == null) return false;
+    return _attemptCachedSubjectSynchronization(
+      currentSubject,
+      allowWhileBlocked: true,
+    );
+  }
+
+  Future<bool> _attemptCachedSubjectSynchronization(
+    StudySubject currentSubject, {
+    bool allowWhileBlocked = false,
+  }) async {
     try {
       final hasParticipantSession =
           (debugHasParticipantSessionForSync ?? isUserLoggedIn)();
@@ -231,22 +247,25 @@ class AppState with ChangeNotifier {
               await (debugRestoreParticipantSessionForSync ??
                   _restoreParticipantSessionForSync)();
         } on AuthApiException catch (error) {
-          if (error.code == 'invalid_credentials') return;
+          if (error.code == 'invalid_credentials') return false;
           rethrow;
         }
         if (!didRestoreSession || activeSubject?.id != currentSubject.id) {
-          return;
+          return false;
         }
       }
-      await _synchronizeCachedSubject(currentSubject);
+      return await _synchronizeCachedSubject(
+        currentSubject,
+        allowWhileBlocked: allowWhileBlocked,
+      );
     } catch (error) {
       final status = connectionStatusFromError(error);
       if (status != null) {
         appConnectionStatusController.setStatus(status);
-        return;
+        return false;
       }
       if (!shouldAttemptParticipantAuthRecovery(error)) {
-        return;
+        return false;
       }
       final bool didRestoreSession;
       try {
@@ -254,19 +273,23 @@ class AppState with ChangeNotifier {
             await (debugRestoreParticipantSessionForSync ??
                 _restoreParticipantSessionForSync)();
       } on AuthApiException catch (error) {
-        if (error.code == 'invalid_credentials') return;
+        if (error.code == 'invalid_credentials') return false;
         rethrow;
       }
       if (!didRestoreSession || activeSubject?.id != currentSubject.id) {
-        return;
+        return false;
       }
       try {
-        await _synchronizeCachedSubject(currentSubject);
+        return await _synchronizeCachedSubject(
+          currentSubject,
+          allowWhileBlocked: allowWhileBlocked,
+        );
       } catch (recoveryError) {
         final recoveryStatus = connectionStatusFromError(recoveryError);
         if (recoveryStatus != null) {
           appConnectionStatusController.setStatus(recoveryStatus);
         }
+        return false;
       }
     }
   }
@@ -302,32 +325,39 @@ class AppState with ChangeNotifier {
     }
   }
 
-  Future<void> _synchronizeCachedSubject(StudySubject currentSubject) async {
+  Future<bool> _synchronizeCachedSubject(
+    StudySubject currentSubject, {
+    bool allowWhileBlocked = false,
+  }) async {
     final fetchRemoteSubject =
         debugFetchRemoteSubjectForSync ?? _fetchRemoteSubjectForSync;
     final remoteSubject = await fetchRemoteSubject(currentSubject.id);
     if (remoteSubject == null || activeSubject?.id != currentSubject.id) {
-      return;
+      return false;
     }
-    final synchronization = await Cache.synchronize(remoteSubject);
+    final synchronization = await Cache.synchronize(
+      remoteSubject,
+      allowWhileBlocked: allowWhileBlocked,
+    );
     final latestActiveSubject = activeSubject;
     if (!synchronization.succeeded ||
         latestActiveSubject?.id != currentSubject.id) {
       markActiveSubjectSynchronizationPending();
       if (synchronization.error != null) throw synchronization.error!;
-      return;
+      return false;
     }
     if (!Cache.containsAllProgress(
       subject: synchronization.subject,
       progressSource: latestActiveSubject!,
     )) {
       markActiveSubjectSynchronizationPending();
-      return;
+      return false;
     }
     _activeSubjectSyncPending = false;
     appConnectionStatusController.setStatus(AppConnectionStatus.healthy);
     updateActiveSubject(synchronization.subject);
     _cancelActiveSubjectSyncRetry();
+    return true;
   }
 
   Future<bool> _restoreParticipantSessionForSync() async {

--- a/app/lib/screens/app_onboarding/app_error_screen.dart
+++ b/app/lib/screens/app_onboarding/app_error_screen.dart
@@ -326,8 +326,31 @@ class _AppErrorScreenState extends State<AppErrorScreen> {
       } else {
         StudyULogger.info("Deleting all secure storage data");
         await appState.stopAndAwaitActiveSubjectSynchronization();
-        appState.clearActiveStudyState();
-        await clearAllLocalData();
+        final currentSubject = appState.activeSubject;
+        final cleared = await Cache.runWithSubjectSynchronizationBlocked(
+          () async {
+            if (currentSubject != null &&
+                !await appState
+                    .synchronizeActiveSubjectBeforeDestructiveAction()) {
+              return false;
+            }
+            appState.clearActiveStudyState();
+            await clearAllLocalData();
+            return true;
+          },
+        );
+        if (!cleared) {
+          await appState.resumeActiveSubjectSynchronization();
+          if (!mounted) return;
+          ScaffoldMessenger.of(this.context).showSnackBar(
+            SnackBar(
+              content: Text(
+                AppLocalizations.of(this.context)!.could_not_save_results,
+              ),
+            ),
+          );
+          return;
+        }
         StudyULogger.info("Secure storage data deleted");
       }
 

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -18,7 +18,6 @@ import 'package:studyu_app/services/deep_link_service.dart';
 import 'package:studyu_app/services/deferred_link_service.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/schedule_notifications.dart';
-import 'package:studyu_app/util/study_local_cleanup.dart';
 import 'package:studyu_app/widgets/deep_link_onboarding_widgets.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
@@ -190,6 +189,10 @@ Future<AuthApiException?> tryRestoreParticipantSession({
 }
 
 class LoadingScreen extends StatefulWidget {
+  @visibleForTesting
+  static Future<StudySubject?> Function(String subjectId)?
+  debugRetrieveSubjectOverride;
+
   final String? sessionString;
   final Map<String, String>? queryParameters;
   final String? deepLinkStudyId;
@@ -502,8 +505,6 @@ class _LoadingScreenState extends State<LoadingScreen> {
     try {
       subject = await _retrieveSubject(selectedSubjectId);
     } on SubjectDeletedException catch (error) {
-      await clearStudyLocalData(fallbackSubject: state.activeSubject);
-      state.clearActiveStudyState();
       StudyULogger.warning(
         "Subject $selectedSubjectId was deleted from backend. Showing recovery screen.",
       );
@@ -588,6 +589,11 @@ class _LoadingScreenState extends State<LoadingScreen> {
   }
 
   Future<StudySubject?> _retrieveSubject(String selectedStudyObjectId) {
+    final retrieveOverride = LoadingScreen.debugRetrieveSubjectOverride;
+    if (retrieveOverride != null) {
+      return retrieveOverride(selectedStudyObjectId);
+    }
+
     return restoreCachedValueForStartup<StudySubject>(
       fetchRemote: () => _fetchRemoteSubject(selectedStudyObjectId),
       loadCached: Cache.loadSubject,

--- a/app/lib/screens/app_onboarding/loading_screen.dart
+++ b/app/lib/screens/app_onboarding/loading_screen.dart
@@ -727,6 +727,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
           extra: TaskInstance(
             tasks.first,
             tasks.first.schedule.completionPeriods.first.id,
+            interventionId: state.selectedStudy!.interventions.first.id,
           ),
         );
         _iFrameHelper.postRouteFinished();

--- a/app/lib/screens/app_onboarding/study_switch_dialogs.dart
+++ b/app/lib/screens/app_onboarding/study_switch_dialogs.dart
@@ -175,8 +175,10 @@ class StudySwitchDialogs {
     }
 
     final appState = context.read<AppState>();
-    await deleteStudySubjectAndClearLocalData(
+    final deleted = await deleteStudySubjectAndClearLocalData(
       subject: currentSubject,
+      synchronizeActiveSubject:
+          appState.synchronizeActiveSubjectBeforeDestructiveAction,
       deleteRemoteSubject: () async {
         await currentSubject.softDelete();
       },
@@ -185,6 +187,14 @@ class StudySwitchDialogs {
           appState.stopAndAwaitActiveSubjectSynchronization,
       resumeActiveSynchronization: appState.resumeActiveSubjectSynchronization,
     );
+    if (!deleted) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(loc.could_not_save_results)));
+      }
+      return false;
+    }
     if (context.mounted) {
       await cancelNotifications(context);
     }
@@ -223,9 +233,11 @@ class StudySwitchDialogs {
     }
 
     final appState = context.read<AppState>();
-    await deleteStudySubjectAndClearLocalData(
+    final deleted = await deleteStudySubjectAndClearLocalData(
       subject: currentSubject,
       clearStoredParticipantCredentials: true,
+      synchronizeActiveSubject:
+          appState.synchronizeActiveSubjectBeforeDestructiveAction,
       deleteRemoteSubject: () async {
         await currentSubject.delete();
       },
@@ -234,6 +246,14 @@ class StudySwitchDialogs {
           appState.stopAndAwaitActiveSubjectSynchronization,
       resumeActiveSynchronization: appState.resumeActiveSubjectSynchronization,
     );
+    if (!deleted) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(loc.could_not_save_results)));
+      }
+      return false;
+    }
     if (context.mounted) {
       await cancelNotifications(context);
     }

--- a/app/lib/screens/study/dashboard/settings.dart
+++ b/app/lib/screens/study/dashboard/settings.dart
@@ -202,8 +202,10 @@ class OptOutAlertDialog extends StatelessWidget {
           onPressed: () async {
             final appState = context.read<AppState>();
             try {
-              await deleteStudySubjectAndClearLocalData(
+              final deleted = await deleteStudySubjectAndClearLocalData(
                 subject: subject!,
+                synchronizeActiveSubject:
+                    appState.synchronizeActiveSubjectBeforeDestructiveAction,
                 deleteRemoteSubject: () async {
                   await subject!.softDelete();
                 },
@@ -213,6 +215,17 @@ class OptOutAlertDialog extends StatelessWidget {
                 resumeActiveSynchronization:
                     appState.resumeActiveSubjectSynchronization,
               );
+              if (!deleted) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    _buildStatusSnackBar(
+                      context,
+                      AppLocalizations.of(context)!.could_not_save_results,
+                    ),
+                  );
+                }
+                return;
+              }
             } catch (error) {
               final status = connectionStatusFromError(error);
               if (status != null) {
@@ -257,9 +270,11 @@ class DeleteAlertDialog extends StatelessWidget {
         onPressed: () async {
           final appState = context.read<AppState>();
           try {
-            await deleteStudySubjectAndClearLocalData(
+            final deleted = await deleteStudySubjectAndClearLocalData(
               subject: subject!,
               clearStoredParticipantCredentials: true,
+              synchronizeActiveSubject:
+                  appState.synchronizeActiveSubjectBeforeDestructiveAction,
               deleteRemoteSubject: () async {
                 try {
                   await subject!.delete();
@@ -273,6 +288,17 @@ class DeleteAlertDialog extends StatelessWidget {
               resumeActiveSynchronization:
                   appState.resumeActiveSubjectSynchronization,
             );
+            if (!deleted) {
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  _buildStatusSnackBar(
+                    context,
+                    AppLocalizations.of(context)!.could_not_save_results,
+                  ),
+                );
+              }
+              return;
+            }
           } on PostgrestException catch (error) {
             // Unexpected DB error — don't clear local data
             if (context.mounted) {

--- a/app/lib/screens/study/tasks/intervention/checkmark_task_widget.dart
+++ b/app/lib/screens/study/tasks/intervention/checkmark_task_widget.dart
@@ -8,9 +8,15 @@ import 'package:studyu_core/core.dart';
 
 class CheckmarkTaskWidget extends StatefulWidget {
   final CheckmarkTask? task;
+  final String interventionId;
   final CompletionPeriod? completionPeriod;
 
-  const CheckmarkTaskWidget({this.task, this.completionPeriod, super.key});
+  const CheckmarkTaskWidget({
+    required this.interventionId,
+    this.task,
+    this.completionPeriod,
+    super.key,
+  });
 
   @override
   State<CheckmarkTaskWidget> createState() => _CheckmarkTaskWidgetState();
@@ -43,6 +49,7 @@ class _CheckmarkTaskWidgetState extends State<CheckmarkTaskWidget> {
                 (StudySubject? subject) async {
                   await subject!.addResult<bool>(
                     taskId: widget.task!.id,
+                    interventionId: widget.interventionId,
                     periodId: widget.completionPeriod!.id,
                     result: true,
                   );

--- a/app/lib/screens/study/tasks/observation/questionnaire_task_widget.dart
+++ b/app/lib/screens/study/tasks/observation/questionnaire_task_widget.dart
@@ -10,10 +10,12 @@ import 'package:studyu_core/core.dart';
 
 class QuestionnaireTaskWidget extends StatefulWidget {
   final QuestionnaireTask task;
+  final String interventionId;
   final CompletionPeriod completionPeriod;
 
   const QuestionnaireTaskWidget({
     required this.task,
+    required this.interventionId,
     required this.completionPeriod,
     super.key,
   });
@@ -40,6 +42,7 @@ class _QuestionnaireTaskWidgetState extends State<QuestionnaireTaskWidget> {
       (StudySubject? subject) async {
         await subject!.addResult<T>(
           taskId: widget.task.id,
+          interventionId: widget.interventionId,
           periodId: widget.completionPeriod.id,
           result: response,
         );

--- a/app/lib/screens/study/tasks/task_screen.dart
+++ b/app/lib/screens/study/tasks/task_screen.dart
@@ -24,20 +24,8 @@ class TaskScreen extends StatefulWidget {
 }
 
 class _TaskScreenState extends State<TaskScreen> {
-  late TaskInstance taskInstance;
-  StudySubject? subject;
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    subject = context.watch<AppState>().activeSubject;
-    taskInstance = TaskInstance.fromInstanceId(
-      widget.taskInstance.id,
-      study: subject!.study,
-    );
-  }
-
   Widget _buildTask() {
+    final taskInstance = widget.taskInstance;
     switch (taskInstance.task) {
       case final CheckmarkTask checkmarkTask:
         return SingleChildScrollView(
@@ -50,6 +38,7 @@ class _TaskScreenState extends State<TaskScreen> {
                 CheckmarkTaskWidget(
                   task: checkmarkTask,
                   key: UniqueKey(),
+                  interventionId: taskInstance.interventionId,
                   completionPeriod: taskInstance.completionPeriod,
                 ),
               ],
@@ -60,6 +49,7 @@ class _TaskScreenState extends State<TaskScreen> {
         return QuestionnaireTaskWidget(
           task: questionnaireTask,
           key: UniqueKey(),
+          interventionId: taskInstance.interventionId,
           completionPeriod: taskInstance.completionPeriod,
         );
       default:
@@ -70,7 +60,7 @@ class _TaskScreenState extends State<TaskScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(taskInstance.task.title ?? '')),
+      appBar: AppBar(title: Text(widget.taskInstance.task.title ?? '')),
       body: Padding(padding: const EdgeInsets.all(16), child: _buildTask()),
     );
   }
@@ -80,75 +70,78 @@ Future<bool> handleTaskCompletion(
   BuildContext context,
   Future<void> Function(StudySubject?) completionCallback, {
   required VoidCallback onCacheRetrySucceeded,
-}) async {
-  final state = context.read<AppState>();
-  final activeSubject = state.activeSubject;
-  final wasConnectionDegraded =
-      state.connectionStatus != AppConnectionStatus.healthy;
-  var cacheWriteSucceeded = false;
-  var cacheRetryInFlight = false;
+}) {
+  return Cache.runSubjectOperation(() async {
+    final state = context.read<AppState>();
+    final activeSubject = state.activeSubject;
+    final wasConnectionDegraded =
+        state.connectionStatus != AppConnectionStatus.healthy;
+    var cacheWriteSucceeded = false;
+    var cacheRetryInFlight = false;
 
-  Future<bool> storeInCache() async {
-    try {
-      await Cache.storeSubject(activeSubject);
-      state.markActiveSubjectSynchronizationPending();
-      cacheWriteSucceeded = true;
-      debugPrint("Store subject in cache");
-      return true;
-    } catch (cacheError) {
-      debugPrint("Could not cache results: $cacheError");
-      if (!context.mounted) return false;
+    Future<bool> storeInCache() async {
+      try {
+        await Cache.storeSubject(activeSubject);
+        state.markActiveSubjectSynchronizationPending();
+        cacheWriteSucceeded = true;
+        debugPrint("Store subject in cache");
+        return true;
+      } catch (cacheError) {
+        debugPrint("Could not cache results: $cacheError");
+        if (!context.mounted) return false;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(AppLocalizations.of(context)!.could_not_save_results),
+            duration: const Duration(seconds: 10),
+            persist: true,
+            action: SnackBarAction(
+              label: 'Retry',
+              onPressed: () async {
+                if (cacheRetryInFlight || cacheWriteSucceeded) return;
+                cacheRetryInFlight = true;
+                try {
+                  if (await Cache.runSubjectOperation(storeInCache) &&
+                      context.mounted) {
+                    onCacheRetrySucceeded();
+                  }
+                } finally {
+                  cacheRetryInFlight = false;
+                }
+              },
+            ),
+          ),
+        );
+        return false;
+      }
+    }
+
+    if (!state.trackParticipantProgress) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(AppLocalizations.of(context)!.could_not_save_results),
-          duration: const Duration(seconds: 10),
-          persist: true,
-          action: SnackBarAction(
-            label: 'Retry',
-            onPressed: () async {
-              if (cacheRetryInFlight || cacheWriteSucceeded) return;
-              cacheRetryInFlight = true;
-              try {
-                if (await storeInCache() && context.mounted) {
-                  onCacheRetrySucceeded();
-                }
-              } finally {
-                cacheRetryInFlight = false;
-              }
-            },
+          content: Text(
+            AppLocalizations.of(context)!.preview_mode_results_not_saved,
           ),
+          duration: const Duration(seconds: 3),
         ),
       );
-      return false;
+      return true;
     }
-  }
 
-  if (!state.trackParticipantProgress) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          AppLocalizations.of(context)!.preview_mode_results_not_saved,
-        ),
-        duration: const Duration(seconds: 3),
-      ),
-    );
+    try {
+      await completionCallback(activeSubject);
+    } catch (exception) {
+      final status = connectionStatusFromError(exception);
+      if (status != null) {
+        state.setConnectionStatus(status);
+      }
+      debugPrint("Could not save results: $exception");
+      return storeInCache();
+    }
+
+    if (wasConnectionDegraded) {
+      return storeInCache();
+    }
+    state.setConnectionStatus(AppConnectionStatus.healthy);
     return true;
-  }
-
-  try {
-    await completionCallback(activeSubject);
-  } catch (exception) {
-    final status = connectionStatusFromError(exception);
-    if (status != null) {
-      state.setConnectionStatus(status);
-    }
-    debugPrint("Could not save results: $exception");
-    return storeInCache();
-  }
-
-  if (wasConnectionDegraded) {
-    return storeInCache();
-  }
-  state.setConnectionStatus(AppConnectionStatus.healthy);
-  return true;
+  });
 }

--- a/app/lib/util/cache.dart
+++ b/app/lib/util/cache.dart
@@ -28,7 +28,8 @@ class Cache {
   static int _synchronizationBlockCount = 0;
   static int _synchronizationGeneration = 0;
   static Completer<void>? _activeSynchronization;
-  static final Set<Completer<void>> _activeSubjectRemoteMutations = {};
+  static final Set<Completer<void>> _activeSubjectOperations = {};
+  static final Object _subjectOperationZoneKey = Object();
 
   @visibleForTesting
   static Future<void> Function(String studyId, String userId)?
@@ -53,7 +54,7 @@ class Cache {
     _synchronizationBlockCount = 0;
     _synchronizationGeneration = 0;
     _activeSynchronization = null;
-    _activeSubjectRemoteMutations.clear();
+    _activeSubjectOperations.clear();
     debugAfterSubjectSnapshotLoaded = null;
   }
 
@@ -128,11 +129,16 @@ class Cache {
 
   static Future<void> storeSubject(StudySubject? subject) async {
     // debugPrint("Store subject in cache");
-    if (subject == null || _synchronizationBlockCount > 0) return;
+    final activeOperation = Zone.current[_subjectOperationZoneKey] == true;
+    if (subject == null ||
+        (_synchronizationBlockCount > 0 && !activeOperation)) {
+      return;
+    }
     final synchronizationGeneration = _synchronizationGeneration;
     await _queueSubjectWrite(() async {
-      if (_synchronizationBlockCount > 0 ||
-          synchronizationGeneration != _synchronizationGeneration) {
+      if (!activeOperation &&
+          (_synchronizationBlockCount > 0 ||
+              synchronizationGeneration != _synchronizationGeneration)) {
         return;
       }
       await _writeSubject(subject);
@@ -142,10 +148,11 @@ class Cache {
 
   static Future<bool> _storeSubjectIfRevisionUnchanged(
     StudySubject subject,
-    int expectedRevision,
-  ) {
+    int expectedRevision, {
+    bool allowWhileBlocked = false,
+  }) {
     return _queueSubjectWrite(() async {
-      if (_synchronizationBlockCount > 0 ||
+      if ((!allowWhileBlocked && _synchronizationBlockCount > 0) ||
           _subjectRevision != expectedRevision) {
         return false;
       }
@@ -163,7 +170,7 @@ class Cache {
     final activeOperations = <Future<void>>[
       if (_activeSynchronization case final synchronization?)
         synchronization.future,
-      ..._activeSubjectRemoteMutations.map((mutation) => mutation.future),
+      ..._activeSubjectOperations.map((operation) => operation.future),
     ];
     try {
       await Future.wait(activeOperations);
@@ -173,27 +180,36 @@ class Cache {
     }
   }
 
-  static Future<T> runSubjectRemoteMutation<T>(
-    Future<T> Function() mutation,
+  static Future<T> runSubjectOperation<T>(
+    Future<T> Function() operation,
   ) async {
     if (_synchronizationBlockCount > 0) {
       throw const _CacheSynchronizationCancelled();
     }
-    final activeMutation = Completer<void>();
-    _activeSubjectRemoteMutations.add(activeMutation);
+    final activeOperation = Completer<void>();
+    _activeSubjectOperations.add(activeOperation);
     try {
       if (_synchronizationBlockCount > 0) {
         throw const _CacheSynchronizationCancelled();
       }
-      return await mutation();
+      return await runZoned(
+        operation,
+        zoneValues: {_subjectOperationZoneKey: true},
+      );
     } finally {
-      _activeSubjectRemoteMutations.remove(activeMutation);
-      activeMutation.complete();
+      _activeSubjectOperations.remove(activeOperation);
+      activeOperation.complete();
     }
   }
 
-  static void _ensureSynchronizationAllowed(int generation) {
-    if (_synchronizationBlockCount > 0 ||
+  static Future<T> runSubjectRemoteMutation<T>(Future<T> Function() mutation) =>
+      runSubjectOperation(mutation);
+
+  static void _ensureSynchronizationAllowed(
+    int generation, {
+    bool allowWhileBlocked = false,
+  }) {
+    if ((!allowWhileBlocked && _synchronizationBlockCount > 0) ||
         generation != _synchronizationGeneration) {
       throw const _CacheSynchronizationCancelled();
     }
@@ -344,9 +360,11 @@ class Cache {
   }
 
   static Future<CacheSynchronizationResult> synchronize(
-    StudySubject remoteSubject,
-  ) async {
-    if (_synchronizationBlockCount > 0 || isSynchronizing) {
+    StudySubject remoteSubject, {
+    bool allowWhileBlocked = false,
+  }) async {
+    if ((!allowWhileBlocked && _synchronizationBlockCount > 0) ||
+        isSynchronizing) {
       final snapshot = await _loadSubjectSnapshot(backupSubject: remoteSubject);
       return (
         subject: snapshot.subject ?? remoteSubject,
@@ -364,7 +382,10 @@ class Cache {
     try {
       final snapshot = await _loadSubjectSnapshot(backupSubject: remoteSubject);
       await debugAfterSubjectSnapshotLoaded?.call();
-      _ensureSynchronizationAllowed(synchronizationGeneration);
+      _ensureSynchronizationAllowed(
+        synchronizationGeneration,
+        allowWhileBlocked: allowWhileBlocked,
+      );
       localSubject = snapshot.subject;
       if (localSubject == null) {
         return await _successfulSynchronizationIfRevisionUnchanged(
@@ -405,15 +426,24 @@ class Cache {
       }
 
       debugPrint("Synchronize subject with cache");
-      _ensureSynchronizationAllowed(synchronizationGeneration);
+      _ensureSynchronizationAllowed(
+        synchronizationGeneration,
+        allowWhileBlocked: allowWhileBlocked,
+      );
       await uploadBlobFiles(
         remoteSubject.studyId,
         remoteSubject.userId,
         beforeRemoteMutation: () {
-          _ensureSynchronizationAllowed(synchronizationGeneration);
+          _ensureSynchronizationAllowed(
+            synchronizationGeneration,
+            allowWhileBlocked: allowWhileBlocked,
+          );
         },
       );
-      _ensureSynchronizationAllowed(synchronizationGeneration);
+      _ensureSynchronizationAllowed(
+        synchronizationGeneration,
+        allowWhileBlocked: allowWhileBlocked,
+      );
       final syncPlan = buildProgressSyncPlan(
         localSubject: localSubject,
         remoteSubject: remoteSubject,
@@ -424,14 +454,21 @@ class Cache {
           remoteSubject: remoteSubject,
           syncPlan: syncPlan,
           beforeRemoteMutation: () {
-            _ensureSynchronizationAllowed(synchronizationGeneration);
+            _ensureSynchronizationAllowed(
+              synchronizationGeneration,
+              allowWhileBlocked: allowWhileBlocked,
+            );
           },
         );
       }
-      _ensureSynchronizationAllowed(synchronizationGeneration);
+      _ensureSynchronizationAllowed(
+        synchronizationGeneration,
+        allowWhileBlocked: allowWhileBlocked,
+      );
       final stored = await _storeSubjectIfRevisionUnchanged(
         remoteSubject,
         snapshot.revision,
+        allowWhileBlocked: allowWhileBlocked,
       );
       if (!stored) {
         final latestSubject = await _loadSubjectSnapshot(

--- a/app/lib/util/study_local_cleanup.dart
+++ b/app/lib/util/study_local_cleanup.dart
@@ -47,8 +47,9 @@ Future<void> clearStudyLocalData({
   );
 }
 
-Future<void> deleteStudySubjectAndClearLocalData({
+Future<bool> deleteStudySubjectAndClearLocalData({
   required StudySubject subject,
+  required Future<bool> Function() synchronizeActiveSubject,
   required Future<void> Function() deleteRemoteSubject,
   required FutureOr<void> Function() onRemoteDeleted,
   required Future<void> Function() stopActiveSynchronization,
@@ -58,7 +59,8 @@ Future<void> deleteStudySubjectAndClearLocalData({
   await stopActiveSynchronization();
   var remoteDeleted = false;
   try {
-    await Cache.runWithSubjectSynchronizationBlocked(() async {
+    final deleted = await Cache.runWithSubjectSynchronizationBlocked(() async {
+      if (!await synchronizeActiveSubject()) return false;
       await deleteRemoteSubject();
       remoteDeleted = true;
       await onRemoteDeleted();
@@ -66,7 +68,10 @@ Future<void> deleteStudySubjectAndClearLocalData({
         fallbackSubject: subject,
         clearStoredParticipantCredentials: clearStoredParticipantCredentials,
       );
+      return true;
     });
+    if (!deleted) await resumeActiveSynchronization();
+    return deleted;
   } catch (_) {
     if (!remoteDeleted) await resumeActiveSynchronization();
     rethrow;

--- a/app/lib/util/study_subject_extension.dart
+++ b/app/lib/util/study_subject_extension.dart
@@ -40,6 +40,7 @@ Future<void> saveResultProgress({
 extension StudySubjectExtension on StudySubject {
   Future<void> addResult<T>({
     required String taskId,
+    required String interventionId,
     required String periodId,
     required T result,
     bool offline = false,
@@ -62,7 +63,7 @@ extension StudySubjectExtension on StudySubject {
     final initialProgressCount = progress.length;
     final progressEntry = SubjectProgress(
       subjectId: id,
-      interventionId: getInterventionForDate(DateTime.now())!.id,
+      interventionId: interventionId,
       taskId: taskId,
       result: resultObject,
       resultType: resultObject.type,

--- a/app/test/app_error_screen_test.dart
+++ b/app/test/app_error_screen_test.dart
@@ -4,9 +4,11 @@ import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/screens/app_onboarding/app_error_screen.dart';
+import 'package:studyu_app/screens/app_onboarding/loading_screen.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
@@ -105,6 +107,100 @@ void main() {
       appConnectionStatusController.reset();
     }
   });
+
+  testWidgets(
+    'deleted-subject recovery preserves data before reset confirmation',
+    (tester) async {
+      final originalStoragePlatform = FlutterSecureStoragePlatform.instance;
+      FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
+        <String, String>{},
+      );
+      Cache.debugResetSubjectWrites();
+      final study = Study('study-id', 'owner-id')
+        ..schedule.includeBaseline = false
+        ..schedule.numberOfCycles = 1
+        ..schedule.phaseDuration = 1
+        ..interventions = [Intervention('intervention-id', 'Intervention')];
+      final subject =
+          StudySubject.fromStudy(study, 'user-id', ['intervention-id'], null)
+            ..id = 'subject-id'
+            ..startedAt = DateTime.now().subtract(const Duration(days: 1))
+            ..progress = [
+              SubjectProgress(
+                subjectId: 'subject-id',
+                interventionId: 'intervention-id',
+                taskId: 'task-id',
+                resultType: 'bool',
+                result: Result<bool>.app(
+                  type: 'bool',
+                  periodId: 'period-id',
+                  result: true,
+                ),
+              )..completedAt = DateTime.now().toUtc(),
+            ];
+      final appState = AppState()..updateActiveSubject(subject);
+      await SecureStorage.write(selectedSubjectIdKey, subject.id);
+      await SecureStorage.write('has_processed_deferred_link', 'true');
+      await Cache.storeSubject(subject);
+      appConnectionStatusController.setStatus(
+        AppConnectionStatus.backendUnavailable,
+      );
+      LoadingScreen.debugRetrieveSubjectOverride = (_) =>
+          Future<StudySubject?>.error(const SubjectDeletedException());
+      final router = GoRouter(
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const LoadingScreen()),
+          GoRoute(
+            path: '/${RouteNames.appErrorScreen}',
+            builder: (_, state) {
+              final arguments = state.extra! as AppErrorScreenArguments;
+              return AppErrorScreen(
+                selectedSubjectId: arguments.selectedSubjectId,
+                reason: arguments.reason,
+              );
+            },
+          ),
+        ],
+      );
+
+      try {
+        await tester.pumpWidget(
+          ChangeNotifierProvider.value(
+            value: appState,
+            child: MaterialApp.router(
+              supportedLocales: AppLocalizations.supportedLocales,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              locale: const Locale('en'),
+              routerConfig: router,
+            ),
+          ),
+        );
+        for (
+          var attempt = 0;
+          attempt < 100 && find.text('Study unavailable').evaluate().isEmpty;
+          attempt++
+        ) {
+          await tester.pump(const Duration(milliseconds: 20));
+        }
+
+        expect(find.text('Study unavailable'), findsOneWidget);
+        expect(appState.activeSubject, same(subject));
+        expect(await SecureStorage.read(selectedSubjectIdKey), subject.id);
+        expect((await Cache.loadSubject()).progress, hasLength(1));
+        expect(
+          find.widgetWithText(TextButton, 'Leave study and delete all data'),
+          findsOneWidget,
+        );
+      } finally {
+        router.dispose();
+        appState.dispose();
+        LoadingScreen.debugRetrieveSubjectOverride = null;
+        Cache.debugResetSubjectWrites();
+        FlutterSecureStoragePlatform.instance = originalStoragePlatform;
+        appConnectionStatusController.reset();
+      }
+    },
+  );
 
   testWidgets('cache missing error screen renders recoverable copy', (
     tester,

--- a/app/test/app_error_screen_test.dart
+++ b/app/test/app_error_screen_test.dart
@@ -1,7 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
+import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/screens/app_onboarding/app_error_screen.dart';
+import 'package:studyu_app/util/cache.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 Widget buildTestApp(Widget child) {
   return MaterialApp(
@@ -13,6 +21,91 @@ Widget buildTestApp(Widget child) {
 }
 
 void main() {
+  testWidgets('reset retains pending study data when final sync fails', (
+    tester,
+  ) async {
+    final originalStoragePlatform = FlutterSecureStoragePlatform.instance;
+    final storageData = <String, String>{};
+    FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
+      storageData,
+    );
+    Cache.debugResetSubjectWrites();
+    final study = Study('study-id', 'owner-id')
+      ..title = 'Pending study'
+      ..schedule.includeBaseline = false
+      ..schedule.numberOfCycles = 1
+      ..schedule.phaseDuration = 1
+      ..interventions = [Intervention('intervention-id', 'Intervention')];
+    final subject =
+        StudySubject.fromStudy(study, 'user-id', ['intervention-id'], null)
+          ..id = 'subject-id'
+          ..startedAt = DateTime.now().subtract(const Duration(days: 1))
+          ..progress = [
+            SubjectProgress(
+              subjectId: 'subject-id',
+              interventionId: 'intervention-id',
+              taskId: 'task-id',
+              resultType: 'bool',
+              result: Result<bool>.app(
+                type: 'bool',
+                periodId: 'period-id',
+                result: true,
+              ),
+            )..completedAt = DateTime.now().toUtc(),
+          ];
+    final remoteSubject = StudySubject.fromJson(subject.toFullJson())
+      ..progress = [];
+    final appState = AppState();
+    appState.debugHasParticipantSessionForSync = () => true;
+    appState.debugRestoreParticipantSessionForSync = () async => false;
+    appState.debugFetchRemoteSubjectForSync = (_) async => remoteSubject;
+    appState.updateActiveSubject(subject);
+    await Cache.storeSubject(subject);
+    Cache.debugUploadBlobFilesOverride = (_, _) =>
+        Future<void>.error(Exception('upload failed'));
+
+    final router = GoRouter(
+      routes: [GoRoute(path: '/', builder: (_, _) => const AppErrorScreen())],
+    );
+
+    try {
+      await tester.pumpWidget(
+        ChangeNotifierProvider.value(
+          value: appState,
+          child: MaterialApp.router(
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            locale: const Locale('en'),
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.ensureVisible(find.text('Leave study and delete all data'));
+      await tester.tap(find.text('Leave study and delete all data'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Reset App'));
+      for (
+        var attempt = 0;
+        attempt < 100 && find.text('Could not save results').evaluate().isEmpty;
+        attempt++
+      ) {
+        await tester.pump(const Duration(milliseconds: 20));
+      }
+
+      expect(find.text('Could not save results'), findsOneWidget);
+      expect(appState.activeSubject, same(subject));
+      expect(await SecureStorage.containsKey(cacheSubjectKey), isTrue);
+    } finally {
+      router.dispose();
+      appState.dispose();
+      Cache.debugUploadBlobFilesOverride = null;
+      FlutterSecureStoragePlatform.instance = originalStoragePlatform;
+      appConnectionStatusController.reset();
+    }
+  });
+
   testWidgets('cache missing error screen renders recoverable copy', (
     tester,
   ) async {

--- a/app/test/offline_task_persistence_test.dart
+++ b/app/test/offline_task_persistence_test.dart
@@ -12,6 +12,7 @@ import 'package:provider/provider.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/screens/study/tasks/intervention/checkmark_task_widget.dart';
+import 'package:studyu_app/screens/study/tasks/task_screen.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/study_subject_extension.dart';
 import 'package:studyu_app/util/temporary_storage_handler.dart';
@@ -144,6 +145,7 @@ void main() {
     Cache.debugUploadBlobFilesOverride = null;
     Cache.debugSaveProgressOverride = null;
     Cache.debugSaveSubjectOverride = null;
+    TemporaryStorageHandler.debugMoveStagingFileToUploadDirectory = null;
     if (documentsDirectory.parent.existsSync()) {
       await documentsDirectory.parent.delete(recursive: true);
     }
@@ -168,6 +170,7 @@ void main() {
       );
       await subject.addResult<bool>(
         taskId: checkmarkTask.id,
+        interventionId: _interventionId,
         periodId: completionPeriod.id,
         result: true,
         offline: true,
@@ -227,6 +230,7 @@ void main() {
       try {
         await subject.addResult<bool>(
           taskId: checkmarkTask.id,
+          interventionId: _interventionId,
           periodId: _checkmarkPeriodId,
           result: true,
         );
@@ -238,6 +242,40 @@ void main() {
       } finally {
         appConnectionStatusController.setStatus(AppConnectionStatus.healthy);
       }
+    },
+  );
+
+  test(
+    'issued task keeps its intervention when submitted after study end',
+    () async {
+      final completionPeriod = CompletionPeriod(
+        id: _checkmarkPeriodId,
+        unlockTime: StudyUTimeOfDay(hour: 8),
+        lockTime: StudyUTimeOfDay(hour: 20),
+      );
+      final checkmarkTask = CheckmarkTask.withId()
+        ..title = 'Final task'
+        ..schedule.completionPeriods = [completionPeriod];
+      final subject = _buildSubject(
+        checkmarkTask: checkmarkTask,
+        questionnaireTask: QuestionnaireTask.withId(),
+      );
+      final TaskInstance issuedTask = subject
+          .scheduleFor(DateTime.now())
+          .firstWhere((instance) => instance.task.id == checkmarkTask.id);
+      subject.startedAt = DateTime.now().subtract(const Duration(days: 30));
+
+      await subject.addResult<bool>(
+        taskId: issuedTask.task.id,
+        interventionId: issuedTask.interventionId,
+        periodId: issuedTask.completionPeriod.id,
+        result: true,
+        offline: true,
+      );
+
+      expect(subject.getInterventionForDate(DateTime.now()), isNull);
+      expect(subject.progress.single.interventionId, _interventionId);
+      expect(subject.progress.single.result.periodId, _checkmarkPeriodId);
     },
   );
 
@@ -332,6 +370,7 @@ void main() {
           builder: (_, _) => Scaffold(
             body: CheckmarkTaskWidget(
               task: checkmarkTask,
+              interventionId: _interventionId,
               completionPeriod: completionPeriod,
             ),
           ),
@@ -415,6 +454,83 @@ void main() {
     appState.dispose();
   });
 
+  testWidgets(
+    'destructive cleanup waits for an offline completion cache write',
+    (tester) async {
+      final subject = _buildSubject(
+        checkmarkTask: CheckmarkTask.withId(),
+        questionnaireTask: QuestionnaireTask.withId(),
+      );
+      final appState = AppState()..updateActiveSubject(subject);
+      final moveStarted = Completer<void>();
+      final releaseMove = Completer<void>();
+      final questionnaireState = QuestionnaireState();
+      questionnaireState.answers[_questionId] = Answer<FutureBlobFile>(
+        _questionId,
+        DateTime.now(),
+      )..response = FutureBlobFile('/tmp/staging.jpg', 'pending-blob.jpg');
+      TemporaryStorageHandler.debugMoveStagingFileToUploadDirectory =
+          (_, _) async {
+            moveStarted.complete();
+            await releaseMove.future;
+          };
+      appConnectionStatusController.setStatus(
+        AppConnectionStatus.backendUnavailable,
+      );
+      Future<bool>? completion;
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider.value(
+          value: appState,
+          child: MaterialApp(
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            locale: const Locale('en'),
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () {
+                    completion = handleTaskCompletion(
+                      context,
+                      (activeSubject) => activeSubject!.addResult(
+                        taskId: 'task-id',
+                        interventionId: _interventionId,
+                        periodId: _questionnairePeriodId,
+                        result: questionnaireState,
+                        offline: true,
+                      ),
+                      onCacheRetrySucceeded: () {},
+                    );
+                  },
+                  child: const Text('Complete'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Complete'));
+      await moveStarted.future;
+      var destructiveActionStarted = false;
+      final destructiveAction = Cache.runWithSubjectSynchronizationBlocked(
+        () async {
+          destructiveActionStarted = true;
+          return (await Cache.loadSubject()).progress.length == 1;
+        },
+      );
+      await tester.pump();
+
+      expect(destructiveActionStarted, isFalse);
+
+      releaseMove.complete();
+      expect(await completion, isTrue);
+      expect(await destructiveAction, isTrue);
+      expect(destructiveActionStarted, isTrue);
+      appState.dispose();
+    },
+  );
+
   test(
     'offline checkmark completion persists subject progress across cache reload',
     () async {
@@ -444,6 +560,7 @@ void main() {
 
       await subject.addResult<bool>(
         taskId: checkmarkTask.id,
+        interventionId: _interventionId,
         periodId: _checkmarkPeriodId,
         result: true,
         offline: true,
@@ -504,6 +621,7 @@ void main() {
 
       await subject.addResult<QuestionnaireState>(
         taskId: questionnaireTask.id,
+        interventionId: _interventionId,
         periodId: _questionnairePeriodId,
         result: questionnaireState,
         offline: true,

--- a/app/test/study_local_cleanup_test.dart
+++ b/app/test/study_local_cleanup_test.dart
@@ -233,6 +233,76 @@ void main() {
   );
 
   test(
+    'failed final synchronization preserves pending data and skips deletion',
+    () async {
+      final subject = _buildSubject();
+      final remoteSubject = StudySubject.fromJson(subject.toFullJson());
+      subject.progress = [
+        SubjectProgress(
+          subjectId: subject.id,
+          interventionId: 'intervention-id',
+          taskId: 'task-id',
+          resultType: 'bool',
+          result: Result<bool>.app(
+            type: 'bool',
+            periodId: 'period-id',
+            result: true,
+          ),
+        )..completedAt = DateTime.utc(2026, 8, 28, 8),
+      ];
+      await Cache.storeSubject(subject);
+      final pendingUpload = await TemporaryStorageHandler(
+        subject.studyId,
+        subject.userId,
+      ).getStagingImage();
+      await File(pendingUpload!.localFilePath).create(recursive: true);
+      await File(pendingUpload.localFilePath).writeAsString('pending');
+      await TemporaryStorageHandler.moveStagingFileToUploadDirectory(
+        pendingUpload.localFilePath,
+        pendingUpload.futureBlobId,
+      );
+      final appState = AppState()..updateActiveSubject(subject);
+      appState
+        ..debugHasParticipantSessionForSync = () {
+          return true;
+        }
+        ..debugRestoreParticipantSessionForSync = () async {
+          return false;
+        }
+        ..debugFetchRemoteSubjectForSync = (_) async => remoteSubject;
+      Cache.debugUploadBlobFilesOverride = (_, _) =>
+          Future<void>.error(Exception('upload failed'));
+      var remoteDeleted = false;
+
+      final deleted = await deleteStudySubjectAndClearLocalData(
+        subject: subject,
+        synchronizeActiveSubject:
+            appState.synchronizeActiveSubjectBeforeDestructiveAction,
+        deleteRemoteSubject: () async {
+          remoteDeleted = true;
+        },
+        onRemoteDeleted: appState.clearActiveStudyState,
+        stopActiveSynchronization:
+            appState.stopAndAwaitActiveSubjectSynchronization,
+        resumeActiveSynchronization:
+            appState.resumeActiveSubjectSynchronization,
+      );
+
+      expect(deleted, isFalse);
+      expect(remoteDeleted, isFalse);
+      expect(appState.activeSubject, same(subject));
+      expect((await Cache.loadSubject()).progress, hasLength(1));
+      expect(
+        (await TemporaryStorageHandler.getFutureBlobFiles()).map(
+          (file) => file.futureBlobId,
+        ),
+        contains(pendingUpload.futureBlobId),
+      );
+      appState.dispose();
+    },
+  );
+
+  test(
     'subject deletion cancels blocked synchronization before remote progress writes',
     () async {
       final remoteSubject = _buildSubject();
@@ -276,6 +346,7 @@ void main() {
       await synchronizationStarted.future;
       final deletionFuture = deleteStudySubjectAndClearLocalData(
         subject: cachedSubject,
+        synchronizeActiveSubject: () async => true,
         deleteRemoteSubject: () async {
           remoteDeletionStarted = true;
           await releaseRemoteDeletion.future;
@@ -348,6 +419,7 @@ void main() {
 
       final resultMutation = subject.addResult<QuestionnaireState>(
         taskId: 'task-id',
+        interventionId: 'intervention-id',
         periodId: 'period-id',
         result: questionnaireState,
       );
@@ -355,6 +427,7 @@ void main() {
 
       final deletion = deleteStudySubjectAndClearLocalData(
         subject: subject,
+        synchronizeActiveSubject: () async => true,
         deleteRemoteSubject: () async {
           remoteDeletionStarted = true;
           subject.isDeleted = true;
@@ -402,6 +475,7 @@ void main() {
       await restorationStarted.future;
       final deletion = deleteStudySubjectAndClearLocalData(
         subject: subject,
+        synchronizeActiveSubject: () async => true,
         deleteRemoteSubject: () async {
           remoteDeletionStarted = true;
         },
@@ -447,6 +521,7 @@ void main() {
       await expectLater(
         deleteStudySubjectAndClearLocalData(
           subject: subject,
+          synchronizeActiveSubject: () async => true,
           deleteRemoteSubject: () => Future<void>.error(remoteDeletionError),
           onRemoteDeleted: appState.clearActiveStudyState,
           stopActiveSynchronization:
@@ -568,6 +643,7 @@ void main() {
       await expectLater(
         deleteStudySubjectAndClearLocalData(
           subject: subject,
+          synchronizeActiveSubject: () async => true,
           deleteRemoteSubject: () async {
             remoteDeleted = true;
           },

--- a/core/lib/src/models/tables/study_subject.dart
+++ b/core/lib/src/models/tables/study_subject.dart
@@ -275,12 +275,24 @@ class StudySubject extends SupabaseObjectFunctions<StudySubject> {
     for (final task in activeIntervention.tasks) {
       if (task.title == null) continue;
       for (final completionPeriod in task.schedule.completionPeriods) {
-        taskSchedule.add(TaskInstance(task, completionPeriod.id));
+        taskSchedule.add(
+          TaskInstance(
+            task,
+            completionPeriod.id,
+            interventionId: activeIntervention.id,
+          ),
+        );
       }
     }
     for (final observation in study.observations) {
       for (final completionPeriod in observation.schedule.completionPeriods) {
-        taskSchedule.add(TaskInstance(observation, completionPeriod.id));
+        taskSchedule.add(
+          TaskInstance(
+            observation,
+            completionPeriod.id,
+            interventionId: activeIntervention.id,
+          ),
+        );
       }
     }
     return taskSchedule;

--- a/core/lib/src/models/tasks/task_instance.dart
+++ b/core/lib/src/models/tasks/task_instance.dart
@@ -3,33 +3,37 @@ import 'package:studyu_core/core.dart';
 class TaskInstance {
   final Task task;
   final String id;
+  final String interventionId;
 
-  TaskInstance(this.task, this.id) : assert(task.id != id);
+  TaskInstance(this.task, this.id, {required this.interventionId})
+    : assert(task.id != id);
 
   factory TaskInstance.fromInstanceId(
     String taskInstanceId, {
     StudySubject? subject,
     Study? study,
+    String? interventionId,
     DateTime? date,
   }) {
     date ??= DateTime.now();
-    final Task tempTask;
     if (subject != null) {
-      tempTask = _taskFromSubject(taskInstanceId, subject, date);
-    } else if (study != null) {
-      tempTask = _taskFromStudy(taskInstanceId, study, date);
-    } else {
-      throw "Either subject or study need to be given to create TaskInstance";
+      return subject
+          .scheduleFor(date)
+          .firstWhere((element) => element.id == taskInstanceId);
     }
+    if (study == null || interventionId == null) {
+      throw "Either subject or study with interventionId need to be given to create TaskInstance";
+    }
+    final tempTask = _taskFromStudy(taskInstanceId, study);
     assert(tempTask.id != taskInstanceId);
-    return TaskInstance(tempTask, taskInstanceId);
+    return TaskInstance(
+      tempTask,
+      taskInstanceId,
+      interventionId: interventionId,
+    );
   }
 
-  static Task _taskFromStudy(
-    String taskInstanceId,
-    Study study,
-    DateTime date,
-  ) {
+  static Task _taskFromStudy(String taskInstanceId, Study study) {
     final tasks = <Task>[
       ...study.observations,
       ...study.interventions
@@ -44,17 +48,6 @@ class TaskInstance {
       }
       return false;
     });
-  }
-
-  static Task _taskFromSubject(
-    String taskInstanceId,
-    StudySubject subject,
-    DateTime now,
-  ) {
-    return subject
-        .scheduleFor(now)
-        .firstWhere((element) => element.id == taskInstanceId)
-        .task;
   }
 
   CompletionPeriod get completionPeriod =>


### PR DESCRIPTION
## Description

Related Jira issue: [STUDYU-95](https://studyu.atlassian.net/browse/STUDYU-95)

**Stack 1 of 3** · Base: #936

Offline progress could still be lost at study-end and recovery boundaries. Destructive actions could clear pending progress or media before synchronization, and deleted-subject startup recovery cleared local data before the participant could contact the researcher.

This PR:

- preserves issued task progress when completion happens after the study schedule ends;
- keeps offline questionnaire and media progress durable across reloads;
- blocks quit, switch, delete, reset, and new-study actions until pending work synchronizes;
- serializes destructive cleanup against active cache writes and synchronization;
- routes deleted-subject startup failures to the existing recovery screen without clearing local results;
- clears recovery data only after explicit participant confirmation.

This PR is stacked on #936. The next PR adds deferred Fitbit synchronization.

## Testing Steps

1. Complete ordinary and media tasks while the backend is unavailable and reload the app.
2. Verify the cached completion and pending upload remain available.
3. Attempt a destructive study action while synchronization fails and verify it remains blocked.
4. Trigger deleted-subject recovery and verify local progress remains available before Reset App is confirmed.
5. Automated verification completed:
   - focused app-state, cache synchronization, offline persistence, recovery-screen, and cleanup tests;
   - `scripts/pre-commit-check`;
   - `git diff --check`.

## PR Checklist
- [ ] I tested the changes and affected user flows.
- [ ] I reviewed the full diff and checked for unintended changes.


[STUDYU-95]: https://studyu.atlassian.net/browse/STUDYU-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ