### PR TITLE
fix: quote skill description

### DIFF
--- a/.agents/skills/asd-ste100/SKILL.md
+++ b/.agents/skills/asd-ste100/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asd-ste100
-description: Rewrite text agents consume — commits, PR bodies, review comments, code comments, errors, docs — into unambiguous STE100. Use when writing or editing any text another agent or non-native reader will parse. Triggers on: disambiguate, simplify, STE100, "make clearer", "non-native", or any commit, PR, review, or comment edit. Not for creative or marketing copy.
+description: 'Rewrite text agents consume — commits, PR bodies, review comments, code comments, errors, docs — into unambiguous STE100. Use when writing or editing any text another agent or non-native reader will parse. Triggers on: disambiguate, simplify, STE100, "make clearer", "non-native", or any commit, PR, review, or comment edit. Not for creative or marketing copy.'
 ---
 
 # Simplified Technical English


### PR DESCRIPTION
## Jira ticket
Not applicable. This is a small repository configuration fix.

## Description
The `asd-ste100` skill failed to load because its YAML description contained an unquoted colon. Quote the description so the skill frontmatter parses as valid YAML.

## Testing Steps
1. Run the YAML parser against `.agents/skills/asd-ste100/SKILL.md`.
2. Confirm that the parser reports valid frontmatter.
3. Run `git diff --check`.

## PR Checklist
- [x] I tested the changes and affected user flows.
- [x] I reviewed the full diff and checked for unintended changes.
- [x] Screenshot or video attached, or this item removed for non-visual changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the skill description formatting without changing its content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->