### PR TITLE
STUDYU-95: feat(app): complete Fitbit tasks offline

### DIFF
--- a/app/lib/screens/study/onboarding/kickoff.dart
+++ b/app/lib/screens/study/onboarding/kickoff.dart
@@ -6,6 +6,7 @@ import 'package:studyu_app/app_router.dart';
 import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
 import 'package:studyu_app/util/cache.dart';
+import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
@@ -19,9 +20,33 @@ class KickoffScreen extends StatefulWidget {
 class _KickoffScreen extends State<KickoffScreen> {
   StudySubject? subject;
   bool ready = false;
+  bool setupFailed = false;
+  bool fitbitAuthorizationFailed = false;
+  bool isSettingUp = false;
 
   Future<void> _storeUserStudy(BuildContext context) async {
+    if (isSettingUp) return;
+    setState(() {
+      isSettingUp = true;
+      setupFailed = false;
+    });
     try {
+      final requiresFitbitAuthorization = FitbitHandler.requiredTypesForStudy(
+        subject!.study,
+      ).isNotEmpty;
+      if (requiresFitbitAuthorization) {
+        try {
+          if (!await FitbitHandler.authorizeForOfflineParticipation(
+            subject!.study,
+          )) {
+            throw Exception('Fitbit authorization was not completed');
+          }
+        } catch (_) {
+          fitbitAuthorizationFailed = true;
+          rethrow;
+        }
+      }
+      fitbitAuthorizationFailed = false;
       // Start study at the next day
       final now = DateTime.now();
       subject!.startedAt = DateTime(now.year, now.month, now.day + 1).toUtc();
@@ -38,6 +63,11 @@ class _KickoffScreen extends State<KickoffScreen> {
       context.go('/${RouteNames.dashboard}');
     } catch (e) {
       StudyULogger.fatal('Failed creating subject: $e');
+      if (!mounted) return;
+      setState(() {
+        isSettingUp = false;
+        setupFailed = true;
+      });
     }
   }
 
@@ -61,7 +91,13 @@ class _KickoffScreen extends State<KickoffScreen> {
     _storeUserStudy(context);
   }
 
-  Widget _constructStatusIcon(BuildContext context) => !ready
+  Widget _constructStatusIcon(BuildContext context) => setupFailed
+      ? Icon(
+          Icons.error_outline,
+          color: Theme.of(context).colorScheme.error,
+          size: 64,
+        )
+      : !ready
       ? const SizedBox(
           height: 64,
           width: 64,
@@ -73,7 +109,11 @@ class _KickoffScreen extends State<KickoffScreen> {
           size: 64,
         );
 
-  String _getStatusText(BuildContext context) => !ready
+  String _getStatusText(BuildContext context) => setupFailed
+      ? fitbitAuthorizationFailed
+            ? AppLocalizations.of(context)!.fitbit_data_not_synced
+            : AppLocalizations.of(context)!.setting_up_study
+      : !ready
       ? AppLocalizations.of(context)!.setting_up_study
       : AppLocalizations.of(context)!.good_to_go;
 
@@ -99,10 +139,17 @@ class _KickoffScreen extends State<KickoffScreen> {
                       style: Theme.of(context).textTheme.titleLarge,
                     ),
                     const SizedBox(height: 16),
-                    /*OutlinedButton(
-                      onPressed: () => _storeUserStudy(context),
-                      child: Text(AppLocalizations.of(context)!.start_study),
-                    ),*/
+                    if (setupFailed)
+                      OutlinedButton(
+                        onPressed: isSettingUp
+                            ? null
+                            : () => _storeUserStudy(context),
+                        child: Text(
+                          fitbitAuthorizationFailed
+                              ? AppLocalizations.of(context)!.sync_fitbit_data
+                              : AppLocalizations.of(context)!.start_study,
+                        ),
+                      ),
                   ],
                 ),
               ),

--- a/app/lib/screens/study/tasks/observation/questionnaire_task_widget.dart
+++ b/app/lib/screens/study/tasks/observation/questionnaire_task_widget.dart
@@ -2,11 +2,22 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:studyu_app/screens/study/tasks/task_screen.dart';
+import 'package:studyu_app/util/deferred_fitbit_sync.dart';
 import 'package:studyu_app/util/misc.dart';
 import 'package:studyu_app/util/study_subject_extension.dart';
 import 'package:studyu_app/util/temporary_storage_handler.dart';
 import 'package:studyu_app/widgets/questionnaire/questionnaire_widget.dart';
 import 'package:studyu_core/core.dart';
+
+bool hasDeferredFitbitAnswers(
+  QuestionnaireTask task,
+  QuestionnaireState questionnaireState,
+) {
+  return task.questions.questions.whereType<FitbitQuestion>().any((question) {
+    final response = questionnaireState.answers[question.id]?.response;
+    return response is List && response.isEmpty;
+  });
+}
 
 class QuestionnaireTaskWidget extends StatefulWidget {
   final QuestionnaireTask task;
@@ -37,16 +48,35 @@ class _QuestionnaireTaskWidgetState extends State<QuestionnaireTaskWidget> {
     T response,
     BuildContext context,
   ) async {
-    final completed = await handleTaskCompletion(
-      context,
-      (StudySubject? subject) async {
-        await subject!.addResult<T>(
-          taskId: widget.task.id,
+    final deferredFitbit =
+        response is QuestionnaireState &&
+        hasDeferredFitbitAnswers(widget.task, response);
+    final completedAt = DateTime.now().toUtc();
+
+    Future<void> persistResult(StudySubject? subject) async {
+      if (deferredFitbit) {
+        await persistDeferredFitbitQuestionnaireResult(
+          subject: subject!,
+          task: widget.task,
           interventionId: widget.interventionId,
           periodId: widget.completionPeriod.id,
-          result: response,
+          questionnaireState: response as QuestionnaireState,
+          completedAt: completedAt,
         );
-      },
+        return;
+      }
+      await subject!.addResult<T>(
+        interventionId: widget.interventionId,
+        taskId: widget.task.id,
+        periodId: widget.completionPeriod.id,
+        result: response,
+      );
+    }
+
+    final completed = await handleTaskCompletion(
+      context,
+      persistResult,
+      cacheFallback: deferredFitbit ? persistResult : null,
       onCacheRetrySucceeded: () {
         if (context.mounted) context.pop(true);
       },

--- a/app/lib/screens/study/tasks/task_screen.dart
+++ b/app/lib/screens/study/tasks/task_screen.dart
@@ -70,6 +70,7 @@ Future<bool> handleTaskCompletion(
   BuildContext context,
   Future<void> Function(StudySubject?) completionCallback, {
   required VoidCallback onCacheRetrySucceeded,
+  Future<void> Function(StudySubject?)? cacheFallback,
 }) {
   return Cache.runSubjectOperation(() async {
     final state = context.read<AppState>();
@@ -81,7 +82,7 @@ Future<bool> handleTaskCompletion(
 
     Future<bool> storeInCache() async {
       try {
-        await Cache.storeSubject(activeSubject);
+        await (cacheFallback ?? Cache.storeSubject)(activeSubject);
         state.markActiveSubjectSynchronizationPending();
         cacheWriteSucceeded = true;
         debugPrint("Store subject in cache");

--- a/app/lib/widgets/questionnaire/questions/fitbit_question_widget.dart
+++ b/app/lib/widgets/questionnaire/questions/fitbit_question_widget.dart
@@ -8,6 +8,7 @@ import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_app/util/string_extensions.dart';
 import 'package:studyu_app/widgets/questionnaire/questions/question_widget.dart';
 import 'package:studyu_core/core.dart';
+import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
 class FitbitQuestionWidget extends QuestionWidget {
   final FitbitQuestion question;
@@ -35,7 +36,16 @@ class _FitbitQuestionWidgetState extends State<FitbitQuestionWidget> {
     value = [];
   }
 
+  void _completeDeferred() {
+    value = [];
+    widget.onDone(widget.question.constructAnswer(value));
+  }
+
   Future<void> _syncFitbitData() async {
+    if (hasDegradedConnectionStatus()) {
+      _completeDeferred();
+      return;
+    }
     try {
       setState(() {
         _isLoading = true;
@@ -66,10 +76,21 @@ class _FitbitQuestionWidgetState extends State<FitbitQuestionWidget> {
 
       widget.onDone(widget.question.constructAnswer(value));
     } catch (e) {
+      final status = connectionStatusFromError(e);
+      if (status != null) {
+        appConnectionStatusController.setStatus(status);
+        if (mounted) {
+          setState(() {
+            _isLoading = false;
+          });
+          _completeDeferred();
+        }
+        return;
+      }
+      if (!mounted) return;
       setState(() {
         _isLoading = false;
       });
-      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(

--- a/app/test/deferred_fitbit_synchronization_test.dart
+++ b/app/test/deferred_fitbit_synchronization_test.dart
@@ -1,12 +1,17 @@
 import 'package:fitbitter/fitbitter.dart' as fitbitter;
+import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
 import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:studyu_app/l10n/app_localizations.dart';
 import 'package:studyu_app/models/app_state.dart';
+import 'package:studyu_app/screens/study/onboarding/kickoff.dart';
 import 'package:studyu_app/util/cache.dart';
 import 'package:studyu_app/util/deferred_fitbit_sync.dart';
 import 'package:studyu_app/util/fitbit_handler.dart';
 import 'package:studyu_app/util/study_local_cleanup.dart';
+import 'package:studyu_app/widgets/questionnaire/questions/fitbit_question_widget.dart';
 import 'package:studyu_core/core.dart';
 import 'package:studyu_flutter_common/studyu_flutter_common.dart';
 
@@ -495,6 +500,120 @@ void main() {
       expect(await Cache.loadDeferredFitbitRequests(), hasLength(1));
     },
   );
+
+  testWidgets('degraded Fitbit completion stays local without invoking sync', (
+    tester,
+  ) async {
+    final fixture = _buildFitbitStudy();
+    var syncCalls = 0;
+    FitbitHandler.debugSyncFitbitDataOverride = (_, _, _, _) async {
+      syncCalls++;
+      return [];
+    };
+
+    appConnectionStatusController.setStatus(
+      AppConnectionStatus.backendUnavailable,
+    );
+    Answer? answer;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        locale: const Locale('en'),
+        home: Scaffold(
+          body: FitbitQuestionWidget(
+            question: fixture.question,
+            taskId: fixture.task.id,
+            onDone: (completedAnswer) => answer = completedAnswer,
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pump();
+
+    expect(syncCalls, 0);
+    expect(answer, isNotNull);
+    expect(answer!.response, isEmpty);
+  });
+
+  testWidgets(
+    'kickoff keeps Fitbit studies gated after authorization failure',
+    (tester) async {
+      final fixture = _buildFitbitStudy();
+      final appState = AppState()..updateActiveSubject(fixture.subject);
+      addTearDown(appState.dispose);
+      var authorizationCalls = 0;
+      FitbitHandler.debugAuthorizeForOfflineParticipationOverride =
+          (_, _) async {
+            authorizationCalls++;
+            return false;
+          };
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider.value(
+          value: appState,
+          child: const MaterialApp(
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            locale: Locale('en'),
+            home: KickoffScreen(),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(authorizationCalls, 1);
+      expect(find.byType(OutlinedButton), findsOneWidget);
+      await tester.tap(find.byType(OutlinedButton));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(authorizationCalls, 2);
+      expect(find.byType(OutlinedButton), findsOneWidget);
+    },
+  );
+
+  testWidgets('healthy Fitbit completion keeps the online sync path', (
+    tester,
+  ) async {
+    final fixture = _buildFitbitStudy();
+    final appState = AppState()..updateActiveSubject(fixture.subject);
+    addTearDown(appState.dispose);
+    var syncCalls = 0;
+    final syncedData = [FitbitStepData(42, DateTime(2026, 8, 3, 14, 29))];
+    FitbitHandler.debugSyncFitbitDataOverride = (_, _, _, _) async {
+      syncCalls++;
+      return syncedData;
+    };
+    appConnectionStatusController.setStatus(AppConnectionStatus.healthy);
+    Answer? answer;
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: appState,
+        child: MaterialApp(
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          locale: const Locale('en'),
+          home: Scaffold(
+            body: FitbitQuestionWidget(
+              question: fixture.question,
+              taskId: fixture.task.id,
+              onDone: (completedAnswer) => answer = completedAnswer,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+
+    expect(syncCalls, 1);
+    expect(answer, isNotNull);
+    expect(answer!.response, hasLength(1));
+  });
 
   test('calendar-day iteration includes every date across DST boundaries', () {
     final days = FitbitHandler.daysInWindowForTesting(


### PR DESCRIPTION
## Description

Related Jira issue: [STUDYU-95](https://studyu.atlassian.net/browse/STUDYU-95)

**Stack 3 of 3** · Previous: #955

The deferred Fitbit engine from #955 must be connected to the visible participant flow. Participants also need durable Fitbit authorization before leaving the online kickoff so Fitbit tasks can be completed without connectivity.

This PR:

- requires durable Fitbit authorization during kickoff only for studies containing Fitbit questions;
- keeps participants in setup with retry when authorization is cancelled or storage fails;
- completes Fitbit questionnaire tasks locally while connectivity is degraded;
- queues the original Fitbit acquisition window instead of invoking immediate synchronization;
- keeps the normal online Fitbit path unchanged;
- resolves queued Fitbit data after reconnecting, including after the study has ended;
- handles calendar-day Fitbit acquisition windows without creating placeholder answers.

This completes the three-PR advanced offline participation stack built on #936.

## Testing Steps

1. Start a Fitbit study online and verify kickoff cannot complete until authorization is durably stored.
2. Disconnect, complete ordinary, media, and Fitbit tasks, then reload while still offline.
3. Reconnect after the study ends and verify pending media, Fitbit data, and ordinary progress synchronize once.
4. Verify non-Fitbit studies and online Fitbit completion retain their existing behavior.
5. Automated verification completed:
   - 61 integrated recovery, cleanup, cache, offline-task, and Fitbit tests;
   - `scripts/pre-commit-check`;
   - `git diff --check`.

Manual Fitbit OAuth, token refresh/revocation, rate limits, and real multi-day sleep responses remain device/API verification items.

## PR Checklist
- [ ] I tested the changes and affected user flows.
- [ ] I reviewed the full diff and checked for unintended changes.


[STUDYU-95]: https://studyu.atlassian.net/browse/STUDYU-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ