### PR TITLE
STUDYU-95: feat(app): defer Fitbit sync while offline

### DIFF
--- a/app/lib/models/app_state.dart
+++ b/app/lib/models/app_state.dart
@@ -347,9 +347,10 @@ class AppState with ChangeNotifier {
       return false;
     }
     if (!Cache.containsAllProgress(
-      subject: synchronization.subject,
-      progressSource: latestActiveSubject!,
-    )) {
+          subject: synchronization.subject,
+          progressSource: latestActiveSubject!,
+        ) ||
+        await Cache.hasDeferredFitbitRequestsForSubject(currentSubject.id)) {
       markActiveSubjectSynchronizationPending();
       return false;
     }

--- a/app/lib/models/deferred_fitbit_request.dart
+++ b/app/lib/models/deferred_fitbit_request.dart
@@ -1,0 +1,97 @@
+import 'package:studyu_core/core.dart';
+
+class DeferredFitbitQuestionRequest {
+  DeferredFitbitQuestionRequest({
+    required this.questionId,
+    required this.answerTimestamp,
+    required this.windowEnd,
+    required this.windowStarts,
+  });
+
+  factory DeferredFitbitQuestionRequest.fromJson(Map<String, dynamic> json) {
+    return DeferredFitbitQuestionRequest(
+      questionId: json['questionId'] as String,
+      answerTimestamp: DateTime.parse(json['answerTimestamp'] as String),
+      windowEnd: DateTime.parse(json['windowEnd'] as String),
+      windowStarts: (json['windowStarts'] as Map<String, dynamic>).map(
+        (type, start) => MapEntry(
+          FitbitQuestionType.fromJson(type),
+          DateTime.parse(start as String),
+        ),
+      ),
+    );
+  }
+
+  final String questionId;
+  final DateTime answerTimestamp;
+  final DateTime windowEnd;
+  final Map<FitbitQuestionType, DateTime> windowStarts;
+
+  List<FitbitQuestionType> get types => windowStarts.keys.toList();
+
+  Map<String, dynamic> toJson() => {
+    'questionId': questionId,
+    'answerTimestamp': answerTimestamp.toIso8601String(),
+    'windowEnd': windowEnd.toIso8601String(),
+    'windowStarts': windowStarts.map(
+      (type, start) => MapEntry(type.toJson(), start.toIso8601String()),
+    ),
+  };
+}
+
+class DeferredFitbitRequest {
+  DeferredFitbitRequest({
+    required this.subjectId,
+    required this.studyId,
+    required this.taskId,
+    required this.interventionId,
+    required this.periodId,
+    required this.completedAt,
+    required this.questionnaireAnswers,
+    required this.questions,
+  });
+
+  factory DeferredFitbitRequest.fromJson(Map<String, dynamic> json) {
+    return DeferredFitbitRequest(
+      subjectId: json['subjectId'] as String,
+      studyId: json['studyId'] as String,
+      taskId: json['taskId'] as String,
+      interventionId: json['interventionId'] as String,
+      periodId: json['periodId'] as String,
+      completedAt: DateTime.parse(json['completedAt'] as String),
+      questionnaireAnswers: (json['questionnaireAnswers'] as List)
+          .map((answer) => Map<String, dynamic>.from(answer as Map))
+          .toList(),
+      questions: (json['questions'] as List)
+          .map(
+            (question) => DeferredFitbitQuestionRequest.fromJson(
+              Map<String, dynamic>.from(question as Map),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  final String subjectId;
+  final String studyId;
+  final String taskId;
+  final String interventionId;
+  final String periodId;
+  final DateTime completedAt;
+  final List<Map<String, dynamic>> questionnaireAnswers;
+  final List<DeferredFitbitQuestionRequest> questions;
+
+  String get id =>
+      '$subjectId:$interventionId:$taskId:$periodId:${completedAt.toUtc().toIso8601String()}';
+
+  Map<String, dynamic> toJson() => {
+    'subjectId': subjectId,
+    'studyId': studyId,
+    'taskId': taskId,
+    'interventionId': interventionId,
+    'periodId': periodId,
+    'completedAt': completedAt.toIso8601String(),
+    'questionnaireAnswers': questionnaireAnswers,
+    'questions': questions.map((question) => question.toJson()).toList(),
+  };
+}

--- a/app/lib/util/cache.dart
+++ b/app/lib/util/cache.dart
@@ -560,14 +560,18 @@ class Cache {
         allowWhileBlocked: allowWhileBlocked,
       );
       localSubject = snapshot.subject;
+      final hasDeferredFitbitRequests =
+          await hasDeferredFitbitRequestsForSubject(remoteSubject.id);
       if (localSubject == null) {
-        return await _successfulSynchronizationIfRevisionUnchanged(
-          subject: remoteSubject,
-          backupSubject: remoteSubject,
-          expectedRevision: snapshot.revision,
-        );
-      }
-      if (!isCompatibleCachedSubject(
+        if (!hasDeferredFitbitRequests) {
+          return await _successfulSynchronizationIfRevisionUnchanged(
+            subject: remoteSubject,
+            backupSubject: remoteSubject,
+            expectedRevision: snapshot.revision,
+          );
+        }
+        localSubject = StudySubject.fromJson(remoteSubject.toFullJson());
+      } else if (!isCompatibleCachedSubject(
         localSubject: localSubject,
         remoteSubject: remoteSubject,
       )) {
@@ -580,8 +584,6 @@ class Cache {
           expectedRevision: snapshot.revision,
         );
       }
-      final hasDeferredFitbitRequests =
-          await hasDeferredFitbitRequestsForSubject(remoteSubject.id);
       if (!hasDeferredFitbitRequests && localSubject == remoteSubject) {
         return await _successfulSynchronizationIfRevisionUnchanged(
           subject: remoteSubject,
@@ -625,7 +627,7 @@ class Cache {
         },
       );
       // local and remote subject are equal, nothing to synchronize
-      if (localSubject == remoteSubject) {
+      if (snapshot.subject != null && localSubject == remoteSubject) {
         return await _successfulSynchronizationIfRevisionUnchanged(
           subject: remoteSubject,
           backupSubject: remoteSubject,

--- a/app/lib/util/cache.dart
+++ b/app/lib/util/cache.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:studyu_app/models/deferred_fitbit_request.dart';
+import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_app/util/temporary_storage_handler.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
@@ -21,6 +23,8 @@ class _CacheSynchronizationCancelled implements Exception {
 }
 
 class Cache {
+  static const String deferredFitbitRequestsKey = 'deferred_fitbit_requests';
+
   static bool isSynchronizing = false;
   static int _subjectRevision = 0;
   static final Queue<Future<void> Function()> _subjectOperationQueue = Queue();
@@ -79,6 +83,9 @@ class Cache {
 
     for (final progress in localSubject.progress) {
       final key = _progressSyncKey(progress);
+      if (_isDeferredFitbitPlaceholder(localSubject, progress)) {
+        continue;
+      }
       if (remoteKeys.add(key)) {
         newProgress.add(progress);
         mergedProgress.add(progress);
@@ -304,6 +311,70 @@ class Cache {
     return null;
   }
 
+  static Future<List<DeferredFitbitRequest>>
+  _readDeferredFitbitRequests() async {
+    final encoded = await SecureStorage.read(deferredFitbitRequestsKey);
+    if (encoded == null) return [];
+    return (jsonDecode(encoded) as List)
+        .map(
+          (request) => DeferredFitbitRequest.fromJson(
+            Map<String, dynamic>.from(request as Map),
+          ),
+        )
+        .toList();
+  }
+
+  static Future<void> _writeDeferredFitbitRequests(
+    List<DeferredFitbitRequest> requests,
+  ) async {
+    if (requests.isEmpty) {
+      await SecureStorage.delete(deferredFitbitRequestsKey);
+      return;
+    }
+    await SecureStorage.write(
+      deferredFitbitRequestsKey,
+      jsonEncode(requests.map((request) => request.toJson()).toList()),
+    );
+  }
+
+  static Future<List<DeferredFitbitRequest>> loadDeferredFitbitRequests() {
+    return _queueSubjectWrite(_readDeferredFitbitRequests);
+  }
+
+  static Future<void> storeDeferredFitbitRequest(
+    DeferredFitbitRequest request,
+  ) {
+    return _queueSubjectWrite(() async {
+      final requests = await _readDeferredFitbitRequests();
+      requests.removeWhere((existing) => existing.id == request.id);
+      requests.add(request);
+      await _writeDeferredFitbitRequests(requests);
+    });
+  }
+
+  static Future<void> removeDeferredFitbitRequest(String requestId) {
+    return _queueSubjectWrite(() async {
+      final requests = await _readDeferredFitbitRequests();
+      requests.removeWhere((request) => request.id == requestId);
+      await _writeDeferredFitbitRequests(requests);
+    });
+  }
+
+  static Future<bool> hasDeferredFitbitRequestsForSubject(String subjectId) {
+    return _queueSubjectWrite(() async {
+      final requests = await _readDeferredFitbitRequests();
+      return requests.any((request) => request.subjectId == subjectId);
+    });
+  }
+
+  static Future<void> deleteDeferredFitbitRequestsForSubject(String subjectId) {
+    return _queueSubjectWrite(() async {
+      final requests = await _readDeferredFitbitRequests();
+      requests.removeWhere((request) => request.subjectId == subjectId);
+      await _writeDeferredFitbitRequests(requests);
+    });
+  }
+
   static Future<void> delete() async {
     StudyULogger.warning("Delete cache");
     await _queueSubjectWrite(() async {
@@ -359,6 +430,108 @@ class Cache {
     }
   }
 
+  static bool _sameProgressIdentity(
+    SubjectProgress first,
+    SubjectProgress second,
+  ) {
+    return first.subjectId == second.subjectId &&
+        first.interventionId == second.interventionId &&
+        first.taskId == second.taskId &&
+        first.result.periodId == second.result.periodId &&
+        first.completedAt?.toUtc() == second.completedAt?.toUtc();
+  }
+
+  static bool _progressMatchesDeferredRequest(
+    SubjectProgress progress,
+    DeferredFitbitRequest request,
+  ) {
+    return progress.subjectId == request.subjectId &&
+        progress.interventionId == request.interventionId &&
+        progress.taskId == request.taskId &&
+        progress.result.periodId == request.periodId &&
+        progress.completedAt?.toUtc() == request.completedAt.toUtc();
+  }
+
+  static bool _isDeferredFitbitPlaceholder(
+    StudySubject subject,
+    SubjectProgress progress,
+  ) {
+    if (progress.resultType != 'QuestionnaireState') return false;
+    final tasks = <Task>[
+      ...subject.selectedInterventions.expand(
+        (intervention) => intervention.tasks,
+      ),
+      ...subject.study.observations,
+    ];
+    final task = tasks.where((task) => task.id == progress.taskId).firstOrNull;
+    if (task is! QuestionnaireTask) return false;
+    final state = (progress.result as Result<QuestionnaireState>).result;
+    return task.questions.questions.whereType<FitbitQuestion>().any((question) {
+      final response = state.answers[question.id]?.response;
+      return response is List && response.isEmpty;
+    });
+  }
+
+  static void _replaceDeferredPlaceholder(
+    StudySubject localSubject,
+    DeferredFitbitRequest request,
+    SubjectProgress progress,
+  ) {
+    localSubject.progress.removeWhere(
+      (localProgress) =>
+          _progressMatchesDeferredRequest(localProgress, request),
+    );
+    localSubject.progress.add(progress);
+  }
+
+  static Future<void> _synchronizeDeferredFitbitRequests(
+    StudySubject localSubject,
+    StudySubject remoteSubject, {
+    FutureOr<void> Function()? beforeRemoteMutation,
+  }) async {
+    final requests = (await loadDeferredFitbitRequests())
+        .where((request) => request.subjectId == remoteSubject.id)
+        .toList();
+    for (final request in requests) {
+      final remoteProgress = remoteSubject.progress
+          .where(
+            (progress) => _progressMatchesDeferredRequest(progress, request),
+          )
+          .firstOrNull;
+      if (remoteProgress != null) {
+        _replaceDeferredPlaceholder(localSubject, request, remoteProgress);
+        await removeDeferredFitbitRequest(request.id);
+        continue;
+      }
+      final questionnaireState = await FitbitHandler.resolveDeferredRequest(
+        remoteSubject,
+        request,
+      );
+      final progress = SubjectProgress(
+        subjectId: request.subjectId,
+        interventionId: request.interventionId,
+        taskId: request.taskId,
+        resultType: 'QuestionnaireState',
+        result: Result<QuestionnaireState>.app(
+          type: 'QuestionnaireState',
+          periodId: request.periodId,
+          result: questionnaireState,
+        ),
+      )..completedAt = request.completedAt;
+      await beforeRemoteMutation?.call();
+      final savedProgress =
+          await (debugSaveProgressOverride ?? (progress) => progress.save())(
+            progress,
+          );
+      remoteSubject.progress.add(savedProgress);
+      await beforeRemoteMutation?.call();
+      await (debugSaveSubjectOverride ??
+          (subject) => subject.save(onlyUpdate: true))(remoteSubject);
+      _replaceDeferredPlaceholder(localSubject, request, savedProgress);
+      await removeDeferredFitbitRequest(request.id);
+    }
+  }
+
   static Future<CacheSynchronizationResult> synchronize(
     StudySubject remoteSubject, {
     bool allowWhileBlocked = false,
@@ -407,8 +580,9 @@ class Cache {
           expectedRevision: snapshot.revision,
         );
       }
-      // local and remote subject are equal, nothing to synchronize
-      if (localSubject == remoteSubject) {
+      final hasDeferredFitbitRequests =
+          await hasDeferredFitbitRequestsForSubject(remoteSubject.id);
+      if (!hasDeferredFitbitRequests && localSubject == remoteSubject) {
         return await _successfulSynchronizationIfRevisionUnchanged(
           subject: remoteSubject,
           backupSubject: remoteSubject,
@@ -440,6 +614,24 @@ class Cache {
           );
         },
       );
+      await _synchronizeDeferredFitbitRequests(
+        localSubject,
+        remoteSubject,
+        beforeRemoteMutation: () {
+          _ensureSynchronizationAllowed(
+            synchronizationGeneration,
+            allowWhileBlocked: allowWhileBlocked,
+          );
+        },
+      );
+      // local and remote subject are equal, nothing to synchronize
+      if (localSubject == remoteSubject) {
+        return await _successfulSynchronizationIfRevisionUnchanged(
+          subject: remoteSubject,
+          backupSubject: remoteSubject,
+          expectedRevision: snapshot.revision,
+        );
+      }
       _ensureSynchronizationAllowed(
         synchronizationGeneration,
         allowWhileBlocked: allowWhileBlocked,
@@ -513,9 +705,13 @@ class Cache {
     required StudySubject progressSource,
   }) {
     final subjectProgress = subject.progress.map(_progressSyncKey).toSet();
-    return progressSource.progress.every(
-      (progress) => subjectProgress.contains(_progressSyncKey(progress)),
-    );
+    return progressSource.progress.every((progress) {
+      if (subjectProgress.contains(_progressSyncKey(progress))) return true;
+      return _isDeferredFitbitPlaceholder(progressSource, progress) &&
+          subject.progress.any(
+            (remoteProgress) => _sameProgressIdentity(progress, remoteProgress),
+          );
+    });
   }
 
   static String _progressSyncKey(SubjectProgress progress) =>

--- a/app/lib/util/deferred_fitbit_sync.dart
+++ b/app/lib/util/deferred_fitbit_sync.dart
@@ -1,0 +1,47 @@
+import 'package:studyu_app/util/cache.dart';
+import 'package:studyu_app/util/fitbit_handler.dart';
+import 'package:studyu_app/util/study_subject_extension.dart';
+import 'package:studyu_core/core.dart';
+
+Future<void> persistDeferredFitbitQuestionnaireResult({
+  required StudySubject subject,
+  required QuestionnaireTask task,
+  required String interventionId,
+  required String periodId,
+  required QuestionnaireState questionnaireState,
+  DateTime? completedAt,
+}) async {
+  await prepareQuestionnaireForLocalPersistence(questionnaireState);
+  final request = await FitbitHandler.createDeferredRequest(
+    subject: subject,
+    task: task,
+    interventionId: interventionId,
+    periodId: periodId,
+    questionnaireState: questionnaireState,
+    completedAt: completedAt,
+  );
+  await Cache.storeDeferredFitbitRequest(request);
+  final alreadyCompleted = subject.progress.any(
+    (progress) =>
+        progress.interventionId == interventionId &&
+        progress.taskId == task.id &&
+        progress.result.periodId == periodId &&
+        progress.completedAt?.toUtc() == request.completedAt,
+  );
+  if (!alreadyCompleted) {
+    subject.progress.add(
+      SubjectProgress(
+        subjectId: subject.id,
+        interventionId: interventionId,
+        taskId: task.id,
+        resultType: 'QuestionnaireState',
+        result: Result<QuestionnaireState>.app(
+          type: 'QuestionnaireState',
+          periodId: periodId,
+          result: questionnaireState,
+        ),
+      )..completedAt = request.completedAt,
+    );
+  }
+  await Cache.storeSubject(subject);
+}

--- a/app/lib/util/fitbit_handler.dart
+++ b/app/lib/util/fitbit_handler.dart
@@ -1,12 +1,42 @@
 import 'dart:convert';
 
 import 'package:fitbitter/fitbitter.dart' as fitbitter;
+import 'package:flutter/foundation.dart';
 import 'package:studyu_app/constants.dart';
+import 'package:studyu_app/models/deferred_fitbit_request.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 class FitbitHandler {
   static const String _fitbitCredentialsPrefix = 'fitbit_credentials_';
+
+  @visibleForTesting
+  static Future<List<FitbitData>> Function(
+    Study study,
+    DeferredFitbitQuestionRequest question,
+    StudySubject subject,
+  )?
+  debugResolveDeferredQuestionOverride;
+
+  @visibleForTesting
+  static Future<List<FitbitData>> Function(
+    Study study,
+    FitbitQuestion question,
+    String taskId,
+    StudySubject subject,
+  )?
+  debugSyncFitbitDataOverride;
+
+  @visibleForTesting
+  static Future<bool> Function(Study study, List<FitbitQuestionType> types)?
+  debugAuthorizeForOfflineParticipationOverride;
+
+  @visibleForTesting
+  static Future<fitbitter.FitbitCredentials?> Function(
+    Study study,
+    List<FitbitQuestionType> types,
+  )?
+  debugObtainCredentialsOverride;
 
   static Map<String, dynamic> _credentialsToJson(
     fitbitter.FitbitCredentials credentials,
@@ -36,8 +66,9 @@ class FitbitHandler {
 
   static Future<void> _storeCredentials(
     fitbitter.FitbitCredentials? credentials,
-    String studyKey,
-  ) async {
+    String studyKey, {
+    bool requirePersistence = false,
+  }) async {
     final key = '$_fitbitCredentialsPrefix$studyKey';
 
     try {
@@ -51,6 +82,7 @@ class FitbitHandler {
       }
     } catch (e) {
       StudyULogger.error('Failed to store Fitbit credentials: $e');
+      if (requirePersistence) rethrow;
     }
   }
 
@@ -77,8 +109,9 @@ class FitbitHandler {
   static Future<fitbitter.FitbitCredentials?> _validateToken(
     Study study,
     FitbitAuthCredentials studyCredentials,
-    fitbitter.FitbitCredentials currentCredentials,
-  ) async {
+    fitbitter.FitbitCredentials currentCredentials, {
+    bool requirePersistentCredentials = false,
+  }) async {
     try {
       final valid = await fitbitter.FitbitConnector.isTokenValid(
         fitbitCredentials: currentCredentials,
@@ -92,7 +125,11 @@ class FitbitHandler {
         clientSecret: studyCredentials.clientSecret,
       );
 
-      await _storeCredentials(newCredentials, study.id);
+      await _storeCredentials(
+        newCredentials,
+        study.id,
+        requirePersistence: requirePersistentCredentials,
+      );
 
       return newCredentials;
     } catch (e) {
@@ -101,10 +138,27 @@ class FitbitHandler {
     }
   }
 
+  static Future<fitbitter.FitbitCredentials?> _loadValidCredentials(
+    Study study, {
+    bool requirePersistentCredentials = false,
+  }) async {
+    final fitbitCreds = study.fitbitCredentials?.fitbitCredentials;
+    if (fitbitCreds == null) return null;
+    final storedCredentials = await _loadCredentials(study.id);
+    if (storedCredentials == null) return null;
+    return _validateToken(
+      study,
+      fitbitCreds,
+      storedCredentials,
+      requirePersistentCredentials: requirePersistentCredentials,
+    );
+  }
+
   static Future<fitbitter.FitbitCredentials?> _obtainCredentials(
     Study study,
-    List<FitbitQuestionType> types,
-  ) async {
+    List<FitbitQuestionType> types, {
+    bool requirePersistentCredentials = false,
+  }) async {
     final fitbitCreds = study.fitbitCredentials?.fitbitCredentials;
 
     if (fitbitCreds == null) {
@@ -112,18 +166,23 @@ class FitbitHandler {
       return null;
     }
 
-    final storedCredentials = await _loadCredentials(study.id);
-
-    if (storedCredentials != null) {
-      final validCredentials = await _validateToken(
-        study,
-        fitbitCreds,
-        storedCredentials,
-      );
-
-      if (validCredentials != null) return validCredentials;
-    }
+    final validCredentials = await _loadValidCredentials(
+      study,
+      requirePersistentCredentials: requirePersistentCredentials,
+    );
+    if (validCredentials != null) return validCredentials;
     try {
+      final obtainOverride = debugObtainCredentialsOverride;
+      if (obtainOverride != null) {
+        final credentials = await obtainOverride(study, types);
+        if (credentials == null) return null;
+        await _storeCredentials(
+          credentials,
+          study.id,
+          requirePersistence: requirePersistentCredentials,
+        );
+        return credentials;
+      }
       final scopes = <fitbitter.FitbitAuthScope>[];
 
       for (final type in types) {
@@ -146,7 +205,11 @@ class FitbitHandler {
       );
 
       if (newCredentials != null) {
-        await _storeCredentials(newCredentials, study.id);
+        await _storeCredentials(
+          newCredentials,
+          study.id,
+          requirePersistence: requirePersistentCredentials,
+        );
         return newCredentials;
       }
     } catch (e) {
@@ -156,53 +219,66 @@ class FitbitHandler {
     return null;
   }
 
-  static DateTime _startOfToday() {
-    final now = DateTime.now();
-    return DateTime(now.year, now.month, now.day);
+  static DateTime _startOfDay(DateTime date) {
+    return DateTime(date.year, date.month, date.day);
+  }
+
+  static Iterable<DateTime> _daysInWindow(DateTime start, DateTime end) sync* {
+    var day = _startOfDay(start);
+    final lastDay = _startOfDay(end);
+    while (!day.isAfter(lastDay)) {
+      yield day;
+      day = DateTime(day.year, day.month, day.day + 1);
+    }
   }
 
   static Future<List<FitbitHeartData>> _fetchHeartData(
     FitbitAuthCredentials studyCredentials,
     fitbitter.FitbitCredentials credentials,
-    DateTime latest,
+    DateTime start,
+    DateTime end,
   ) async {
     final manager = fitbitter.FitbitHeartRateIntradayDataManager(
       clientID: studyCredentials.clientId,
       clientSecret: studyCredentials.clientSecret,
     );
-
-    final startDate = DateTime(latest.year, latest.month, latest.day);
-
-    final url = fitbitter.FitbitHeartRateIntradayAPIURL.dayAndDetailLevel(
-      date: startDate,
-      fitbitCredentials: credentials,
-      intradayDetailLevel: fitbitter.IntradayDetailLevel.ONE_MINUTE,
-    );
-
-    final items =
-        await manager.fetch(url) as List<fitbitter.FitbitHeartRateIntradayData>;
-
-    return items
-        .map((item) => FitbitHeartData(item.value!, item.dateOfMonitoring!))
-        .where((data) => data.dateTime.isAfter(latest))
+    final data = <FitbitHeartData>[];
+    for (final day in _daysInWindow(start, end)) {
+      final url = fitbitter.FitbitHeartRateIntradayAPIURL.dayAndDetailLevel(
+        date: day,
+        fitbitCredentials: credentials,
+        intradayDetailLevel: fitbitter.IntradayDetailLevel.ONE_MINUTE,
+      );
+      final items =
+          await manager.fetch(url)
+              as List<fitbitter.FitbitHeartRateIntradayData>;
+      data.addAll(
+        items.map(
+          (item) => FitbitHeartData(item.value!, item.dateOfMonitoring!),
+        ),
+      );
+    }
+    return data
+        .where(
+          (data) => data.dateTime.isAfter(start) && !data.dateTime.isAfter(end),
+        )
         .toList();
   }
 
   static Future<List<FitbitSleepData>> _fetchSleepData(
     FitbitAuthCredentials studyCredentials,
     fitbitter.FitbitCredentials credentials,
-    DateTime latest,
+    DateTime start,
+    DateTime end,
   ) async {
     final manager = fitbitter.FitbitSleepDataManager(
       clientID: studyCredentials.clientId,
       clientSecret: studyCredentials.clientSecret,
     );
 
-    final startDate = DateTime(latest.year, latest.month, latest.day);
-
     final url = fitbitter.FitbitSleepAPIURL.dateRange(
-      startDate: startDate,
-      endDate: DateTime.now(),
+      startDate: _startOfDay(start),
+      endDate: end,
       fitbitCredentials: credentials,
     );
 
@@ -217,94 +293,67 @@ class FitbitHandler {
             item.dateOfSleep!,
           ),
         )
-        .where((data) => data.entryDateTime.isAfter(latest))
+        .where(
+          (data) =>
+              data.entryDateTime.isAfter(start) &&
+              !data.entryDateTime.isAfter(end),
+        )
         .toList();
   }
 
   static Future<List<FitbitStepData>> _fetchStepData(
     FitbitAuthCredentials studyCredentials,
     fitbitter.FitbitCredentials credentials,
-    DateTime latest,
+    DateTime start,
+    DateTime end,
   ) async {
     final manager = fitbitter.FitbitActivityTimeseriesIntradayDataManager(
       clientID: studyCredentials.clientId,
       clientSecret: studyCredentials.clientSecret,
     );
 
-    final startDate = DateTime(latest.year, latest.month, latest.day);
-
-    final days = DateTime.now().difference(startDate).inDays;
-
-    if (days > 1) {
-      final List<fitbitter.FitbitActivityTimeseriesData> items = [];
-
-      for (int i = 0; i < days; i++) {
-        final url =
-            fitbitter.FitbitActivityTimeseriesIntradayAPIURL.dayWithResource(
-              date: startDate.add(Duration(days: i)),
-              fitbitCredentials: credentials,
-              resource: fitbitter.Resource.steps,
-              detailLevel: fitbitter.IntradayDetailLevel.ONE_MINUTE,
-            );
-
-        StudyULogger.warning(url);
-
-        items.addAll(
-          await manager.fetch(url)
-              as List<fitbitter.FitbitActivityTimeseriesData>,
-        );
-      }
-
-      return items
-          .map((item) => FitbitStepData(item.value!, item.dateOfMonitoring!))
-          .where((data) => data.dateTime.isAfter(latest))
-          .toList();
-    } else {
+    final items = <fitbitter.FitbitActivityTimeseriesData>[];
+    for (final day in _daysInWindow(start, end)) {
       final url =
           fitbitter.FitbitActivityTimeseriesIntradayAPIURL.dayWithResource(
-            date: startDate,
+            date: day,
             fitbitCredentials: credentials,
             resource: fitbitter.Resource.steps,
             detailLevel: fitbitter.IntradayDetailLevel.ONE_MINUTE,
           );
-
-      final items =
-          await manager.fetch(url)
-              as List<fitbitter.FitbitActivityTimeseriesData>;
-
-      return items
-          .map((item) => FitbitStepData(item.value!, item.dateOfMonitoring!))
-          .where((data) => data.dateTime.isAfter(latest))
-          .toList();
+      items.addAll(
+        await manager.fetch(url)
+            as List<fitbitter.FitbitActivityTimeseriesData>,
+      );
     }
+    return items
+        .map((item) => FitbitStepData(item.value!, item.dateOfMonitoring!))
+        .where(
+          (data) => data.dateTime.isAfter(start) && !data.dateTime.isAfter(end),
+        )
+        .toList();
   }
 
-  static Future<List<FitbitData>> _getFitbitData(
-    List<FitbitQuestionType> types,
+  static Future<List<FitbitData>> _getFitbitDataForWindow(
     FitbitAuthCredentials studyCredentials,
     fitbitter.FitbitCredentials credentials,
-    String taskId,
-    StudySubject subject,
-    FitbitQuestion question,
+    Map<FitbitQuestionType, DateTime> starts,
+    DateTime end,
   ) async {
     final allData = <FitbitData>[];
-    for (final type in types) {
-      final latest =
-          await _findLatestDataEntry(subject, taskId, question.id, type) ??
-          _startOfToday();
-
+    for (final MapEntry(key: type, value: start) in starts.entries) {
       switch (type) {
         case FitbitQuestionType.steps:
           allData.addAll(
-            await _fetchStepData(studyCredentials, credentials, latest),
+            await _fetchStepData(studyCredentials, credentials, start, end),
           );
         case FitbitQuestionType.heartrate:
           allData.addAll(
-            await _fetchHeartData(studyCredentials, credentials, latest),
+            await _fetchHeartData(studyCredentials, credentials, start, end),
           );
         case FitbitQuestionType.sleep:
           allData.addAll(
-            await _fetchSleepData(studyCredentials, credentials, latest),
+            await _fetchSleepData(studyCredentials, credentials, start, end),
           );
       }
     }
@@ -336,56 +385,6 @@ class FitbitHandler {
     return mapped;
   }
 
-  /*static Future<DateTime?> _findLatestDataEntry(
-    StudySubject subject,
-    String taskId,
-    String questionId,
-    FitbitQuestionType type,
-  ) async {
-    if (subject.progress.isEmpty) {
-      return null;
-    }
-
-    final answers = subject.progress
-        .where((entry) =>
-            entry.taskId == taskId && entry.resultType == 'QuestionnaireState')
-        .map((entry) =>
-            (entry.result as Result<QuestionnaireState>).result.answers.values)
-        .expand((answerList) => answerList)
-        .where((answer) => answer.question == questionId)
-        .map((answer) => answer.response as List<dynamic>)
-        .toList();
-
-    if (answers.isEmpty) return null;
-
-    final fitbitData = answers
-        .map((raw) => raw.cast<String>())
-        .map((stringList) => stringList.map(parseLine).toList())
-        .map((parsedList) => parsedList.map(FitbitData.fromJson).toList())
-        .toList()
-        .expand((element) => element)
-        .toList();
-
-    if (fitbitData.isEmpty) return null;
-
-    final fitbitDataTypedList = fitbitData
-        .where((data) =>
-            data.type.toLowerCase() == type.toReadable().toLowerCase())
-        .toList();
-
-    if (fitbitDataTypedList.isEmpty) return null;
-
-    switch (type) {
-      case FitbitQuestionType.steps:
-        return fitbitDataTypedList.last.dateTime;
-      case FitbitQuestionType.heartrate:
-        return fitbitDataTypedList.last.dateTime;
-      case FitbitQuestionType.sleep:
-        return (fitbitDataTypedList.last as FitbitSleepData).entryDateTime;
-    }
-  }*/
-
-  //refactored
   static Future<DateTime?> _findLatestDataEntry(
     StudySubject subject,
     String taskId,
@@ -406,10 +405,22 @@ class FitbitHandler {
           (entry.result as Result<QuestionnaireState>).result;
 
       for (final answer in questionnaireState.answers.values) {
-        if (answer.question != questionId) continue;
+        if (answer.question != questionId || answer.response is! List) continue;
 
-        for (final raw in (answer.response as List<dynamic>).cast<String>()) {
-          final data = FitbitData.fromJson(parseLine(raw));
+        final responses = answer.response as List<dynamic>;
+        if (responses.isEmpty) {
+          if (latestDate == null || answer.timestamp.isAfter(latestDate)) {
+            latestDate = answer.timestamp;
+          }
+          continue;
+        }
+
+        for (final raw in responses) {
+          final data = switch (raw) {
+            FitbitData() => raw,
+            Map<String, dynamic>() => FitbitData.fromJson(raw),
+            _ => FitbitData.fromJson(parseLine(raw.toString())),
+          };
 
           if (data.type.toLowerCase() != typeLower) continue;
 
@@ -428,12 +439,136 @@ class FitbitHandler {
     return latestDate;
   }
 
+  @visibleForTesting
+  static List<DateTime> daysInWindowForTesting(DateTime start, DateTime end) =>
+      _daysInWindow(start, end).toList();
+
+  static List<FitbitQuestionType> requiredTypesForStudy(Study study) {
+    final tasks = <Task>[
+      ...study.observations,
+      ...study.interventions.expand((intervention) => intervention.tasks),
+    ];
+    return tasks
+        .whereType<QuestionnaireTask>()
+        .expand((task) => task.questions.questions.whereType<FitbitQuestion>())
+        .expand((question) => question.types)
+        .toSet()
+        .toList();
+  }
+
+  static Future<bool> authorizeForOfflineParticipation(Study study) async {
+    final types = requiredTypesForStudy(study);
+    if (types.isEmpty) return true;
+    final override = debugAuthorizeForOfflineParticipationOverride;
+    if (override != null) return override(study, types);
+    return await _obtainCredentials(
+          study,
+          types,
+          requirePersistentCredentials: true,
+        ) !=
+        null;
+  }
+
+  static Future<DeferredFitbitRequest> createDeferredRequest({
+    required StudySubject subject,
+    required QuestionnaireTask task,
+    required String interventionId,
+    required String periodId,
+    required QuestionnaireState questionnaireState,
+    DateTime? completedAt,
+  }) async {
+    final completionTime = (completedAt ?? DateTime.now()).toUtc();
+    final fitbitQuestions = task.questions.questions
+        .whereType<FitbitQuestion>();
+    final requests = <DeferredFitbitQuestionRequest>[];
+    for (final question in fitbitQuestions) {
+      final answer = questionnaireState.answers[question.id];
+      if (answer == null ||
+          answer.response is! List ||
+          (answer.response as List).isNotEmpty) {
+        continue;
+      }
+      final windowEnd = answer.timestamp;
+      final starts = <FitbitQuestionType, DateTime>{};
+      for (final type in question.types) {
+        starts[type] =
+            await _findLatestDataEntry(subject, task.id, question.id, type) ??
+            _startOfDay(windowEnd);
+      }
+      requests.add(
+        DeferredFitbitQuestionRequest(
+          questionId: question.id,
+          answerTimestamp: answer.timestamp,
+          windowEnd: windowEnd,
+          windowStarts: starts,
+        ),
+      );
+    }
+    if (requests.isEmpty) {
+      throw ArgumentError('Questionnaire has no deferred Fitbit answers');
+    }
+    final deferredQuestionIds = requests
+        .map((request) => request.questionId)
+        .toSet();
+    return DeferredFitbitRequest(
+      subjectId: subject.id,
+      studyId: subject.studyId,
+      taskId: task.id,
+      interventionId: interventionId,
+      periodId: periodId,
+      completedAt: completionTime,
+      questionnaireAnswers: questionnaireState
+          .toJson()
+          .where((answer) => !deferredQuestionIds.contains(answer['question']))
+          .toList(),
+      questions: requests,
+    );
+  }
+
+  static Future<QuestionnaireState> resolveDeferredRequest(
+    StudySubject subject,
+    DeferredFitbitRequest request,
+  ) async {
+    if (subject.id != request.subjectId || subject.studyId != request.studyId) {
+      throw ArgumentError('Deferred Fitbit request does not match subject');
+    }
+    final questionnaireState = QuestionnaireState.fromJson(
+      request.questionnaireAnswers,
+    );
+    final override = debugResolveDeferredQuestionOverride;
+    fitbitter.FitbitCredentials? credentials;
+    if (override == null) {
+      credentials = await _loadValidCredentials(subject.study);
+      if (credentials == null) {
+        throw Exception('Stored Fitbit credentials are unavailable');
+      }
+    }
+    for (final question in request.questions) {
+      final data = override != null
+          ? await override(subject.study, question, subject)
+          : await _getFitbitDataForWindow(
+              subject.study.fitbitCredentials!.fitbitCredentials,
+              credentials!,
+              question.windowStarts,
+              question.windowEnd,
+            );
+      questionnaireState.answers[question.questionId] =
+          Answer<List<FitbitData>>(
+            question.questionId,
+            question.answerTimestamp,
+          )..response = data;
+    }
+    return questionnaireState;
+  }
+
   static Future<List<FitbitData>> syncFitbitData(
     Study study,
     FitbitQuestion question,
     String taskId,
     StudySubject subject,
   ) async {
+    final override = debugSyncFitbitDataOverride;
+    if (override != null) return override(study, question, taskId, subject);
     final credentials = await _obtainCredentials(study, question.types);
 
     if (credentials == null) {
@@ -441,13 +576,18 @@ class FitbitHandler {
         'Failed to obtain Fitbit credentials. Please try syncing again',
       );
     }
-    return _getFitbitData(
-      question.types,
+    final end = DateTime.now();
+    final starts = <FitbitQuestionType, DateTime>{};
+    for (final type in question.types) {
+      starts[type] =
+          await _findLatestDataEntry(subject, taskId, question.id, type) ??
+          _startOfDay(end);
+    }
+    return _getFitbitDataForWindow(
       study.fitbitCredentials!.fitbitCredentials,
       credentials,
-      taskId,
-      subject,
-      question,
+      starts,
+      end,
     );
   }
 }

--- a/app/lib/util/study_local_cleanup.dart
+++ b/app/lib/util/study_local_cleanup.dart
@@ -26,6 +26,7 @@ Future<void> _clearStudyLocalData({
   );
   await Cache.deletePendingBlobFilesForSubject(subject);
   if (subject != null) {
+    await Cache.deleteDeferredFitbitRequestsForSubject(subject.id);
     await FitbitHandler.deleteFitbitCredentials(subject.studyId);
   }
   await deleteActiveStudyReference();

--- a/app/lib/util/study_subject_extension.dart
+++ b/app/lib/util/study_subject_extension.dart
@@ -13,6 +13,25 @@ debugSaveResultProgressOverride;
 Future<StudySubject> Function(StudySubject subject)?
 debugSaveResultSubjectOverride;
 
+Future<void> prepareQuestionnaireForLocalPersistence(
+  QuestionnaireState questionnaireState,
+) async {
+  if (kIsWeb) return;
+  for (final answerEntry in questionnaireState.answers.entries.toList()) {
+    final answer = answerEntry.value;
+    if (answer.response is! FutureBlobFile) continue;
+    final futureBlobFile = answer.response as FutureBlobFile;
+    await TemporaryStorageHandler.moveStagingFileToUploadDirectory(
+      futureBlobFile.localFilePath,
+      futureBlobFile.futureBlobId,
+    );
+    questionnaireState.answers[answerEntry.key] = Answer<String>(
+      answer.question,
+      answer.timestamp,
+    )..response = futureBlobFile.futureBlobId;
+  }
+}
+
 @visibleForTesting
 Future<void> saveResultProgress({
   required StudySubject subject,
@@ -69,34 +88,22 @@ extension StudySubjectExtension on StudySubject {
       resultType: resultObject.type,
     );
 
-    Future<void> moveQuestionnaireFiles() async {
-      if (kIsWeb || resultObject.result is! QuestionnaireState) return;
-      final questionnaireState = resultObject.result as QuestionnaireState;
-      for (final answerEntry in questionnaireState.answers.entries.toList()) {
-        final answer = answerEntry.value;
-        if (answer.response is! FutureBlobFile) continue;
-        final futureBlobFile = answer.response as FutureBlobFile;
-        await TemporaryStorageHandler.moveStagingFileToUploadDirectory(
-          futureBlobFile.localFilePath,
-          futureBlobFile.futureBlobId,
+    Future<void> prepareQuestionnaire() async {
+      if (resultObject.result is QuestionnaireState) {
+        await prepareQuestionnaireForLocalPersistence(
+          resultObject.result as QuestionnaireState,
         );
-
-        // Replaces Answer<FutureBlobFile> with Answer<String>
-        questionnaireState.answers[answerEntry.key] = Answer<String>(
-          answer.question,
-          answer.timestamp,
-        )..response = futureBlobFile.futureBlobId;
       }
     }
 
     try {
       if (saveOffline) {
-        await moveQuestionnaireFiles();
+        await prepareQuestionnaire();
         progressEntry.completedAt = DateTime.now().toUtc();
         progress.add(progressEntry);
       } else {
         await Cache.runSubjectRemoteMutation(() async {
-          await moveQuestionnaireFiles();
+          await prepareQuestionnaire();
           if (!kIsWeb) {
             await Cache.uploadBlobFiles(studyId, userId);
           }

--- a/app/test/deferred_fitbit_synchronization_test.dart
+++ b/app/test/deferred_fitbit_synchronization_test.dart
@@ -1,0 +1,508 @@
+import 'package:fitbitter/fitbitter.dart' as fitbitter;
+import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:studyu_app/models/app_state.dart';
+import 'package:studyu_app/util/cache.dart';
+import 'package:studyu_app/util/deferred_fitbit_sync.dart';
+import 'package:studyu_app/util/fitbit_handler.dart';
+import 'package:studyu_app/util/study_local_cleanup.dart';
+import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
+
+const _studyId = 'fitbit-study';
+const _subjectId = 'fitbit-subject';
+const _userId = 'fitbit-user';
+const _interventionId = 'fitbit-intervention';
+const _periodId = 'fitbit-period';
+
+class _FailingFitbitCredentialWritePlatform
+    extends TestFlutterSecureStoragePlatform {
+  _FailingFitbitCredentialWritePlatform(super.data);
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) {
+    if (key.startsWith('fitbit_credentials_')) {
+      return Future<void>.error(Exception('credential write failed'));
+    }
+    return super.write(key: key, value: value, options: options);
+  }
+}
+
+({StudySubject subject, QuestionnaireTask task, FitbitQuestion question})
+_buildFitbitStudy() {
+  final question = FitbitQuestion.withId(
+    questionType: FitbitQuestion.questionType,
+    types: [FitbitQuestionType.steps, FitbitQuestionType.heartrate],
+  );
+  final task = QuestionnaireTask.withId()
+    ..title = 'Fitbit task'
+    ..questions.questions = [question]
+    ..schedule.completionPeriods = [
+      CompletionPeriod(
+        id: _periodId,
+        unlockTime: StudyUTimeOfDay(),
+        lockTime: StudyUTimeOfDay(hour: 23, minute: 59),
+      ),
+    ];
+  final intervention = Intervention(_interventionId, 'Intervention');
+  final study = Study(_studyId, _userId)
+    ..title = 'Fitbit study'
+    ..status = StudyStatus.running
+    ..schedule.includeBaseline = false
+    ..schedule.numberOfCycles = 1
+    ..schedule.phaseDuration = 1
+    ..interventions = [intervention]
+    ..observations = [task]
+    ..fitbitCredentials = StudyFitbitCredentials(
+      _studyId,
+      FitbitAuthCredentials(clientId: 'client-id', clientSecret: 'secret'),
+    );
+  final subject =
+      StudySubject.fromStudy(study, _userId, [_interventionId], null)
+        ..id = _subjectId
+        ..startedAt = DateTime(2026, 8);
+  return (subject: subject, task: task, question: question);
+}
+
+QuestionnaireState _deferredAnswer(
+  FitbitQuestion question,
+  DateTime answerTimestamp,
+) {
+  final state = QuestionnaireState();
+  state.answers[question.id] = Answer<List<FitbitData>>(
+    question.id,
+    answerTimestamp,
+  )..response = [];
+  return state;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FlutterSecureStoragePlatform originalStoragePlatform;
+  late Map<String, String> storageData;
+
+  setUp(() {
+    Cache.debugResetSubjectWrites();
+    originalStoragePlatform = FlutterSecureStoragePlatform.instance;
+    storageData = {};
+    FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
+      storageData,
+    );
+    Cache.debugUploadBlobFilesOverride = (_, _) async {};
+  });
+
+  tearDown(() {
+    FlutterSecureStoragePlatform.instance = originalStoragePlatform;
+    Cache.debugUploadBlobFilesOverride = null;
+    Cache.debugSaveProgressOverride = null;
+    Cache.debugSaveSubjectOverride = null;
+    FitbitHandler.debugResolveDeferredQuestionOverride = null;
+    FitbitHandler.debugSyncFitbitDataOverride = null;
+    FitbitHandler.debugAuthorizeForOfflineParticipationOverride = null;
+    FitbitHandler.debugObtainCredentialsOverride = null;
+    appConnectionStatusController.reset();
+  });
+
+  test('join-time authorization is conditional on Fitbit questions', () async {
+    final fixture = _buildFitbitStudy();
+    var authorizationCalls = 0;
+    FitbitHandler.debugAuthorizeForOfflineParticipationOverride =
+        (_, types) async {
+          authorizationCalls++;
+          expect(types.toSet(), {
+            FitbitQuestionType.steps,
+            FitbitQuestionType.heartrate,
+          });
+          return false;
+        };
+
+    expect(
+      await FitbitHandler.authorizeForOfflineParticipation(
+        Study('study-without-fitbit', _userId),
+      ),
+      isTrue,
+    );
+    expect(authorizationCalls, 0);
+    expect(
+      await FitbitHandler.authorizeForOfflineParticipation(
+        fixture.subject.study,
+      ),
+      isFalse,
+    );
+    expect(authorizationCalls, 1);
+  });
+
+  test('offline authorization requires durable credentials', () async {
+    final fixture = _buildFitbitStudy();
+    FlutterSecureStoragePlatform.instance =
+        _FailingFitbitCredentialWritePlatform(storageData);
+    FitbitHandler.debugObtainCredentialsOverride = (_, _) async =>
+        fitbitter.FitbitCredentials(
+          userID: 'fitbit-user',
+          fitbitAccessToken: 'access-token',
+          fitbitRefreshToken: 'refresh-token',
+        );
+
+    expect(
+      await FitbitHandler.authorizeForOfflineParticipation(
+        fixture.subject.study,
+      ),
+      isFalse,
+    );
+  });
+
+  test(
+    'offline completion stores a reload-safe request with original window',
+    () async {
+      final fixture = _buildFitbitStudy();
+      final answerTime = DateTime(2026, 8, 3, 14, 30);
+      final completedAt = DateTime.utc(2026, 8, 3, 14, 31);
+
+      await persistDeferredFitbitQuestionnaireResult(
+        subject: fixture.subject,
+        task: fixture.task,
+        interventionId: _interventionId,
+        periodId: _periodId,
+        questionnaireState: _deferredAnswer(fixture.question, answerTime),
+        completedAt: completedAt,
+      );
+
+      final reloaded = await Cache.loadDeferredFitbitRequests();
+      expect(reloaded, hasLength(1));
+      expect(reloaded.single.completedAt, completedAt);
+      expect(reloaded.single.questionnaireAnswers, isEmpty);
+      expect(reloaded.single.questions, hasLength(1));
+      expect(reloaded.single.questions.single.windowEnd, answerTime);
+      expect(
+        reloaded.single.questions.single.windowStarts.values,
+        everyElement(DateTime(2026, 8, 3)),
+      );
+      expect(fixture.subject.progress, hasLength(1));
+      final cachedSubject = await Cache.loadSubject(
+        backupSubject: fixture.subject,
+      );
+      expect(
+        cachedSubject.completedTaskInstanceForDay(
+          fixture.task.id,
+          fixture.task.schedule.completionPeriods.single,
+          completedAt,
+        ),
+        isTrue,
+      );
+      expect(
+        (fixture.subject.progress.single.result as Result<QuestionnaireState>)
+            .result
+            .answers[fixture.question.id]!
+            .response,
+        isEmpty,
+      );
+    },
+  );
+
+  test(
+    'reconnect after study end materializes and uploads deferred Fitbit progress',
+    () async {
+      final fixture = _buildFitbitStudy();
+      final completedAt = DateTime.utc(2026, 8, 3, 14, 31);
+      await Cache.storeSubject(fixture.subject);
+      await persistDeferredFitbitQuestionnaireResult(
+        subject: fixture.subject,
+        task: fixture.task,
+        interventionId: _interventionId,
+        periodId: _periodId,
+        questionnaireState: _deferredAnswer(
+          fixture.question,
+          DateTime(2026, 8, 3, 14, 30),
+        ),
+        completedAt: completedAt,
+      );
+      final remoteSubject = StudySubject.fromJson(fixture.subject.toFullJson())
+        ..progress = [];
+      final dataTime = DateTime(2026, 8, 3, 14, 29);
+      FitbitHandler.debugResolveDeferredQuestionOverride =
+          (_, request, _) async {
+            expect(request.windowEnd, DateTime(2026, 8, 3, 14, 30));
+            return [FitbitStepData(42, dataTime)];
+          };
+      var savedProgressCount = 0;
+      Cache.debugSaveProgressOverride = (progress) async {
+        savedProgressCount++;
+        return progress;
+      };
+      Cache.debugSaveSubjectOverride = (subject) async => subject;
+
+      final synchronization = await Cache.synchronize(remoteSubject);
+
+      expect(synchronization.succeeded, isTrue);
+      expect(savedProgressCount, 1);
+      expect(synchronization.subject.progress, hasLength(1));
+      final progress = synchronization.subject.progress.single;
+      expect(progress.completedAt, completedAt);
+      expect(progress.interventionId, _interventionId);
+      expect(progress.result.periodId, _periodId);
+      final state = (progress.result as Result<QuestionnaireState>).result;
+      expect(state.answers[fixture.question.id]!.response, hasLength(1));
+      expect(await Cache.loadDeferredFitbitRequests(), isEmpty);
+    },
+  );
+
+  test('Fitbit acquisition failure retains the request for retry', () async {
+    final fixture = _buildFitbitStudy();
+    await Cache.storeSubject(fixture.subject);
+    await persistDeferredFitbitQuestionnaireResult(
+      subject: fixture.subject,
+      task: fixture.task,
+      interventionId: _interventionId,
+      periodId: _periodId,
+      questionnaireState: _deferredAnswer(
+        fixture.question,
+        DateTime(2026, 8, 3, 14, 30),
+      ),
+    );
+    FitbitHandler.debugResolveDeferredQuestionOverride = (_, _, _) =>
+        Future.error(Exception('Fitbit unavailable'));
+    var saveProgressCalls = 0;
+    Cache.debugSaveProgressOverride = (progress) async {
+      saveProgressCalls++;
+      return progress;
+    };
+    Cache.debugSaveSubjectOverride = (subject) async => subject;
+
+    final remoteSubject = StudySubject.fromJson(fixture.subject.toFullJson())
+      ..progress = [];
+    final synchronization = await Cache.synchronize(remoteSubject);
+
+    expect(synchronization.succeeded, isFalse);
+    expect(saveProgressCalls, 0);
+    expect(await Cache.loadDeferredFitbitRequests(), hasLength(1));
+  });
+
+  test(
+    'destructive action stays blocked while Fitbit work is pending',
+    () async {
+      final fixture = _buildFitbitStudy();
+      await Cache.storeSubject(fixture.subject);
+      await persistDeferredFitbitQuestionnaireResult(
+        subject: fixture.subject,
+        task: fixture.task,
+        interventionId: _interventionId,
+        periodId: _periodId,
+        questionnaireState: _deferredAnswer(
+          fixture.question,
+          DateTime(2026, 8, 3, 14, 30),
+        ),
+      );
+      FitbitHandler.debugResolveDeferredQuestionOverride = (_, _, _) =>
+          Future.error(Exception('Fitbit unavailable'));
+      final remoteSubject = StudySubject.fromJson(fixture.subject.toFullJson())
+        ..progress = [];
+      final appState = AppState();
+      appState.debugHasParticipantSessionForSync = () => true;
+      appState.debugRestoreParticipantSessionForSync = () async => false;
+      appState.debugFetchRemoteSubjectForSync = (_) async => remoteSubject;
+      appState.updateActiveSubject(fixture.subject);
+      var remoteDeleted = false;
+
+      final deleted = await deleteStudySubjectAndClearLocalData(
+        subject: fixture.subject,
+        synchronizeActiveSubject:
+            appState.synchronizeActiveSubjectBeforeDestructiveAction,
+        deleteRemoteSubject: () async => remoteDeleted = true,
+        onRemoteDeleted: appState.clearActiveStudyState,
+        stopActiveSynchronization:
+            appState.stopAndAwaitActiveSubjectSynchronization,
+        resumeActiveSynchronization:
+            appState.resumeActiveSubjectSynchronization,
+      );
+
+      expect(deleted, isFalse);
+      expect(remoteDeleted, isFalse);
+      expect(appState.activeSubject, isNotNull);
+      expect(await Cache.loadDeferredFitbitRequests(), hasLength(1));
+      appState.dispose();
+    },
+  );
+
+  test(
+    'ambiguous retry removes the request without duplicate progress',
+    () async {
+      final fixture = _buildFitbitStudy();
+      final completedAt = DateTime.utc(2026, 8, 3, 14, 31);
+      await Cache.storeSubject(fixture.subject);
+      await persistDeferredFitbitQuestionnaireResult(
+        subject: fixture.subject,
+        task: fixture.task,
+        interventionId: _interventionId,
+        periodId: _periodId,
+        questionnaireState: _deferredAnswer(
+          fixture.question,
+          DateTime(2026, 8, 3, 14, 30),
+        ),
+        completedAt: completedAt,
+      );
+      final remoteSubject = StudySubject.fromJson(fixture.subject.toFullJson())
+        ..progress = [];
+      var resolveCalls = 0;
+      var saveProgressCalls = 0;
+      FitbitHandler.debugResolveDeferredQuestionOverride = (_, _, _) async {
+        resolveCalls++;
+        return [FitbitStepData(42, DateTime(2026, 8, 3, 14, 29))];
+      };
+      Cache.debugSaveProgressOverride = (progress) async {
+        saveProgressCalls++;
+        return progress;
+      };
+      Cache.debugSaveSubjectOverride = (_) =>
+          Future.error(Exception('response lost after progress save'));
+
+      final first = await Cache.synchronize(remoteSubject);
+      expect(first.succeeded, isFalse);
+      expect(remoteSubject.progress, hasLength(1));
+      expect(await Cache.loadDeferredFitbitRequests(), hasLength(1));
+
+      Cache.debugSaveSubjectOverride = (subject) async => subject;
+      final second = await Cache.synchronize(remoteSubject);
+
+      expect(second.succeeded, isTrue);
+      expect(resolveCalls, 1);
+      expect(saveProgressCalls, 1);
+      expect(remoteSubject.progress, hasLength(1));
+      expect(await Cache.loadDeferredFitbitRequests(), isEmpty);
+    },
+  );
+
+  test(
+    'two daily completions with the same period remain independently pending',
+    () async {
+      final fixture = _buildFitbitStudy();
+      await Cache.storeSubject(fixture.subject);
+      for (final day in [3, 4]) {
+        await persistDeferredFitbitQuestionnaireResult(
+          subject: fixture.subject,
+          task: fixture.task,
+          interventionId: _interventionId,
+          periodId: _periodId,
+          questionnaireState: _deferredAnswer(
+            fixture.question,
+            DateTime(2026, 8, day, 14, 30),
+          ),
+          completedAt: DateTime.utc(2026, 8, day, 14, 31),
+        );
+      }
+
+      final pending = await Cache.loadDeferredFitbitRequests();
+      expect(pending, hasLength(2));
+      expect(pending.map((request) => request.id).toSet(), hasLength(2));
+
+      final remoteSubject = StudySubject.fromJson(fixture.subject.toFullJson())
+        ..progress = [];
+      FitbitHandler.debugResolveDeferredQuestionOverride =
+          (_, request, _) async => [
+            FitbitStepData(
+              42,
+              request.windowEnd.subtract(const Duration(minutes: 1)),
+            ),
+          ];
+      Cache.debugSaveProgressOverride = (progress) async => progress;
+      Cache.debugSaveSubjectOverride = (subject) async => subject;
+
+      final synchronization = await Cache.synchronize(remoteSubject);
+
+      expect(synchronization.succeeded, isTrue);
+      expect(synchronization.subject.progress, hasLength(2));
+      expect(await Cache.loadDeferredFitbitRequests(), isEmpty);
+    },
+  );
+
+  test('later offline period starts after the earlier placeholder', () async {
+    final fixture = _buildFitbitStudy();
+    final morning = DateTime(2026, 8, 3, 9);
+    final evening = DateTime(2026, 8, 3, 18);
+    await persistDeferredFitbitQuestionnaireResult(
+      subject: fixture.subject,
+      task: fixture.task,
+      interventionId: _interventionId,
+      periodId: 'morning',
+      questionnaireState: _deferredAnswer(fixture.question, morning),
+      completedAt: morning.toUtc(),
+    );
+    await persistDeferredFitbitQuestionnaireResult(
+      subject: fixture.subject,
+      task: fixture.task,
+      interventionId: _interventionId,
+      periodId: 'evening',
+      questionnaireState: _deferredAnswer(fixture.question, evening),
+      completedAt: evening.toUtc(),
+    );
+
+    final requests = await Cache.loadDeferredFitbitRequests();
+    final eveningRequest = requests.singleWhere(
+      (request) => request.periodId == 'evening',
+    );
+    expect(
+      eveningRequest.questions.single.windowStarts.values,
+      everyElement(morning),
+    );
+  });
+
+  test(
+    'pending blobs upload before deferred Fitbit progress is resolved',
+    () async {
+      final fixture = _buildFitbitStudy();
+      final state = _deferredAnswer(
+        fixture.question,
+        DateTime(2026, 8, 3, 14, 30),
+      );
+      state.answers['media-question'] = Answer<String>(
+        'media-question',
+        DateTime(2026, 8, 3, 14),
+      )..response = 'pending-blob-id';
+      await Cache.storeSubject(fixture.subject);
+      await persistDeferredFitbitQuestionnaireResult(
+        subject: fixture.subject,
+        task: fixture.task,
+        interventionId: _interventionId,
+        periodId: _periodId,
+        questionnaireState: state,
+      );
+      var resolveCalls = 0;
+      var progressSaveCalls = 0;
+      Cache.debugUploadBlobFilesOverride = (_, _) =>
+          Future<void>.error(Exception('blob upload failed'));
+      FitbitHandler.debugResolveDeferredQuestionOverride = (_, _, _) async {
+        resolveCalls++;
+        return [];
+      };
+      Cache.debugSaveProgressOverride = (progress) async {
+        progressSaveCalls++;
+        return progress;
+      };
+      final remoteSubject = StudySubject.fromJson(fixture.subject.toFullJson())
+        ..progress = [];
+
+      final synchronization = await Cache.synchronize(remoteSubject);
+
+      expect(synchronization.succeeded, isFalse);
+      expect(resolveCalls, 0);
+      expect(progressSaveCalls, 0);
+      expect(remoteSubject.progress, isEmpty);
+      expect(await Cache.loadDeferredFitbitRequests(), hasLength(1));
+    },
+  );
+
+  test('calendar-day iteration includes every date across DST boundaries', () {
+    final days = FitbitHandler.daysInWindowForTesting(
+      DateTime(2026, 3, 28),
+      DateTime(2026, 3, 30),
+    );
+
+    expect(days.map((day) => day.day), [28, 29, 30]);
+    expect(days.every((day) => day.hour == 0), isTrue);
+  });
+}

--- a/app/test/deferred_fitbit_synchronization_test.dart
+++ b/app/test/deferred_fitbit_synchronization_test.dart
@@ -33,6 +33,23 @@ class _FailingFitbitCredentialWritePlatform
   }
 }
 
+class _FailingSubjectCacheWritePlatform
+    extends TestFlutterSecureStoragePlatform {
+  _FailingSubjectCacheWritePlatform(super.data);
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) {
+    if (key == cacheSubjectKey) {
+      return Future<void>.error(Exception('subject cache write failed'));
+    }
+    return super.write(key: key, value: value, options: options);
+  }
+}
+
 ({StudySubject subject, QuestionnaireTask task, FitbitQuestion question})
 _buildFitbitStudy() {
   final question = FitbitQuestion.withId(
@@ -249,6 +266,58 @@ void main() {
       final state = (progress.result as Result<QuestionnaireState>).result;
       expect(state.answers[fixture.question.id]!.response, hasLength(1));
       expect(await Cache.loadDeferredFitbitRequests(), isEmpty);
+    },
+  );
+
+  test(
+    'reconnect resolves a request when its subject cache write failed',
+    () async {
+      final fixture = _buildFitbitStudy();
+      final remoteSubject = StudySubject.fromJson(fixture.subject.toFullJson())
+        ..progress = [];
+      FlutterSecureStoragePlatform.instance = _FailingSubjectCacheWritePlatform(
+        storageData,
+      );
+
+      await expectLater(
+        () => persistDeferredFitbitQuestionnaireResult(
+          subject: fixture.subject,
+          task: fixture.task,
+          interventionId: _interventionId,
+          periodId: _periodId,
+          questionnaireState: _deferredAnswer(
+            fixture.question,
+            DateTime(2026, 8, 3, 14, 30),
+          ),
+        ),
+        throwsException,
+      );
+      expect(await Cache.loadDeferredFitbitRequests(), hasLength(1));
+      expect(await SecureStorage.containsKey(cacheSubjectKey), isFalse);
+
+      FlutterSecureStoragePlatform.instance = TestFlutterSecureStoragePlatform(
+        storageData,
+      );
+      var resolveCalls = 0;
+      FitbitHandler.debugResolveDeferredQuestionOverride = (_, _, _) async {
+        resolveCalls++;
+        return [FitbitStepData(42, DateTime(2026, 8, 3, 14, 29))];
+      };
+      var saveProgressCalls = 0;
+      Cache.debugSaveProgressOverride = (progress) async {
+        saveProgressCalls++;
+        return progress;
+      };
+      Cache.debugSaveSubjectOverride = (subject) async => subject;
+
+      final synchronization = await Cache.synchronize(remoteSubject);
+
+      expect(synchronization.succeeded, isTrue);
+      expect(resolveCalls, 1);
+      expect(saveProgressCalls, 1);
+      expect(remoteSubject.progress, hasLength(1));
+      expect(await Cache.loadDeferredFitbitRequests(), isEmpty);
+      expect((await Cache.loadSubject()).progress, hasLength(1));
     },
   );
 

--- a/app/test/study_local_cleanup_test.dart
+++ b/app/test/study_local_cleanup_test.dart
@@ -303,6 +303,63 @@ void main() {
   );
 
   test(
+    'successful final synchronization uploads progress before deletion',
+    () async {
+      final subject = _buildSubject();
+      final remoteSubject = StudySubject.fromJson(subject.toFullJson());
+      subject.progress = [
+        SubjectProgress(
+          subjectId: subject.id,
+          interventionId: 'intervention-id',
+          taskId: 'task-id',
+          resultType: 'bool',
+          result: Result<bool>.app(
+            type: 'bool',
+            periodId: 'period-id',
+            result: true,
+          ),
+        )..completedAt = DateTime.utc(2026, 8, 28, 8),
+      ];
+      await Cache.storeSubject(subject);
+      final appState = AppState()..updateActiveSubject(subject);
+      appState
+        ..debugHasParticipantSessionForSync = () {
+          return true;
+        }
+        ..debugFetchRemoteSubjectForSync = (_) async => remoteSubject;
+      Cache.debugUploadBlobFilesOverride = (_, _) async {};
+      var savedProgressCount = 0;
+      Cache.debugSaveProgressOverride = (progress) async {
+        savedProgressCount++;
+        return progress;
+      };
+      Cache.debugSaveSubjectOverride = (savedSubject) async => savedSubject;
+      var remoteDeleted = false;
+
+      final deleted = await deleteStudySubjectAndClearLocalData(
+        subject: subject,
+        synchronizeActiveSubject:
+            appState.synchronizeActiveSubjectBeforeDestructiveAction,
+        deleteRemoteSubject: () async {
+          remoteDeleted = true;
+        },
+        onRemoteDeleted: appState.clearActiveStudyState,
+        stopActiveSynchronization:
+            appState.stopAndAwaitActiveSubjectSynchronization,
+        resumeActiveSynchronization:
+            appState.resumeActiveSubjectSynchronization,
+      );
+
+      expect(deleted, isTrue);
+      expect(savedProgressCount, 1);
+      expect(remoteDeleted, isTrue);
+      expect(appState.activeSubject, isNull);
+      expect(await SecureStorage.containsKey(cacheSubjectKey), isFalse);
+      appState.dispose();
+    },
+  );
+
+  test(
     'subject deletion cancels blocked synchronization before remote progress writes',
     () async {
       final remoteSubject = _buildSubject();


### PR DESCRIPTION
## Description

Related Jira issue: [STUDYU-95](https://studyu.atlassian.net/browse/STUDYU-95)

**Stack 2 of 3** · Previous: #954

Fitbit questionnaire completion previously required immediate connectivity. A participant who completed a Fitbit task offline had no durable acquisition request carrying the original measurement window, so historical Fitbit data could not be safely retrieved after reconnecting or after the study ended.

This PR:

- persists deferred Fitbit requests before updating the subject cache;
- preserves each question's original acquisition window across reloads and study completion;
- uploads pending media before resolving Fitbit requests and ordinary progress;
- retrieves real Fitbit data after reconnecting instead of uploading placeholders;
- retains failed requests for retry and removes them only after progress is persisted;
- prevents duplicate progress after ambiguous or response-loss retries;
- recovers queued Fitbit work even when its preceding subject-cache write failed;
- keeps destructive actions blocked while deferred Fitbit work remains pending.

This PR is stacked on #954. The next PR connects the deferred engine to participant kickoff and Fitbit task completion.

## Testing Steps

1. Queue a Fitbit request while offline, reload, reconnect, and verify it resolves once.
2. Reconnect after the study end date and verify the stored historical window is acquired and uploaded.
3. Simulate Fitbit acquisition, blob upload, progress upload, and subject-cache failures; verify pending work remains retryable.
4. Simulate a lost response after remote progress persistence and verify no duplicate progress is created.
5. Automated verification completed:
   - 48 focused recovery, cleanup, cache, and deferred-Fitbit tests;
   - `scripts/pre-commit-check`;
   - `git diff --check`.

## PR Checklist
- [ ] I tested the changes and affected user flows.
- [ ] I reviewed the full diff and checked for unintended changes.


[STUDYU-95]: https://studyu.atlassian.net/browse/STUDYU-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ